### PR TITLE
BAU: Fix codeowners file to make all teams codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @govuk-one-login/auth-team
-* @govuk-one-login/auth-leads
-* @govuk-one-login/orchestration-leads
-* @govuk-one-login/orchestration-team
+* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team


### PR DESCRIPTION
## What?

Fix codeowners file to make all teams codeowners.

## Why?

Syntax of the codeowners file was incorrect for the intended purpose.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3494
