### PR TITLE
BAU: Remove Welsh language switch and behaviours

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -19,7 +19,6 @@ params:
   BASIC_AUTH_PASSWORD: ((no-basic-auth-password))
   INCOMING_TRAFFIC_CIDR_BLOCKS: '["0.0.0.0/0"]'
   BASIC_AUTH_BYPASS_CIDR_BLOCKS: '[]'
-  SUPPORT_LANGUAGE_CY: "0"
 inputs:
   - name: frontend-src
   - name: frontend-image
@@ -71,7 +70,6 @@ run:
         -var "sidecar_image_uri=${SIDECAR_IMAGE_URI}" \
         -var "sidecar_image_tag=${SIDECAR_IMAGE_TAG}" \
         -var "sidecar_image_digest=${SIDECAR_IMAGE_DIGEST}" \
-        -var "support_language_cy=${SUPPORT_LANGUAGE_CY}" \
         -var "basic_auth_username=${NORMALISED_BASIC_AUTH_USERNAME}" \
         -var "basic_auth_password=${NORMALISED_BASIC_AUTH_PASSWORD}" \
         -var "incoming_traffic_cidr_blocks=${INCOMING_TRAFFIC_CIDR_BLOCKS}" \

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -6,7 +6,6 @@ frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
 support_international_numbers = "1"
