### PR TITLE
AUT-1721: Update privacy notice for 1.10

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -385,12 +385,40 @@
     </h2>
 
     <p class="govuk-body">
-        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_one' | translate }}
+        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_one.part_one' | translate }}
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.when_you_contact_us.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.when_you_contact_us.paragraph_one.link_text' | translate }}</a>
+        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_one.part_two' | translate }}
     </p>
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.when_you_contact_us.paragraph_two' | translate }}
     </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.privacy.sections.when_you_contact_us.list.item_one' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.when_you_contact_us.list.item_two' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.when_you_contact_us.list.item_three' | translate }}</li>
+    </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_three' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_four' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_five' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.when_you_contact_us.paragraph_six' | translate }}
+    </p>
+
+   <p class="govuk-body">
+       {{ 'pages.privacy.sections.when_you_contact_us.paragraph_seven' | translate }}
+   </p>
 
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.if_you_agree_to_analytics.header' | translate }}
@@ -450,7 +478,6 @@
         <li>{{ 'pages.privacy.sections.why_we_need_your_information.list_two.item_nine' | translate }}</li>
         <li>{{ 'pages.privacy.sections.why_we_need_your_information.list_two.item_ten' | translate }}</li>
         <li>{{ 'pages.privacy.sections.why_we_need_your_information.list_two.item_eleven' | translate }}</li>
-        <li>{{ 'pages.privacy.sections.why_we_need_your_information.list_two.item_twelve' | translate }}</li>
     </ul>
 
 
@@ -477,6 +504,7 @@
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.legal_basis.list_one.item_one' | translate }}</li>
         <li>{{ 'pages.privacy.sections.legal_basis.list_one.item_two' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.legal_basis.list_one.item_three' | translate }}</li>
     </ul>
 
     <p class="govuk-body">
@@ -513,6 +541,14 @@
         <li>{{ 'pages.privacy.sections.legal_basis.list_three.item_one' | translate }}</li>
         <li>{{ 'pages.privacy.sections.legal_basis.list_three.item_two' | translate }}</li>
     </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.legal_basis.paragraph_six' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.legal_basis.paragraph_seven' | translate }}
+    </p>
 
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.who_we_share_with.header' | translate }}
@@ -690,6 +726,10 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.how_long_we_keep_your_information.paragraph_nine' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.how_long_we_keep_your_information.paragraph_ten' | translate }}
     </p>
 
     <ul class="govuk-list govuk-list--bullet">

--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -416,10 +416,6 @@
         {{ 'pages.privacy.sections.when_you_contact_us.paragraph_six' | translate }}
     </p>
 
-   <p class="govuk-body">
-       {{ 'pages.privacy.sections.when_you_contact_us.paragraph_seven' | translate }}
-   </p>
-
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.if_you_agree_to_analytics.header' | translate }}
     </h2>
@@ -504,7 +500,6 @@
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.legal_basis.list_one.item_one' | translate }}</li>
         <li>{{ 'pages.privacy.sections.legal_basis.list_one.item_two' | translate }}</li>
-        <li>{{ 'pages.privacy.sections.legal_basis.list_one.item_three' | translate }}</li>
     </ul>
 
     <p class="govuk-body">
