### PR TITLE
AUT-1706: Turn on the frame_ancestors_form_actions_csp_headers flag

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -16,3 +16,5 @@ url_for_support_links                                               = "https://h
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+frame_ancestors_form_actions_csp_headers = "1"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -19,3 +19,5 @@ url_for_support_links                                               = "https://h
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+frame_ancestors_form_actions_csp_headers = "1"


### PR DESCRIPTION
AUT-1706: Turn on the frame_ancestors_form_actions_csp_headers flag in integration and staging

## What?

Add a functionality to add the frame-ancestors and form-actions CSP headers if the FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS terraform variable is set to true.

## Why?

We need to turn on this flag in integration and testing in order to test if the CSP headers don't break any existing configurations. 
