### PR TITLE
AUT-1907: Enable triage page in production

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -13,7 +13,7 @@ support_account_recovery                                            = "1"
 support_smart_agent                                                 = "0"
 client_name_that_directs_all_contact_form_submissions_to_smartagent = "di-auth-stub-relying-party-production"
 support_welsh_language_in_support_forms                             = "0"
-url_for_support_links                                               = "/contact-us"
+url_for_support_links                                               = "https://home.account.gov.uk/contact-gov-uk-one-login"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

Sets the URL for support links to go to the triage page.

## Why?

We have been given the go-ahead from the Contact Centre team to set support links to go to the new triage page.

## Change have been notified

- [x] UCD have been informed of the change
- [x] Performance Analysis have been informed of the change