@@ -544,10 +539,6 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.legal_basis.paragraph_six' | translate }}
-    </p>
-
-    <p class="govuk-body">
-        {{ 'pages.privacy.sections.legal_basis.paragraph_seven' | translate }}
     </p>
 
     <h2 class="govuk-heading-m">

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1168,9 +1168,24 @@
           "paragraph_two": "Mae’r data hwn yn cael ei storio mewn awdit system a logiau diogelwch ar gyfer monitro system a diogelwch a dibenion datrys problemau technegol."
         },
         "when_you_contact_us": {
-          "header": "Pan fyddwch yn cysylltu â ni neu’n rhoi adborth am y gwasanaeth",
-          "paragraph_one": "Os ydych yn cysylltu â ni am gymorth gyda defnyddio ffurflenni cyswllt GOV.UK One Login, byddwn yn casglu unrhyw wybodaeth sy’n eich adnabod rydych yn ei ddarparu, fel eich enw a’ch cyfeiriad e-bost, ynghyd â manylion eich cais am gymorth.",
-          "paragraph_two": "Ble rydych yn cytuno, byddwn yn cysylltu â chi er mwyn cael eich adborth am y gwasanaeth. Byddwn yn casglu unrhyw wybodaeth sy’n eich adnabod y byddwch yn ei rhoi yn eich adborth, fel eich enw a’ch cyfeiriad e-bost, ynghyd â manylion eich adborth."
+          "header": "Pan fyddwch yn cysylltu â ni am help neu i roi adborth",
+          "paragraph_one": {
+            "part_one": "Mae nifer o ffyrdd i gysylltu â ni os ydych angen help gyda GOV.UK One Login. Maent ar y dudalen ",
+            "link_text": "Cysylltu â GOV.UK One Login.",
+            "link_href": "https://home.account.gov.uk/contact-gov-uk-one-login",
+            "part_two": "."
+          },
+          "paragraph_two": "Os ydych yn cysylltu â ni am help, byddwn yn casglu:",
+          "list": {
+            "item_one": "gwybodaeth amdanoch fel eich enw, rhif ffôn a chyfeiriad e-bost, a byddwn yn defnyddio’r wybodaeth hon i gysylltu â chi am eich ymholiad ac i nodi eich GOV.UK One Login os oes angen",
+            "item_two": "manylion eich cais am help",
+            "item_three": "eich dewis iaith (Cymraeg neu Saesneg) fel y gallwn gysylltu â chi yn yr iaith honno"
+          },
+          "paragraph_three": "Pan fyddwch yn cysylltu â ni, peidiwch â chynnwys unrhyw wybodaeth sensitif neu ariannol amdanoch chi eich hun. Os byddwch yn dewis rhannu manylion amdanoch chi eich hun i roi cyd-destun ychwanegol i`ch ymholiad, byddwn yn storio`r wybodaeth honno yn ein systemau.",
+          "paragraph_four": "Os ydych yn dweud wrthym eich bod angen addasiad, fel bod angen i staff y ganolfan alwadau siarad yn arafach, byddwn yn gofyn i chi a hoffech i ni wneud nodyn o hynny. Mae hyn er mwyn i staff ein canolfan alwadau fod yn ymwybodol eich bod angen addasiad os byddwch yn cysylltu â ni eto.",
+          "paragraph_five": "Rydym yn storio recordiadau o`r holl sgyrsiau ffôn. Rydym yn defnyddio`r rhain ar gyfer monitro a chanfod twyll, datrys cwynion, monitro safon a hyfforddiant a gwella ein gwasanaeth.",
+          "paragraph_six": "Os byddwch yn cysylltu â ni drwy ein ffurflen we, rydym yn casglu gwybodaeth dechnegol am eich dyfais fel yr amlinellir yn adran `Gwybodaeth dechnegol` o’r hysbysiad hwn.",
+          "paragraph_seven": "Os ydych chi`n cytuno i gymryd rhan yn ein harolwg am yr help a gawsoch, rydym yn casglu eich atebion i`r cwestiynau. Mae`r rhain yn cael eu cysylltu â`r cofnod o`r adeg y gwnaethoch gysylltu â ni, sy`n cynnwys gwybodaeth fel eich enw, cyfeiriad e-bost neu rif ffôn."
         },
         "if_you_agree_to_analytics": {
           "header": "Os ydych yn cytuno i ddadansoddi gwe / ap",
@@ -1202,12 +1217,11 @@
             "item_four": "darparu gwasanaeth(au) y llywodraeth rydych yn cael mynediad iddynt drwy GOV.UK One Login gyda gwybodaeth am ganlyniad eich gwiriad hunaniaeth",
             "item_five": "eich darparu gyda chofnod o sut mae eich GOV.UK One Login wedi cael ei ddefnyddio, er enghraifft, pan gafodd ei fewngofnodi iddo ddiwethaf a pha wasanaethau mae wedi cael ei ddefnyddio gyda",
             "item_six": "cysylltu â chi am unrhyw ymyrraeth arfaethedig, problemau neu newidiadau a allai effeithio ar eich GOV.UK One Login (gan ddefnyddio eich cyfeiriad e-bost)",
-            "item_seven": "cysylltu â chi i ofyn am adborth ar eich profiad o ddefnyddio GOV.UK One Login, os ydych wedi rhoi caniatâd i ni ymateb i unrhyw adborth rydych yn ei anfon atom gan ddefnyddio eich cyfeiriad e-bost",
-            "item_eight": "gwella’r gwasanaeth drwy ddeall sut rydych yn ei ddefnyddio ac unrhyw broblemau rydych yn eu profi wrth ddefnyddio Google Analytics a Firebase Crashlytics",
-            "item_nine": "monitro cyfraddau cyflwyno gwiriadau hunaniaeth lwyddiannus ac aflwyddiannus a chynhyrchu adroddiadau dienw am GOV.UK One Login i’n helpu i ddeall ble gallwn ni wneud gwelliannau",
-            "item_ten": "helpu i ddarganfod a thrwsio materion technegol neu ddadfygio",
-            "item_eleven": "cynorthwyo mewn filio a chymodi ar gyfer y gwasanaethau gwirio hunaniaeth trydydd parti rydym yn eu defnyddio",
-            "item_twelve": "monitro’r system ar gyfer bygythiadau diogelwch a materion system, er enghraifft toriad i’r gwasanaeth."
+            "item_seven": "gwella`r gwasanaeth trwy ddeall sut rydych yn ei ddefnyddio ac unrhyw broblemau rydych yn eu profi, er enghraifft defnyddio Google Analytics, Firebase Crashlytics ac arolwg adborth y ganolfan gyswllt",
+            "item_eight": "monitro cyfraddau cyflwyno gwiriadau hunaniaeth lwyddiannus ac aflwyddiannus a chynhyrchu adroddiadau dienw am GOV.UK One Login i’n helpu i ddeall ble gallwn ni wneud gwelliannau",
+            "item_nine": "helpu i ddarganfod a thrwsio materion technegol neu ddadfygio",
+            "item_ten": "cynorthwyo mewn filio a chymodi ar gyfer y gwasanaethau gwirio hunaniaeth trydydd parti rydym yn eu defnyddio",
+            "item_eleven": "monitro’r system ar gyfer bygythiadau diogelwch a materion system, er enghraifft toriad i’r gwasanaeth."
           }
         },
         "legal_basis": {
@@ -1218,7 +1232,8 @@
           "paragraph_two": "Rydym yn cael eich caniatâd i brosesu eich data personol ar gyfer y dibenion canlynol:",
           "list_one": {
             "item_one": "casglu a dadansoddi gwybodaeth am sut rydych yn defnyddio eich GOV.UK One Login gan ddefnyddio cwcis Google Analytics",
-            "item_two": "eich e-bostio i ofyn am adborth am GOV.UK One Login"
+            "item_two": "casglu a phrosesu eich ymatebion i`n harolwg am yr help a gawsoch",
+            "item_three": "cofnodi unrhyw addasiadau rydych yn dweud wrthym amdanynt pan fyddwch yn cysylltu â ni am help"
           },
           "paragraph_three": "Lle byddwn yn dibynnu ar ganiatâd byddwn yn esbonio mor glir a chryno â phosibl sut bydd eich data’n cael ei brosesu fel eich bod yn deall beth rydych yn cydsynio iddo. Os byddwch yn newid eich meddwl yn ddiweddarach, gallwch dynnu eich caniatâd yn ôl ar unrhyw adeg. Bydd sut gallwch wneud hyn yn dibynnu ar beth rdym yn prosesu eich data ar ei gyfer. Er enghraifft, gallwch:",
           "list_two": {
@@ -1240,7 +1255,9 @@
           "list_three": {
             "item_one": "dibenion statudol a llywodraethol ar gyfer gwirio hunaniaeth (paragraff 6, atodlen 1, Deddf Diogelu Data 2018)",
             "item_two": "atal neu ganfod gweithredoedd anghyfreithlon ar gyfer canfod ac atal twyll (paragraff 10, atodlen 1, Deddf Diogelu Data 2018)"
-          }
+          },
+          "paragraph_six": "Gofynnwn i chi beidio â rhannu unrhyw wybodaeth sensitif amdanoch chi eich hun pan fyddwch yn cysylltu â ni am help neu i roi adborth. Os byddwch yn dewis darparu gwybodaeth o`r fath, rydym yn ei phrosesu ar y sail gyfreithiol bod y prosesu`n angenrheidiol am resymau sydd o fudd sylweddol i`r cyhoedd. Yn ogystal, rydym yn dibynnu ar yr amod dibenion statudol a dibenion y llywodraeth yn Neddf Diogelu Data 2018.",
+          "paragraph_seven": "Pan fyddwn yn prosesu eich data categori arbennig i gofnodi unrhyw addasiadau rydych yn dweud wrthym amdanynt pan fyddwch yn cysylltu â ni am gymorth, y sail gyfreithiol rydym yn dibynnu arni yw eich caniatâd penodol."
         },
         "who_we_share_with": {
           "header": "Gyda phwy rydym yn rhannu eich gwybodaeth",
@@ -1324,7 +1341,7 @@
             "item_seven": "hanes cyfeiriad"
           },
           "sub_header_four": "Rhannu eich gwybodaeth gyda’n cyflenwyr",