-support_language_cy           = "1"
 support_account_recovery      = "1"
 
 logging_endpoint_arns = [

--- a/ci/terraform/dev.tfvars
+++ b/ci/terraform/dev.tfvars
@@ -3,6 +3,5 @@ deployer_role_arn             = "arn:aws:iam::761723964695:role/deployer-role-pi
 common_state_bucket           = "digital-identity-dev-tfstate"
 incoming_traffic_cidr_blocks  = ["0.0.0.0/0"]
 logging_endpoint_arns         = []
-support_language_cy           = "1"
 support_account_recovery      = "1"
 support_international_numbers = "1"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -85,10 +85,6 @@ locals {
         value = var.support_international_numbers
       },
       {
-        name  = "SUPPORT_LANGUAGE_CY"
-        value = var.support_language_cy
-      },
-      {
         name  = "ZENDESK_API_TOKEN"
         value = var.zendesk_api_token
       },

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -6,7 +6,6 @@ frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
 support_international_numbers = "1"
-support_language_cy           = "1"
 support_account_recovery      = "0"
 
 logging_endpoint_arns = [

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -9,7 +9,6 @@ service_domain           = "sandpit.account.gov.uk"
 zone_id                  = "Z1031735QZMC84WYW1TP"
 session_expiry           = 300000
 gtm_id                   = ""
-support_language_cy      = "1"
 support_account_recovery = "1"
 
 support_international_numbers   = "1"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -8,7 +8,6 @@ frontend_task_definition_memory = 1024
 frontend_auto_scaling_min_count = 4
 frontend_auto_scaling_max_count = 12
 
-support_language_cy           = "1"
 support_international_numbers = "1"
 support_account_recovery      = "1"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -29,10 +29,6 @@ variable "support_international_numbers" {
   type = string
 }
 
-variable "support_language_cy" {
-  type = string
-}
-
 variable "image_uri" {
   type = string
 }

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -10,7 +10,6 @@
     <h1 class="govuk-heading-l">{{ 'pages.proveIdentityWelcome.header' | translate }}</h1>
 
     <p class="govuk-body">{{ 'pages.proveIdentityWelcome.section1.paragraph1' | translate }}</p>
-    {% if supportLanguageCY %}
         {% set insetTextInnerHtml %}
             {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.paragraph1' | translate }}
             <a href="{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkHref' | translate }}"
@@ -23,11 +22,6 @@
         {{ govukInsetText({
             html: insetTextInnerHtml
         }) }}
-    {% else %}
-        {{ govukInsetText({
-            text: 'pages.proveIdentityWelcome.section1.insetTextEnglishOnly' | translate
-        }) }}
-    {% endif %}
 
     <p class="govuk-body">{{ 'pages.proveIdentityWelcome.section2.paragraph1' | translate }}</p>
 

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -12,7 +12,6 @@
 
     <p class="govuk-body">{{ 'pages.proveIdentityWelcome.section1.paragraph1' | translate }}</p>
 
-    {% if supportLanguageCY %}
         {% set insetTextInnerHtml %}
             {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.paragraph1' | translate }}
             <a href="{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkHref' | translate }}"
@@ -26,11 +25,6 @@
         {{ govukInsetText({
             html: insetTextInnerHtml
         }) }}
-    {% else %}
-        {{ govukInsetText({
-            text: 'pages.proveIdentityWelcome.section1.insetTextEnglishOnly' | translate
-        }) }}
-    {% endif %}
 
     <p class="govuk-body">{{ 'pages.proveIdentityWelcome.section2.paragraph1' | translate }}</p>
 

--- a/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
@@ -3,7 +3,6 @@ import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { IPV_ERROR_CODES, OIDC_ERRORS, PATH_NAMES } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
-import { supportLanguageCY } from "../../config";
 
 export function proveIdentityWelcomeGet(req: Request, res: Response): void {
   res.render(
@@ -17,7 +16,6 @@ export function proveIdentityWelcomeGet(req: Request, res: Response): void {
         IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
         req.session.client.state
       ),
-      supportLanguageCY: supportLanguageCY() ? true : null,
     }
   );
 }

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -37,7 +37,6 @@
       <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
     {% endif %}
   </ul>
-  {% if supportLanguageCY %}
     {% set altLangInsetHtml %}
     {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
     <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
@@ -47,7 +46,6 @@
     {{ govukInsetText({
       html: altLangInsetHtml
     }) }}
-  {% endif %}
 
   <form action="/sign-in-or-create" method="post" novalidate="novalidate">
 

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { supportInternationalNumbers, supportLanguageCY } from "../../config";
+import { supportInternationalNumbers } from "../../config";
 
 export function signInOrCreateGet(req: Request, res: Response): void {
   if (req.query.redirectPost) {
@@ -11,7 +11,6 @@ export function signInOrCreateGet(req: Request, res: Response): void {
   res.render("sign-in-or-create/index.njk", {
     serviceType: req.session.client.serviceType,
     supportInternationalNumbers: supportInternationalNumbers() ? true : null,
-    supportLanguageCY: supportLanguageCY() ? true : null,
   });
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,10 +50,6 @@ export function supportInternationalNumbers(): boolean {
   return process.env.SUPPORT_INTERNATIONAL_NUMBERS === "1";
 }
 
-export function supportLanguageCY(): boolean {
-  return process.env.SUPPORT_LANGUAGE_CY === "1";
-}
-
 export function supportAccountRecovery(): boolean {
   return process.env.SUPPORT_ACCOUNT_RECOVERY === "1";
 }

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,5 +1,5 @@
 import { LOCALE } from "../app.constants";
-import { getServiceDomain, supportLanguageCY } from "../config";
+import { getServiceDomain } from "../config";
 
 export function i18nextConfigurationOptions(
   path: string
@@ -8,7 +8,7 @@ export function i18nextConfigurationOptions(
     debug: false,
     fallbackLng: LOCALE.EN,
     preload: [LOCALE.EN],
-    supportedLngs: supportLanguageCY() ? [LOCALE.EN, LOCALE.CY] : [LOCALE.EN],
+    supportedLngs: [LOCALE.EN, LOCALE.CY],
     backend: {
       loadPath: path,
       allowMultiLoading: true,


### PR DESCRIPTION

## What?

Remove Welsh language switch and behaviours.

## Why?

There is no longer a need to switch-off Welsh language.

## Change have been demonstrated

Welsh is switched-on in all environments so there are no changes to the application pages.
