### PR TITLE
BAU: Add additional config for sandpit deployment

### DIFF
--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -23,6 +23,7 @@ support_welsh_language_in_support_forms = "1"
 url_for_support_links                   = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"
+orch_to_auth_client_id          = "orchestrationAuth"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -24,6 +24,7 @@ url_for_support_links                   = "https://home.build.account.gov.uk/con
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
+orch_to_auth_audience           = "https://signin.sandpit.account.gov.uk/"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

Add additional config for sandpit deployment:

- orch_to_auth_client_id
- orch_to_auth_audience

## Why?

To fix error messages in the frontend on authorize when this config is missing
