### PR TITLE
AUT-1706: fix CSP issues identified by ZAP

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -1,9 +1,29 @@
 import helmet from "helmet";
-import { Request, Response } from "express";
+import e, { Request, Response } from "express";
 import { supportFrameAncestorsFormActionsCspHeaders } from "../config";
 // Helmet does not export the config type - This is the way the recommend getting it on GitHub.
 export function helmetConfiguration(): Parameters<typeof helmet>[0] {
-  const helmetConfig = {
+  let helmetConfig: {
+    permittedCrossDomainPolicies: boolean;
+    referrerPolicy: boolean;
+    expectCt: boolean;
+    frameguard: { action: string };
+    hsts: { maxAge: number; includeSubDomains: boolean; preload: boolean };
+    dnsPrefetchControl: { allow: boolean };
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: string[];
+        objectSrc: string[];
+        styleSrc: string[];
+        scriptSrc: (string | ((req: e.Request, res: e.Response) => string))[];
+        imgSrc: string[];
+        connectSrc: string[];
+        "form-action"?: string[];
+        "frame-ancestors"?: string[]
+      }
+    }
+  };
+  helmetConfig = {
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
@@ -26,8 +46,6 @@ export function helmetConfiguration(): Parameters<typeof helmet>[0] {
         ],
         objectSrc: ["'none'"],
         connectSrc: ["'self'", "https://www.google-analytics.com"],
-        "frame-ancestors": [""],
-        "form-action": [""],
       },
     },
     dnsPrefetchControl: {


### PR DESCRIPTION
## What?

Add a functionality to add the frame-ancestors and form-actions CSP headers if the FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS terraform variable is set to true.

## Why?

The following directives either allow wildcard sources (or ancestors), are not defined, or are overly broadly defined: frame-ancestors, form-action The directive(s): frame-ancestors, form-action are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.

