### PR TITLE
BAU: Update CODEOWNERS for new org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @govuk-one-login/auth-team
+* @govuk-one-login/auth-leads
+* @govuk-one-login/orchestration-leads
+* @govuk-one-login/orchestration-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @alphagov/digital-identity-authentication


### PR DESCRIPTION
## What?

Update CODEOWNERS for new org.

## Why?

Team names are different in the govuk-one-login org.