### PR TITLE
AUT-1706: Remove form-action header from /enter-code page

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -29,3 +29,5 @@ logging_endpoint_arns = [
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr\nCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.build.account.gov.uk/"
+
+frame_ancestors_form_actions_csp_headers = "0"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -32,4 +32,4 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-frame_ancestors_form_actions_csp_headers = "1"
+frame_ancestors_form_actions_csp_headers = "0"

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,8 +8,6 @@ import i18nextMiddleware from "i18next-http-middleware";
 import * as path from "path";
 import { configureNunjucks } from "./config/nunchucks";
 import { i18nextConfigurationOptions } from "./config/i18next";
-import { helmetConfiguration } from "./config/helmet";
-import helmet from "helmet";
 
 import { setHtmlLangMiddleware } from "./middleware/html-lang-middleware";
 import i18next from "i18next";
@@ -83,6 +81,7 @@ import { setInternationalPhoneNumberSupportMiddleware } from "./middleware/set-i
 import { checkYourEmailSecurityCodesRouter } from "./components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-routes";
 import { changeSecurityCodesConfirmationRouter } from "./components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-routes";
 import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-us-links-middleware";
+import { setCspHeaders } from "./middleware/set-csp-headers-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -164,7 +163,7 @@ async function createApp(): Promise<express.Application> {
     );
 
   app.use(i18nextMiddleware.handle(i18next));
-  app.use(helmet(helmetConfiguration()));
+  app.use(setCspHeaders);
 
   const redisConfig = isProduction
     ? await getRedisConfig(getAppEnv())

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -2,7 +2,9 @@ import helmet from "helmet";
 import e, { Request, Response } from "express";
 import { supportFrameAncestorsFormActionsCspHeaders } from "../config";
 // Helmet does not export the config type - This is the way the recommend getting it on GitHub.
-export function helmetConfiguration(): Parameters<typeof helmet>[0] {
+export function helmetConfiguration(
+  req: Request
+): Parameters<typeof helmet>[0] {
   const helmetConfig: {
     permittedCrossDomainPolicies: boolean;
     referrerPolicy: boolean;
@@ -63,14 +65,21 @@ export function helmetConfiguration(): Parameters<typeof helmet>[0] {
     expectCt: false,
   };
   if (supportFrameAncestorsFormActionsCspHeaders()) {
-    helmetConfig.contentSecurityPolicy.directives["frame-ancestors"] = [
-      "'self'",
-      "https://*.account.gov.uk",
-    ];
-    helmetConfig.contentSecurityPolicy.directives["form-action"] = [
-      "'self'",
-      "https://*.account.gov.uk",
-    ];
+    if (req.url == "/enter-code") {
+      helmetConfig.contentSecurityPolicy.directives["frame-ancestors"] = [
+        "'self'",
+        "https://*.account.gov.uk",
+      ];
+    } else {
+      helmetConfig.contentSecurityPolicy.directives["frame-ancestors"] = [
+        "'self'",
+        "https://*.account.gov.uk",
+      ];
+      helmetConfig.contentSecurityPolicy.directives["form-action"] = [
+        "'self'",
+        "https://*.account.gov.uk",
+      ];
+    }
   }
   return helmetConfig;
 }

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -1,6 +1,7 @@
 import helmet from "helmet";
 import e, { Request, Response } from "express";
 import { supportFrameAncestorsFormActionsCspHeaders } from "../config";
+import { PATH_NAMES } from "../app.constants";
 // Helmet does not export the config type - This is the way the recommend getting it on GitHub.
 export function helmetConfiguration(
   req: Request
@@ -65,7 +66,14 @@ export function helmetConfiguration(
     expectCt: false,
   };
   if (supportFrameAncestorsFormActionsCspHeaders()) {
-    if (req.url == "/enter-code") {
+    if (
+      [
+        PATH_NAMES.ENTER_MFA,
+        PATH_NAMES.ENTER_PASSWORD,
+        PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL,
+        PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS,
+      ].includes(req.url)
+    ) {
       helmetConfig.contentSecurityPolicy.directives["frame-ancestors"] = [
         "'self'",
         "https://*.account.gov.uk",

--- a/src/middleware/set-csp-headers-middleware.ts
+++ b/src/middleware/set-csp-headers-middleware.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+import helmet from "helmet";
+import { helmetConfiguration } from "../config/helmet";
+
+export function setCspHeaders(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  helmet(helmetConfiguration(req))(req, res, next);
+}


### PR DESCRIPTION
## What?

Add the form-action CSP head to every other page than "/enter-code"

## Why?

The "/enter-code" page submits form information to multiple services.
