### PR TITLE
AUT-1497: Add "What service were you trying to use?" to the required …

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -502,6 +502,10 @@ export function getQuestionsFromFormTypeForMessageBody(
         "pages.contactUsQuestions.accountNotFound.section2.header",
         { lng: "en" }
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
     },
     anotherProblem: {
       issueDescription: req.t(
@@ -512,6 +516,10 @@ export function getQuestionsFromFormTypeForMessageBody(
         "pages.contactUsQuestions.anotherProblem.section2.header",
         { lng: "en" }
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
     },
     authenticatorApp: {
       issueDescription: req.t(
@@ -520,6 +528,10 @@ export function getQuestionsFromFormTypeForMessageBody(
       ),
       additionalDescription: req.t(
         "pages.contactUsQuestions.authenticatorApp.section2.header",
+        { lng: "en" }
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
         { lng: "en" }
       ),
     },
@@ -538,6 +550,10 @@ export function getQuestionsFromFormTypeForMessageBody(
         "pages.contactUsQuestions.forgottenPassword.section1.header",
         { lng: "en" }
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
     },
     invalidSecurityCode: {
       moreDetailDescription: req.t(
@@ -546,6 +562,10 @@ export function getQuestionsFromFormTypeForMessageBody(
       ),
       radioButtons: req.t(
         "pages.contactUsQuestions.invalidSecurityCode.section1.header",
+        { lng: "en" }
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
         { lng: "en" }
       ),
     },
@@ -558,6 +578,10 @@ export function getQuestionsFromFormTypeForMessageBody(
         "pages.contactUsQuestions.noPhoneNumberAccess.section1.header",
         { lng: "en" }
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
     },
     noSecurityCode: {
       moreDetailDescription: req.t(
@@ -566,6 +590,10 @@ export function getQuestionsFromFormTypeForMessageBody(
       ),
       radioButtons: req.t(
         "pages.contactUsQuestions.noSecurityCode.section1.header",
+        { lng: "en" }
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
         { lng: "en" }
       ),
     },
@@ -580,6 +608,10 @@ export function getQuestionsFromFormTypeForMessageBody(
       ),
       countryPhoneNumberFrom: req.t(
         "pages.contactUsQuestions.signInPhoneNumberIssue.section3.header",
+        { lng: "en" }
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
         { lng: "en" }
       ),
     },

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -39,6 +39,8 @@
     } if (errors['issueDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -15,32 +15,6 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.accountNotFound.section1.header' | translateEnOnly,
-      classes: "govuk-label--s"
-    },
-    hint: {
-        text: 'pages.contactUsQuestions.accountNotFound.section1.paragraph1' | translateEnOnly
-      },
-    id: "issueDescription",
-    name: "issueDescription",
-    maxlength: zendeskFieldMaxLength,
-    value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
-    charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
-    },
-    charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
-    },
-    errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
-    } if (errors['issueDescription'])
-}) }}
-
-{{ govukCharacterCount({
-    label: {
       text: 'pages.contactUsQuestions.accountNotFound.section2.header' | translateEnOnly,
       classes: "govuk-label--s"
     },
@@ -64,6 +38,8 @@
         text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
+
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -62,6 +62,8 @@
     } if (errors['additionalDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -62,6 +62,8 @@
     } if (errors['additionalDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -39,6 +39,8 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -42,6 +42,8 @@
     } if (errors['moreDetailDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -42,6 +42,8 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -42,6 +42,8 @@
     } if (errors['moreDetailDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -39,6 +39,8 @@
     } if (errors['issueDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -62,6 +62,8 @@
     } if (errors['additionalDescription'])
 }) }}
 
+{% include "contact-us/questions/_service-trying-to-use.njk" %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"


### PR DESCRIPTION
## What?

Update user supports forms to add 'What service were you trying to use?' field.
This ticket is to add a ‘What service were you trying to use?’ field and hint text to a number of user support forms.
In all cases, it should be placed just above the warning component.

## Why?

As One Login User Support
I want to know what service a user was trying use
So that I can resolve their problem quicker