-          "paragraph_thirteen": "Rydym yn gweithio gyda chyflenwyr technoleg, er enghraifft rydym yn defnyddio darparwr cynnal allanol. Nid ydym yn caniatáu i’n cyflenwyr gael mynediad rheolaidd i’ch data. Fodd bynnag, mae’n bosib y bydd achosion lle mae angen mynediad arnynt i ddarparu eu gwasanaethau i ni fel pan fyddant yn darparu cymorth technegol i ni. Mae ein cyflenwyr yn gweithredu fel proseswyr data ac yn destun i gontractau gyda ni sy’n eu cyfyngu i brosesu eich data personol ond at y diben o gyflawni ein cyfarwyddiadau."
+          "paragraph_thirteen": "Rydym yn gweithio gyda chyflenwyr technoleg, er enghraifft rydym yn defnyddio darparwr cynnal allanol a darparwr canolfan gyswllt. Rydym ond yn rhoi mynediad i`n cyflenwyr i`ch gwybodaeth os ydynt ei hangen i ddarparu eu gwasanaeth. Mae ein cyflenwyr yn gweithredu fel proseswyr data ac maent yn ddarostyngedig i gontractau gyda ni sy`n eu cyfyngu i brosesu eich data personol ond at ddiben darparu eu gwasanaethau yn unol â`n cyfarwyddiadau."
         },
         "how_long_we_keep_your_information": {
           "header": "Pa mor hir rydym yn cadw eich gwybodaeth",
@@ -1333,10 +1350,11 @@
           "paragraph_three": "Os ydych yn dewis dileu eich GOV.UK One Login, byddwn yn dileu eich cyfrif a’ch gwybodaeth adnabod profedig.",
           "paragraph_four": "Rydym yn dileu eich llun llonydd a gynhyrchir o’ch fideo hunlun, delweddau trwydded yrru a data biometrig y wyneb o systemau Iproov ar ôl 30 diwrnod.",
           "paragraph_five": "Byddwn yn cadw eich data adborth am 2 flynedd.",
-          "paragraph_six": "Mae’r gwiriad hunaniaeth bersonol yn storio eich data am 11 diwrnod i roi digon o amser i chi fynd i Swyddfa’r Post i gwblhau eich gwiriad hunaniaeth.",
-          "paragraph_seven": "Byddwn yn storio gwybodaeth am y camau rydych yn eu cymryd pan fyddwch yn defnyddio eich GOV.UK One Login mewn logiau system am 1 flwyddyn.",
-          "paragraph_eight": "Rydym hefyd yn cynnal llwybr archwilio diogel o holl ddigwyddiadau a gweithgareddau archwilio GOV.UK One Login ac rydym yn ei gadw am 7 mlynedd at ddibenion monitro twyll.",
-          "paragraph_nine": "Nid yw GDS yn storio nac yn cadw’r:",
+          "paragraph_six": "Byddwn yn storio`r wybodaeth rydym yn ei chasglu pan fyddwch yn cysylltu â ni am flwyddyn. Mae hyn yn cynnwys recordiadau galwadau.",
+          "paragraph_seven": "Mae’r gwiriad hunaniaeth bersonol yn storio eich data am 11 diwrnod i roi digon o amser i chi fynd i Swyddfa’r Post i gwblhau eich gwiriad hunaniaeth.",
+          "paragraph_eight": "Byddwn yn storio gwybodaeth am y camau rydych yn eu cymryd pan fyddwch yn defnyddio eich GOV.UK One Login mewn logiau system am 1 flwyddyn.",
+          "paragraph_nine": "Rydym hefyd yn cynnal llwybr archwilio diogel o holl ddigwyddiadau a gweithgareddau archwilio GOV.UK One Login ac rydym yn ei gadw am 7 mlynedd at ddibenion monitro twyll.",
+          "paragraph_ten": "Nid yw GDS yn storio nac yn cadw’r:",
           "list_one": {
             "item_one": "cwestiynau KBV rydym yn yn eu cyrchu gan asiantaethau gwirio credyd neu eich atebion i’r cwestiynau hynny",
             "item_two": "fideo hunlun rydych yn ei gymryd fel rhan o brofi eich hunaniaeth drwy ddefnyddio’r ap Gwirio Hunaniaeth GOV.UK"
@@ -1442,7 +1460,7 @@
           "header": "Newidiadau i’r hysbysiad hwn",
           "paragraph_one": "Efallai y byddwn yn newid yr hysbysiad preifatrwydd hwn. Yn yr achos hynny, bydd dyddiad ’diweddaru olaf’ y ddogfen hon hefyd yn newid. Bydd unrhyw newidiadau i’r hysbysiad preifatrwydd hwn yn berthnasol i chi a’ch gwybodaeth ar unwaith.",
           "paragraph_two": "Os yw’r newidiadau hyn yn effeithio ar sut mae eich gwybodaeth bersonol yn cael ei phrosesu, bydd GDS yn rhoi gwybod i chi.",
-          "paragraph_three": "Diweddarwyd diwethaf: 13 Medi 2023"
+          "paragraph_three": "Diweddarwyd diwethaf: 30 Hydref 2023"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1182,10 +1182,9 @@
             "item_three": "eich dewis iaith (Cymraeg neu Saesneg) fel y gallwn gysylltu â chi yn yr iaith honno"
           },
           "paragraph_three": "Pan fyddwch yn cysylltu â ni, peidiwch â chynnwys unrhyw wybodaeth sensitif neu ariannol amdanoch chi eich hun. Os byddwch yn dewis rhannu manylion amdanoch chi eich hun i roi cyd-destun ychwanegol i`ch ymholiad, byddwn yn storio`r wybodaeth honno yn ein systemau.",
-          "paragraph_four": "Os ydych yn dweud wrthym eich bod angen addasiad, fel bod angen i staff y ganolfan alwadau siarad yn arafach, byddwn yn gofyn i chi a hoffech i ni wneud nodyn o hynny. Mae hyn er mwyn i staff ein canolfan alwadau fod yn ymwybodol eich bod angen addasiad os byddwch yn cysylltu â ni eto.",
-          "paragraph_five": "Rydym yn storio recordiadau o`r holl sgyrsiau ffôn. Rydym yn defnyddio`r rhain ar gyfer monitro a chanfod twyll, datrys cwynion, monitro safon a hyfforddiant a gwella ein gwasanaeth.",
-          "paragraph_six": "Os byddwch yn cysylltu â ni drwy ein ffurflen we, rydym yn casglu gwybodaeth dechnegol am eich dyfais fel yr amlinellir yn adran `Gwybodaeth dechnegol` o’r hysbysiad hwn.",
-          "paragraph_seven": "Os ydych chi`n cytuno i gymryd rhan yn ein harolwg am yr help a gawsoch, rydym yn casglu eich atebion i`r cwestiynau. Mae`r rhain yn cael eu cysylltu â`r cofnod o`r adeg y gwnaethoch gysylltu â ni, sy`n cynnwys gwybodaeth fel eich enw, cyfeiriad e-bost neu rif ffôn."
+          "paragraph_four": "Rydym yn storio recordiadau o`r holl sgyrsiau ffôn. Rydym yn defnyddio`r rhain ar gyfer monitro a chanfod twyll, datrys cwynion, monitro safon a hyfforddiant a gwella ein gwasanaeth.",
+          "paragraph_five": "Os byddwch yn cysylltu â ni drwy ein ffurflen we, rydym yn casglu gwybodaeth dechnegol am eich dyfais fel yr amlinellir yn adran `Gwybodaeth dechnegol` o’r hysbysiad hwn.",
+          "paragraph_six": "Os ydych chi`n cytuno i gymryd rhan yn ein harolwg am yr help a gawsoch, rydym yn casglu eich atebion i`r cwestiynau. Mae`r rhain yn cael eu cysylltu â`r cofnod o`r adeg y gwnaethoch gysylltu â ni, sy`n cynnwys gwybodaeth fel eich enw, cyfeiriad e-bost neu rif ffôn."
         },
         "if_you_agree_to_analytics": {
           "header": "Os ydych yn cytuno i ddadansoddi gwe / ap",
@@ -1232,8 +1231,7 @@
           "paragraph_two": "Rydym yn cael eich caniatâd i brosesu eich data personol ar gyfer y dibenion canlynol:",
           "list_one": {
             "item_one": "casglu a dadansoddi gwybodaeth am sut rydych yn defnyddio eich GOV.UK One Login gan ddefnyddio cwcis Google Analytics",
-            "item_two": "casglu a phrosesu eich ymatebion i`n harolwg am yr help a gawsoch",
-            "item_three": "cofnodi unrhyw addasiadau rydych yn dweud wrthym amdanynt pan fyddwch yn cysylltu â ni am help"
+            "item_two": "casglu a phrosesu eich ymatebion i`n harolwg am yr help a gawsoch"
           },
           "paragraph_three": "Lle byddwn yn dibynnu ar ganiatâd byddwn yn esbonio mor glir a chryno â phosibl sut bydd eich data’n cael ei brosesu fel eich bod yn deall beth rydych yn cydsynio iddo. Os byddwch yn newid eich meddwl yn ddiweddarach, gallwch dynnu eich caniatâd yn ôl ar unrhyw adeg. Bydd sut gallwch wneud hyn yn dibynnu ar beth rdym yn prosesu eich data ar ei gyfer. Er enghraifft, gallwch:",
           "list_two": {
@@ -1256,8 +1254,7 @@
             "item_one": "dibenion statudol a llywodraethol ar gyfer gwirio hunaniaeth (paragraff 6, atodlen 1, Deddf Diogelu Data 2018)",
             "item_two": "atal neu ganfod gweithredoedd anghyfreithlon ar gyfer canfod ac atal twyll (paragraff 10, atodlen 1, Deddf Diogelu Data 2018)"
           },
-          "paragraph_six": "Gofynnwn i chi beidio â rhannu unrhyw wybodaeth sensitif amdanoch chi eich hun pan fyddwch yn cysylltu â ni am help neu i roi adborth. Os byddwch yn dewis darparu gwybodaeth o`r fath, rydym yn ei phrosesu ar y sail gyfreithiol bod y prosesu`n angenrheidiol am resymau sydd o fudd sylweddol i`r cyhoedd. Yn ogystal, rydym yn dibynnu ar yr amod dibenion statudol a dibenion y llywodraeth yn Neddf Diogelu Data 2018.",
-          "paragraph_seven": "Pan fyddwn yn prosesu eich data categori arbennig i gofnodi unrhyw addasiadau rydych yn dweud wrthym amdanynt pan fyddwch yn cysylltu â ni am gymorth, y sail gyfreithiol rydym yn dibynnu arni yw eich caniatâd penodol."
+          "paragraph_six": "Gofynnwn i chi beidio â rhannu unrhyw wybodaeth sensitif amdanoch chi eich hun pan fyddwch yn cysylltu â ni am help neu i roi adborth. Os byddwch yn dewis darparu gwybodaeth o`r fath, rydym yn ei phrosesu ar y sail gyfreithiol bod y prosesu`n angenrheidiol am resymau sydd o fudd sylweddol i`r cyhoedd. Yn ogystal, rydym yn dibynnu ar yr amod dibenion statudol a dibenion y llywodraeth yn Neddf Diogelu Data 2018."
         },
         "who_we_share_with": {
           "header": "Gyda phwy rydym yn rhannu eich gwybodaeth",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1171,7 +1171,7 @@
           "header": "Pan fyddwch yn cysylltu â ni am help neu i roi adborth",
           "paragraph_one": {
             "part_one": "Mae nifer o ffyrdd i gysylltu â ni os ydych angen help gyda GOV.UK One Login. Maent ar y dudalen ",
-            "link_text": "Cysylltu â GOV.UK One Login.",
+            "link_text": "Cysylltu â GOV.UK One Login",
             "link_href": "https://home.account.gov.uk/contact-gov-uk-one-login",
             "part_two": "."
           },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1182,10 +1182,9 @@
             "item_three": "your preferred language (English or Welsh) so we can contact you in that language"
           },
           "paragraph_three": "When you contact us do not include any sensitive or financial information about yourself. If you choose to share details about yourself to give extra context for your enquiry, we will store that information in our systems.",
