### PR TITLE
Stop dropping some ALB logs

### DIFF
--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -108,7 +108,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "frontend_alb_waf_logging_con
     default_behavior = "DROP"
 
     filter {
-      behavior = "DROP"
+      behavior = "KEEP"
 
       condition {
         action_condition {


### PR DESCRIPTION
## What?
- Stop dropping some ALB logs
- Do not drop when action is BLOCK

## Why?
- Will help diagnostics when ALB is rejecting requests
