### PR TITLE
AUT-1706: Switch frame_ancestors_form_actions_csp_headers off in sandpit

### DIFF
--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -32,4 +32,4 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-frame_ancestors_form_actions_csp_headers = "1"
+frame_ancestors_form_actions_csp_headers = "0"


### PR DESCRIPTION

## What?

Switch frame_ancestors_form_actions_csp_headers off in sandpit.

## Why?

Flow is broken with the additional headers when redirecting back to the RP

## Related PRs

#1208 