-          "paragraph_four": "If you tell us that you need an adjustment, such as requiring call centre staff to speak more slowly, we will ask you if you would like us to make a note of that. This is so that our call centre staff will be aware that you need an adjustment if you contact us again.",
-          "paragraph_five": "We store recordings of all telephone conversations. We use these for monitoring and detecting fraud, resolving complaints, quality monitoring and training, and improving our service.",
-          "paragraph_six": "If you contact us through our web form, we collect technical information about your device as outlined in the ‘Technical information‘ section of this notice.",
-          "paragraph_seven": "If you agree to take part in our survey about the help you received, we collect your answers to the questions. These are linked to the record of when you contacted us, which includes information such as your name, email address or telephone number."
+          "paragraph_four": "We store recordings of all telephone conversations. We use these for monitoring and detecting fraud, resolving complaints, quality monitoring and training, and improving our service.",
+          "paragraph_five": "If you contact us through our web form, we collect technical information about your device as outlined in the ‘Technical information‘ section of this notice.",
+          "paragraph_six": "If you agree to take part in our survey about the help you received, we collect your answers to the questions. These are linked to the record of when you contacted us, which includes information such as your name, email address or telephone number."
         },
         "if_you_agree_to_analytics": {
           "header": "If you agree to web / app analytics",
@@ -1232,8 +1231,7 @@
           "paragraph_two": "We obtain your consent to process your personal data for the following purposes:",
           "list_one": {
             "item_one": "collecting and analysing information about how you use your GOV.UK One Login using Google Analytics cookies",
-            "item_two": "collecting and processing your responses to our survey about the help you received",
-            "item_three": "to record any adjustments that you tell us about when you contact us for help  "
+            "item_two": "collecting and processing your responses to our survey about the help you received"
           },
           "paragraph_three": "Where we rely on consent we will explain as clearly and concisely as possible how your data will be processed so you understand what you are consenting to. If you later change your mind, you can withdraw your consent at any time. How you can do this will depend on what we are processing your data for. For example, you can:",
           "list_two": {
@@ -1256,8 +1254,7 @@
             "item_one": "statutory and government purposes for identity checking (paragraph 6, schedule 1, Data Protection Act 2018)",
             "item_two": "preventing or detecting unlawful acts for fraud detection and prevention (paragraph 10, schedule 1, Data Protection Act 2018)"
           },
-          "paragraph_six": "We ask that you do not share any sensitive information about yourself when you contact us for help or to give feedback. If you choose to provide such information we process it on the legal basis that the processing is necessary for reasons of substantial public interest. In addition we rely on the statutory and government purposes condition in the Data Protection Act 2018.",
-          "paragraph_seven": "When we process your special category data to record any adjustments that you tell us about when you contact us for help, the legal basis we rely on is your explicit consent."
+          "paragraph_six": "We ask that you do not share any sensitive information about yourself when you contact us for help or to give feedback. If you choose to provide such information we process it on the legal basis that the processing is necessary for reasons of substantial public interest. In addition we rely on the statutory and government purposes condition in the Data Protection Act 2018."
         },
         "who_we_share_with": {
           "header": "Who we share your information with",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1168,9 +1168,24 @@
           "paragraph_two": "This data is stored in system audit and security logs for system and security monitoring and technical troubleshooting purposes."
         },
         "when_you_contact_us": {
-          "header": "When you contact us or provide feedback about the service",
-          "paragraph_one": "If you contact us for support using GOV.UK One Login’s contact forms, we will collect any identifying information you provide, such as your name and email address, plus the details of your support request.",
-          "paragraph_two": "Where you agree, we will contact you to obtain your feedback about the service. We will collect any identifying information you provide in your feedback, such as your name and email address, plus the details of your feedback."
+          "header": "When you contact us for help or to provide feedback",
+          "paragraph_one": {
+            "part_one": "There are a number of ways to contact us if you need help with GOV.UK One Login. They are on the",
+            "link_text": "Contact GOV.UK One Login",
+            "link_href": "https://home.account.gov.uk/contact-gov-uk-one-login",
+            "part_two": "page."
+          },
+          "paragraph_two": "If you contact us for help, we will collect:",
+          "list": {
+            "item_one": "information about you such as your name, telephone number and email address, and use this information to contact you about your enquiry and to identify your GOV.UK One Login if necessary",
+            "item_two": "the details of your help request",
+            "item_three": "your preferred language (English or Welsh) so we can contact you in that language"
+          },
+          "paragraph_three": "When you contact us do not include any sensitive or financial information about yourself. If you choose to share details about yourself to give extra context for your enquiry, we will store that information in our systems.",
+          "paragraph_four": "If you tell us that you need an adjustment, such as requiring call centre staff to speak more slowly, we will ask you if you would like us to make a note of that. This is so that our call centre staff will be aware that you need an adjustment if you contact us again.",
+          "paragraph_five": "We store recordings of all telephone conversations. We use these for monitoring and detecting fraud, resolving complaints, quality monitoring and training, and improving our service.",
+          "paragraph_six": "If you contact us through our web form, we collect technical information about your device as outlined in the ‘Technical information‘ section of this notice.",
+          "paragraph_seven": "If you agree to take part in our survey about the help you received, we collect your answers to the questions. These are linked to the record of when you contacted us, which includes information such as your name, email address or telephone number."
         },
         "if_you_agree_to_analytics": {
           "header": "If you agree to web / app analytics",
@@ -1202,12 +1217,11 @@
             "item_four": "provide the government service(s) that you access through GOV.UK One Login with information about the outcome of your identity check",
             "item_five": "provide you with a record of how your GOV.UK One Login has been used, for example, when it was last signed in to and what services it has been used with",
             "item_six": "contact you about any planned interruptions, problems or changes that may affect your GOV.UK One Login (using your email address)",
-            "item_seven": "contact you to ask for feedback on your experience of using GOV.UK One Login, if you have given us permission to respond to any feedback you send us using your email address",
-            "item_eight": "improve the service by understanding how you use it and any problems you experience using Google Analytics and Firebase Crashlytics",
-            "item_nine": "monitor the rates of successful and unsuccessful identity checking submissions and produce anonymised reports about GOV.UK One Login to help us understand where we can make improvements",
-            "item_ten": "help diagnose and fix technical or debugging issues",
-            "item_eleven": "assist in billing and reconciliation for the third party identity checking services we use",
-            "item_twelve": "monitor the system for security threats and system issues, for example outages."
+            "item_seven": "improve the service by understanding how you use it and any problems you experience, for example using Google Analytics, Firebase Crashlytics and the contact centre feedback survey",
+            "item_eight": "monitor the rates of successful and unsuccessful identity checking submissions and produce anonymised reports about GOV.UK One Login to help us understand where we can make improvements",
+            "item_nine": "help diagnose and fix technical or debugging issues",
+            "item_ten": "assist in billing and reconciliation for the third party identity checking services we use",
+            "item_eleven": "monitor the system for security threats and system issues, for example outages."
           }
         },
         "legal_basis": {
@@ -1218,7 +1232,8 @@
           "paragraph_two": "We obtain your consent to process your personal data for the following purposes:",
           "list_one": {
             "item_one": "collecting and analysing information about how you use your GOV.UK One Login using Google Analytics cookies",
-            "item_two": "emailing you to ask for feedback about GOV.UK One Login"
+            "item_two": "collecting and processing your responses to our survey about the help you received",
+            "item_three": "to record any adjustments that you tell us about when you contact us for help  "
           },
           "paragraph_three": "Where we rely on consent we will explain as clearly and concisely as possible how your data will be processed so you understand what you are consenting to. If you later change your mind, you can withdraw your consent at any time. How you can do this will depend on what we are processing your data for. For example, you can:",
           "list_two": {
@@ -1240,7 +1255,9 @@
           "list_three": {
             "item_one": "statutory and government purposes for identity checking (paragraph 6, schedule 1, Data Protection Act 2018)",
             "item_two": "preventing or detecting unlawful acts for fraud detection and prevention (paragraph 10, schedule 1, Data Protection Act 2018)"
-          }
+          },
+          "paragraph_six": "We ask that you do not share any sensitive information about yourself when you contact us for help or to give feedback. If you choose to provide such information we process it on the legal basis that the processing is necessary for reasons of substantial public interest. In addition we rely on the statutory and government purposes condition in the Data Protection Act 2018.",
+          "paragraph_seven": "When we process your special category data to record any adjustments that you tell us about when you contact us for help, the legal basis we rely on is your explicit consent."
         },
         "who_we_share_with": {
           "header": "Who we share your information with",
@@ -1324,7 +1341,7 @@
             "item_seven": "address history"
           },
           "sub_header_four": "Sharing your information with our suppliers",
