### PR TITLE
Use tabular, spaced-out numbers in 2FA input field

### DIFF
--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -32,7 +32,7 @@
   label: {
   text: 'pages.enterMfa.code.label' | translate
   },
-  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+  classes: "govuk-input--width-10 govuk-input--extra-letter-spacing govuk-!-font-weight-bold",
   id: "code",
   name: "code",
   inputmode: "numeric",


### PR DESCRIPTION
This makes it easier for users to enter their 2FA code received via SMS by using "tabular numbers" which makes each numeral more distinct and spaced out.

The [guidance on the Design System website](https://design-system.service.gov.uk/components/text-input/#codes-and-sequences) says:

> Help the user visually check the code they’ve typed is correct by styling the input’s text to visually separate each character. This is important if you’re asking the user to enter a code or sequence they’re unlikely to have memorised, such as an application reference ID, account number or security code.

⚠️  Note: this was added in [`govuk-frontend` v4.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.6.0) and needs upgrading to that release or later.

## Screenshots

### Before

<img width="307" alt="Screenshot 2023-10-16 at 15 04 46" src="https://github.com/alphagov/di-authentication-frontend/assets/30665/b2c1a228-2b4c-423c-80b8-3b24a107c6fb">

### After

<img width="296" alt="Screenshot 2023-10-16 at 15 06 14" src="https://github.com/alphagov/di-authentication-frontend/assets/30665/be428b56-74fb-4a9e-ac93-02fc8fdbf178">
