### PR TITLE
AUT-1624: Test standard ECS auto scaling configuration in sandpit, build and staging

### DIFF
--- a/ci/terraform/auto-scaling.tf
+++ b/ci/terraform/auto-scaling.tf
@@ -1,4 +1,5 @@
 
+# TODO: fully replace frontend_auto_scaling_* with frontend_auto_scaling_*_v2 after performance testing
 resource "aws_appautoscaling_target" "frontend_auto_scaling_target" {
   count              = var.frontend_auto_scaling_enabled ? 1 : 0
   min_capacity       = var.frontend_auto_scaling_min_count

--- a/ci/terraform/auto-scaling.tf
+++ b/ci/terraform/auto-scaling.tf
@@ -43,3 +43,108 @@ resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_cpu" {
     scale_in_cooldown  = var.frontend_auto_scaling_policy_scale_in_cooldown
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "ecs_service_scale_out_alarm" {
+  count               = var.frontend_auto_scaling_v2_enabled ? 1 : 0
+  alarm_name          = "${var.environment}-app-cluster/${aws_ecs_service.frontend_ecs_service.name}-AlarmScaleUp"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 60
+  datapoints_to_alarm = 2
+
+  dimensions = {
+    ClusterName = "${var.environment}-app-cluster"
+    ServiceName = "${aws_ecs_service.frontend_ecs_service.name}"
+  }
+
+  alarm_description = "Metric alarm to trigger ECS scale up"
+  alarm_actions     = [aws_appautoscaling_policy.frontend_auto_scaling_policy_scale_out[0].arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_service_scale_in_alarm" {
+  count               = var.frontend_auto_scaling_v2_enabled ? 1 : 0
+  alarm_name          = "${var.environment}-app-cluster/${aws_ecs_service.frontend_ecs_service.name}-AlarmScaleDown"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 5
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 60
+  datapoints_to_alarm = 5
+
+  dimensions = {
+    ClusterName = "${var.environment}-app-cluster"
+    ServiceName = "${aws_ecs_service.frontend_ecs_service.name}"
+  }
+
+  alarm_description = "Metric alarm to trigger ECS scale down"
+  alarm_actions     = [aws_appautoscaling_policy.frontend_auto_scaling_policy_scale_in[0].arn]
+}
+
+resource "aws_appautoscaling_target" "frontend_auto_scaling_target_v2" {
+  count              = var.frontend_auto_scaling_v2_enabled ? 1 : 0
+  min_capacity       = var.frontend_auto_scaling_min_count
+  max_capacity       = var.frontend_auto_scaling_max_count
+  resource_id        = "service/${var.environment}-app-cluster/${aws_ecs_service.frontend_ecs_service.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_scale_out" {
+  count              = var.frontend_auto_scaling_v2_enabled ? 1 : 0
+  name               = "${var.environment}-frontend_auto_scaling_policy_scale_in"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.frontend_auto_scaling_target_v2[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.frontend_auto_scaling_target_v2[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.frontend_auto_scaling_target_v2[0].service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type          = "PercentChangeInCapacity"
+    metric_aggregation_type  = "Average"
+    cooldown                 = 120
+    min_adjustment_magnitude = 5
+
+    step_adjustment {
+      metric_interval_lower_bound = 20
+      metric_interval_upper_bound = 30
+      scaling_adjustment          = 200
+    }
+
+    step_adjustment {
+      metric_interval_lower_bound = 30
+      metric_interval_upper_bound = 35
+      scaling_adjustment          = 300
+    }
+
+    step_adjustment {
+      metric_interval_lower_bound = 35
+      scaling_adjustment          = 500
+    }
+  }
+}
+
+resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_scale_in" {
+  count              = var.frontend_auto_scaling_v2_enabled ? 1 : 0
+  name               = "${var.environment}-frontend_auto_scaling_policy_scale_in"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.frontend_auto_scaling_target_v2[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.frontend_auto_scaling_target_v2[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.frontend_auto_scaling_target_v2[0].service_namespace
+
+  step_scaling_policy_configuration {
+    adjustment_type          = "PercentChangeInCapacity"
+    metric_aggregation_type  = "Average"
+    cooldown                 = 120
+    min_adjustment_magnitude = 5
+
+    step_adjustment {
+      metric_interval_upper_bound = -40
+      scaling_adjustment          = -50
+    }
+  }
+}

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,9 +1,12 @@
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled   = true
+frontend_auto_scaling_v2_enabled = true
+
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
+frontend_auto_scaling_min_count = 1
+frontend_auto_scaling_max_count = 3
 
 support_welsh_language_in_support_forms                             = "1"
 support_smart_agent                                                 = "1"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -14,9 +14,11 @@ support_account_recovery      = "1"
 support_auth_orch_split       = "1"
 support_international_numbers = "1"
 
-frontend_task_definition_cpu    = 256
-frontend_task_definition_memory = 512
-frontend_auto_scaling_enabled   = true
+frontend_task_definition_cpu     = 256
+frontend_task_definition_memory  = 512
+frontend_auto_scaling_v2_enabled = true
+frontend_auto_scaling_min_count  = 1
+frontend_auto_scaling_max_count  = 2
 
 support_smart_agent                     = "1"
 support_welsh_language_in_support_forms = "1"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -2,12 +2,12 @@ environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled                                       = true
+frontend_auto_scaling_v2_enabled                                    = true
 frontend_task_definition_cpu                                        = 512
 frontend_task_definition_memory                                     = 1024
-frontend_auto_scaling_min_count                                     = 4
+frontend_auto_scaling_min_count                                     = 3
 frontend_auto_scaling_max_count                                     = 12
-ecs_desired_count                                                   = 4
+ecs_desired_count                                                   = 3
 support_welsh_language_in_support_forms                             = "1"
 support_language_cy                                                 = "1"
 support_international_numbers                                       = "1"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -80,6 +80,10 @@ variable "frontend_auto_scaling_enabled" {
   default = false
 }
 
+variable "frontend_auto_scaling_v2_enabled" {
+  default = false
+}
+
 variable "frontend_auto_scaling_min_count" {
   type    = number
   default = 2

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -38,7 +38,7 @@ while [[ $# -gt 0 ]]; do
     ;;
   -t | --terraform)
     # shellcheck disable=SC2034
-    OIDC=1
+    TERRAFORM=1
     ;;
   --destroy)
     TERRAFORM_OPTS="-destroy"


### PR DESCRIPTION
## What?

Test standard ECS auto scaling configuration in sandpit, build and staging.

Switch off the current auto scaling configuration and switch on the standard one in these environments. Have applied the standard configuration using Terraform: 

https://github.com/govuk-one-login/architecture/blob/4b985350c63b000343bccc76027101139b0e5e35/adr/01XX-fargate-scaling.md

## Why?

The current configuration did not scale appropriately during performance test.
