### PR TITLE
AUT-1706: Add csp switch env var to ecs config

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -168,6 +168,10 @@ locals {
         name  = "CODE_ENTERED_WRONG_BLOCKED_MINUTES"
         value = var.code_entered_wrong_blocked_minutes
       },
+      {
+        name  = "FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS"
+        value = var.frame_ancestors_form_actions_csp_headers
+      },
     ]
 
     mountPoints = [


### PR DESCRIPTION
## What?

Add csp switch env var to ecs config.

## Why?

So that the switch value gets passed to the application via the ecs task config.  Without this change the switch does not apply.

## Related PRs

#1208 
