### PR TITLE
BAU: Option to log to a file when running locally.  Limit Docker memory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ ANALYTICS_COOKIE_DOMAIN=localhost
 SERVICE_DOMAIN=localhost
 ```
 
-You can find the `API_BASE_URL` in [Concourse](https://cd.gds-reliability.engineering/teams/verify/pipelines/di-authentication-deployment) under the outputs within the deploy-oidc-api-{environment} job, where {environment} is the name of the environment you want to connect to.
-
 `UI_LOCALES` can be used be the stub to request specific locales when authorising.  Only 'en' and 'cy' are supported.
 
 ### Starting all services in Docker
@@ -56,6 +54,22 @@ The startup script will do this for you so just run this command:
 
 ```shell script
 ./startup.sh -l
+```
+
+#### Options for local node running
+
+To run the integration tests when starting node locally:
+
+```shell script
+REDIS_PORT=6389 REDIS_HOST=localhost yarn test:integration
+```
+
+### Additional startup options
+
+To redirect logs to a file `logs/frontend-auth.log`:
+
+```shell script
+./startup.sh -g
 ```
 
 ### General guidance on starting the application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     restart: on-failure
     networks:
       - di-net
+    mem_limit: 768m
+    mem_reservation: 512m
 
   redis:
     image: redis:6.0.5-alpine
@@ -33,6 +35,8 @@ services:
       - "6389:6379"
     networks:
       - di-net
+    mem_limit: 128m
+    mem_reservation: 64m
 
   di-auth-stub-default:
     build:
@@ -53,6 +57,8 @@ services:
     restart: on-failure
     networks:
       - di-net
+    mem_limit: 128m
+    mem_reservation: 64m
 
   di-auth-stub-no-mfa:
     build:
@@ -74,6 +80,8 @@ services:
     restart: on-failure
     networks:
       - di-net
+    mem_limit: 128m
+    mem_reservation: 64m
 
 networks:
   di-net:

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Stopping frontend services..."
+docker-compose down
+killall node || echo "No local running node processes stopped..."

--- a/startup.sh
+++ b/startup.sh
@@ -3,13 +3,17 @@ set -eu
 
 CLEAN=0
 LOCAL=0
-while getopts "cl" opt; do
+LOGS=0
+while getopts "clg" opt; do
   case ${opt} in
     l)
         LOCAL=1
       ;;
     c)
         CLEAN=1
+      ;;
+    g)
+        LOGS=1
       ;;
     *)
         usage
@@ -18,6 +22,8 @@ while getopts "cl" opt; do
   esac
 done
 
+./shutdown.sh
+
 if [ $CLEAN == "1" ]; then
   echo "Cleaning dist and node_modules..."
   rm -rf dist
@@ -25,17 +31,24 @@ if [ $CLEAN == "1" ]; then
   rm -rf logs
 fi
 
-echo "Stopping frontend services..."
-docker-compose down
-
 if [ $LOCAL == "1" ]; then
   echo "Starting frontend local service..."
   docker compose -f "docker-compose.yml" up -d --wait --no-deps redis di-auth-stub-default di-auth-stub-no-mfa
   export $(grep -v '^#' .env | xargs)
   export REDIS_PORT=6389
   export REDIS_HOST=localhost
-  yarn install && yarn copy-assets && yarn dev
+  if [ $CLEAN == "1" ]; then
+    yarn install
+  fi
+  yarn copy-assets
+  if [ $LOGS == "1" ]; then
+    echo "frontend auth is starting, check logs/frontend-auth.log for details..."
+    mkdir -p logs
+    yarn dev > logs/frontend-auth.log 2>&1
+  else
+    yarn dev
+  fi
 else
-  echo "Starting frontend service..."
+  echo "Starting all frontend services in Docker..."
   docker compose up -d --wait --build
 fi


### PR DESCRIPTION
## What?

Option to log to a file when running locally.
Stop local node processes if running.
Limit Docker memory.

## Why?

Logging to a file makes it easier to track what's happening and search for specific events in the logs.

The containers are capable of running in a much reduced footprint.  Limit memory so that memory allocated to Docker can be reduced if required.

## Related PRs

#963 
