### PR TITLE
BAU: Reset build and sandpit ecs task count to the defaults

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,8 +5,6 @@ frontend_auto_scaling_v2_enabled = true
 
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
-frontend_auto_scaling_min_count = 1
-frontend_auto_scaling_max_count = 3
 
 support_welsh_language_in_support_forms                             = "1"
 support_smart_agent                                                 = "1"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -17,8 +17,6 @@ support_international_numbers = "1"
 frontend_task_definition_cpu     = 256
 frontend_task_definition_memory  = 512
 frontend_auto_scaling_v2_enabled = true
-frontend_auto_scaling_min_count  = 1
-frontend_auto_scaling_max_count  = 2
 
 support_smart_agent                     = "1"
 support_welsh_language_in_support_forms = "1"


### PR DESCRIPTION
## What?

Reset build and sandpit ecs task count to the previous defaults.

## Why?

After switching to the v2 scaling policy there was an issue with the application not restarting due to the minimumHealthyPercent threshold not being met during a deployment, as the minimum count had gone down to 1.

## Related PRs

#1202 