### PR TITLE
PYIC-2249 Auth pages service name change DO NOT MERGE

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1585,8 +1585,8 @@
       "header": "placeholder"
     },
     "proveIdentityWelcome": {
-      "title": "Profi pwy ydych chi gyda chyfrif GOV.UK",
-      "header": "Profi pwy ydych chi gyda chyfrif GOV.UK",
+      "title": "Profi pwy ydych chi gyda GOV.UK One Login",
+      "header": "Profi pwy ydych chi gyda GOV.UK One Login",
       "section1": {
         "paragraph1": "Bydd yn cymryd tua 10 munud i chi brofi pwy ydych chi yn y ffordd hyn.",
         "insetAlternativeLanguage": {
@@ -1602,7 +1602,7 @@
       },
       "section2": {
         "paragraph1": "Byddwch angen:",
-        "listItem1_1": "cyfrif GOV.UK – byddwn yn gofyn i chi greu neu fewngofnodi i’ch cyfrif pan fyddwch yn parhau",
+        "listItem1_1": "GOV.UK One Login – byddwn yn gofyn i chi fewngofnodi neu greu un pan fyddwch yn parhau",
         "listItem1_2": "eich ID gyda llun",
         "listItem1_3": "eich cyfeiriad presennol (efallai y byddwch angen eich cyfeiriad blaenorol hefyd os ydych wedi symud yn ddiweddar)",
         "paragraph2": "Byddwn ond yn defnyddio’r wybodaeth rydych yn ei rhoi i ni i wneud yn siwr mai chi yw pwy rydych yn ei ddweud ydych chi."
@@ -1676,9 +1676,9 @@
       }
     },
     "photoId": {
-      "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych gyda chyfrif GOV.UK",
-      "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych gyda chyfrif GOV.UK",
-      "introParagraph": "Gallwch ond brofi pwy ydych chi gyda chyfrif GOV.UK os oes gennych un o’r mathau canlynol o ID llun.",
+      "title": "Mae’n rhaid i chi gael ID gyda llun i brofi pwy ydych chi gyda GOV.UK One Login",
+      "header": "Mae’n rhaid i chi gael ID gyda llun i brofi pwy ydych chi gyda GOV.UK One Login",
+      "introParagraph": "Gallwch ond profi pwy ydych chi gyda GOV.UK One Login os oes gennych un o’r mathau canlynol o ID gyda llun.",
       "section1": {
         "subHeading": "Trwydded yrru y DU gyda llun",
         "paragraph1": "Byddwch angen trwydded yrru lawn neu dros dro dilys gyda’ch llun arno."
@@ -1699,7 +1699,7 @@
       "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
       "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
       "section1": {
-        "paragraph1": "Ar hyn o bryd, dim ond os oes gennych ID llun y gallwch brofi pwy ydych chi gyda’ch cyfrif GOV.UK."
+        "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda GOV.UK One Login os oes gennych ID gyda llun."
       },
       "section2": {
         "subHeading": "Beth allwch chi ei wneud",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1604,7 +1604,7 @@
       },
       "section2": {
         "paragraph1": "You'll need:",
-        "listItem1_1": "a GOV.UK One Login – we’ll ask you to create or sign in to your account when you continue",
+        "listItem1_1": "a GOV.UK One Login – we’ll ask you to sign in or create one when you continue",
         "listItem1_2": "your photo ID",
         "listItem1_3": "your current home address (you might also need your previous address if you’ve recently moved)",
         "paragraph2": "We’ll only use the information you give us to make sure that you are who you say you are."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -46,7 +46,7 @@
     },
     "contactAccounts": {
       "contactLinkHref": "https://signin.account.gov.uk/contact-us",
-      "contactLinkText": "Contact the GOV.UK account team (opens in a new tab)"
+      "contactLinkText": "Contact the GOV.UK One Login team (opens in a new tab)"
     },
     "header": {
       "homepageHref": "https://www.gov.uk/"
@@ -1586,8 +1586,8 @@
       "header": "placeholder"
     },
     "proveIdentityWelcome": {
-      "title": "Prove your identity with a GOV.UK account",
-      "header": "Prove your identity with a GOV.UK account",
+      "title": "Prove your identity with GOV.UK One Login",
+      "header": "Prove your identity with GOV.UK One Login",
       "section1": {
         "paragraph1": "It will take you about 10 minutes to prove your identity this way.",
         "insetAlternativeLanguage": {
@@ -1604,7 +1604,7 @@
       },
       "section2": {
         "paragraph1": "You'll need:",
-        "listItem1_1": "a GOV.UK account – we’ll ask you to create or sign in to your account when you continue",
+        "listItem1_1": "a GOV.UK One Login – we’ll ask you to create or sign in to your account when you continue",
         "listItem1_2": "your photo ID",
         "listItem1_3": "your current home address (you might also need your previous address if you’ve recently moved)",
         "paragraph2": "We’ll only use the information you give us to make sure that you are who you say you are."
@@ -1688,9 +1688,9 @@
       }
     },
     "photoId": {
-      "title": "You must have a photo ID to prove your identity with a GOV.UK account",
-      "header": "You must have a photo ID to prove your identity with a GOV.UK account",
-      "introParagraph": "You can only prove your identity with a GOV.UK account if you have one of the following types of photo ID.",
+      "title": "You must have a photo ID to prove your identity with GOV.UK One Login",
+      "header": "You must have a photo ID to prove your identity with GOV.UK One Login",
+      "introParagraph": "You can only prove your identity with GOV.UK One Login if you have one of the following types of photo ID.",
       "section1": {
         "subHeading": "UK photocard driving licence",
         "paragraph1": "You’ll need a valid full or provisional driving licence with your photo on it."
@@ -1711,7 +1711,7 @@
       "title": "You must have a photo ID to prove your identity this way",
       "header": "You must have a photo ID to prove your identity this way",
       "section1": {
-        "paragraph1": "You can currently only prove your identity with your GOV.UK account if you have a photo ID."
+        "paragraph1": "You can currently only prove your identity with GOV.UK One Login if you have a photo ID."
       },
       "section2": {
         "subHeading": "What you can do",


### PR DESCRIPTION
## What?

This PR collects 3 tickets from the core team which change the name of the service on the user interface:
* [PYIC-2283](https://govukverify.atlassian.net/browse/PYIC-2283) `prove-identity-welcome`
* [PYIC-2284](https://govukverify.atlassian.net/browse/PYIC-2284) `photo-id`
* [PYIC-2285](https://govukverify.atlassian.net/browse/PYIC-2285) `no-photo-id`; this includes a global change to the link for user support on line 47 of `translation.json`.

**do not merge** this work until the Welsh content has also been updated with the name change.

## Why?

The name of the DI service is being changed from **GOV.UK Account** to **GOV.UK One Login**.

## Related PRs

Other pages will also need content revising to match the new name.


[PYIC-2283]: https://govukverify.atlassian.net/browse/PYIC-2283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-2284]: https://govukverify.atlassian.net/browse/PYIC-2284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-2285]: https://govukverify.atlassian.net/browse/PYIC-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