-          "paragraph_thirteen": "We work with technology suppliers, for example we use an external hosting provider. We do not allow our suppliers to have routine access to your data. However, there may be cases where they need access to provide their services to us such as when they provide us with technical support. Our suppliers act as data processors and are subject to contracts with us which restrict them to only processing your personal data for the sole purpose of fulfilling our instructions."
+          "paragraph_thirteen": "We work with technology suppliers, for example we use an external hosting provider and a contact centre provider. We only give our suppliers access to your information if they need it to provide their service. Our suppliers act as data processors and are subject to contracts with us which restrict them to only processing your personal data for the sole purpose of providing their services in accordance with our instructions."
         },
         "how_long_we_keep_your_information": {
           "header": "How long we keep your information",
@@ -1333,10 +1350,11 @@
           "paragraph_three": "If you choose to delete your GOV.UK One Login, we’ll delete your account and your proven identity information.",
           "paragraph_four": "We delete your still photo generated from your selfie video, driving licence images and biometric facial data from Iproov’s systems after 30 days.",
           "paragraph_five": "The in-person identity check stores your data for 11 days to give you enough time to go to the Post Office to complete your identity check.",
-          "paragraph_six": "We will keep your feedback data for 2 years.",
-          "paragraph_seven": "We will store information about the actions you take when you use your GOV.UK One Login in system logs for 1 year.",
-          "paragraph_eight": "We also maintain a secure audit trail of all GOV.UK One Login audit events and activity which we retain for 7 years for fraud monitoring purposes.",
-          "paragraph_nine": "GDS does not store or retain the:",
+          "paragraph_six": "We will store the information we collect when you contact us for help for one year. This includes call recordings.",
+          "paragraph_seven": "We will keep your feedback data for 2 years.",
+          "paragraph_eight": "We will store information about the actions you take when you use your GOV.UK One Login in system logs for 1 year.",
+          "paragraph_nine": "We also maintain a secure audit trail of all GOV.UK One Login audit events and activity which we retain for 7 years for fraud monitoring purposes.",
+          "paragraph_ten": "GDS does not store or retain the:",
           "list_one": {
             "item_one": "KBV questions we source from credit reference agencies or your answers to those questions",
             "item_two": "selfie video you take as part of proving your identity using the GOV.UK Identity Check app"
@@ -1442,7 +1460,7 @@
           "header": "Changes to this notice",
           "paragraph_one": "We may change this privacy notice. In that case, the ‘last updated’ date of this document will also change. Any changes to this privacy notice will apply to you and your information immediately.",
           "paragraph_two": "If these changes affect how your personal information is processed, GDS will let you know.",
-          "paragraph_three": "Last updated: 13 September 2023"
+          "paragraph_three": "Last updated: 30 October 2023"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1155,7 +1155,7 @@
           },
           "paragraph_thirteen": "The Post Office will also take a photo of your face,from which they will measure the unique patterns of your face. This is called facial biometric data. The biometric data from your photo will be compared against the biometric data from the photo on your identity document to check whether you are the actual owner of the identity document.",
           "paragraph_fourteen": "When the Post Office and Yoti have completed the checks, they send us the result of the check and your identity document information.",
-          "paragraph_fifteen": "We then use your email address to tell you that the results of your check are available.To see your result and share it with the service you needed to prove your identity for, you will need to sign in to GOV.UK One Login and be redirected to the government service you were using."
+          "paragraph_fifteen": "We then use your email address to tell you that the results of your check are available. To see your result and share it with the service you needed to prove your identity for, you will need to sign in to GOV.UK One Login and be redirected to the government service you were using."
         },
         "technical_information": {
           "header": "Technical information",


### PR DESCRIPTION
## What?

Updates the privacy notice.

## Why?

Reflects launch of the contact centre

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

[Bump to T&Cs version](https://github.com/govuk-one-login/authentication-api/pull/3470)
