### PR TITLE
AUT-1706: review and fix CSP issues identified by ZAP

### DIFF
--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -29,3 +29,5 @@ orch_to_auth_audience           = "https://signin.sandpit.account.gov.uk/"
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+frame_ancestors_form_actions_csp_headers = "1"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -251,3 +251,9 @@ variable "orch_to_auth_audience" {
   type        = string
   default     = ""
 }
+
+variable "frame_ancestors_form_actions_csp_headers" {
+  description = "When true, sets frame-ancestors and form-action CSP headers in reponses"
+  type        = string
+  default     = "0"
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -164,7 +164,7 @@ async function createApp(): Promise<express.Application> {
     );
 
   app.use(i18nextMiddleware.handle(i18next));
-  app.use(helmet(helmetConfiguration));
+  app.use(helmet(helmetConfiguration()));
 
   const redisConfig = isProduction
     ? await getRedisConfig(getAppEnv())

--- a/src/config.ts
+++ b/src/config.ts
@@ -191,3 +191,7 @@ export function getPasswordResetCodeEnteredWrongBlockDurationInMinutes(): number
     Number(process.env.PASSWORD_RESET_CODE_ENTERED_WRONG_BLOCKED_MINUTES) || 15
   );
 }
+
+export function supportFrameAncestorsFormActionsCspHeaders(): boolean {
+  return process.env.FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS === "1";
+}

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -1,43 +1,76 @@
 import helmet from "helmet";
-import { Request, Response } from "express";
+import e, { Request, Response } from "express";
+import { supportFrameAncestorsFormActionsCspHeaders } from "../config";
 // Helmet does not export the config type - This is the way the recommend getting it on GitHub.
-export const helmetConfiguration: Parameters<typeof helmet>[0] = {
-  contentSecurityPolicy: {
-    directives: {
-      defaultSrc: ["'self'"],
-      styleSrc: ["'self'"],
-      scriptSrc: [
-        "'self'",
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        (req: Request, res: Response): string =>
-          `'nonce-${res.locals.scriptNonce}'`,
-        "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
-        "https://www.googletagmanager.com",
-        "https://www.google-analytics.com",
-        "https://ssl.google-analytics.com",
-      ],
-      imgSrc: [
-        "'self'",
-        "data:",
-        "https://www.googletagmanager.com",
-        "https://www.google-analytics.com",
-      ],
-      objectSrc: ["'none'"],
-      connectSrc: ["'self'", "https://www.google-analytics.com"],
+export function helmetConfiguration(): Parameters<typeof helmet>[0] {
+  const helmetConfig: {
+    permittedCrossDomainPolicies: boolean;
+    referrerPolicy: boolean;
+    expectCt: boolean;
+    frameguard: { action: string };
+    hsts: { maxAge: number; includeSubDomains: boolean; preload: boolean };
+    dnsPrefetchControl: { allow: boolean };
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: string[];
+        objectSrc: string[];
+        styleSrc: string[];
+        scriptSrc: (string | ((req: e.Request, res: e.Response) => string))[];
+        imgSrc: string[];
+        connectSrc: string[];
+        "form-action"?: string[];
+        "frame-ancestors"?: string[];
+      };
+    };
+  } = {
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        styleSrc: ["'self'"],
+        scriptSrc: [
+          "'self'",
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+          (req: Request, res: Response): string =>
+            `'nonce-${res.locals.scriptNonce}'`,
+          "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
+          "https://www.googletagmanager.com",
+          "https://www.google-analytics.com",
+          "https://ssl.google-analytics.com",
+        ],
+        imgSrc: [
+          "'self'",
+          "data:",
+          "https://www.googletagmanager.com",
+          "https://www.google-analytics.com",
+        ],
+        objectSrc: ["'none'"],
+        connectSrc: ["'self'", "https://www.google-analytics.com"],
+      },
     },
-  },
-  dnsPrefetchControl: {
-    allow: false,
-  },
-  frameguard: {
-    action: "deny",
-  },
-  hsts: {
-    maxAge: 31536000, // 1 Year
-    preload: true,
-    includeSubDomains: true,
-  },
-  referrerPolicy: false,
-  permittedCrossDomainPolicies: false,
-  expectCt: false,
-};
+    dnsPrefetchControl: {
+      allow: false,
+    },
+    frameguard: {
+      action: "deny",
+    },
+    hsts: {
+      maxAge: 31536000, // 1 Year
+      preload: true,
+      includeSubDomains: true,
+    },
+    referrerPolicy: false,
+    permittedCrossDomainPolicies: false,
+    expectCt: false,
+  };
+  if (supportFrameAncestorsFormActionsCspHeaders()) {
+    helmetConfig.contentSecurityPolicy.directives["frame-ancestors"] = [
+      "'self'",
+      "https://*.account.gov.uk",
+    ];
+    helmetConfig.contentSecurityPolicy.directives["form-action"] = [
+      "'self'",
+      "https://*.account.gov.uk",
+    ];
+  }
+  return helmetConfig;
+}


### PR DESCRIPTION
## What?

Add a functionality to add the frame-ancestors and form-actions CSP headers if the FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS terraform variable is set to true.

## Why?

The following directives either allow wildcard sources (or ancestors), are not defined, or are overly broadly defined: frame-ancestors, form-action The directive(s): frame-ancestors, form-action are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.

