### PR TITLE
CN-754: Fix issue with Contact Form back links

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -15,6 +15,7 @@ import { logger } from "../../utils/logger";
 import {
   getClientNameThatDirectsAllContactFormSubmissionsToSmartAgent,
   getServiceDomain,
+  getSupportLinkUrl,
 } from "../../config";
 import { contactUsServiceSmartAgent } from "./contact-us-service-smart-agent";
 
@@ -114,15 +115,58 @@ export function contactUsGet(req: Request, res: Response): void {
     }
   }
 
+  const supportLinkURL = getSupportLinkUrl();
+  const backLinkHref = prepareBackLink(req, supportLinkURL, serviceDomain);
+
   const options = {
     referer: referer,
     fromURL: fromURL,
+    hrefBack: backLinkHref,
     ...(getAppSessionId(req.query.appSessionId as string) && {
       appSessionId: getAppSessionId(req.query.appSessionId as string),
     }),
   };
 
   return res.render("contact-us/index-public-contact-us.njk", options);
+}
+
+export function prepareBackLink(
+  req: Request,
+  supportLinkURL: string,
+  serviceDomain: string
+): string {
+  let hrefBack: string;
+
+  if (req.path.endsWith(PATH_NAMES.CONTACT_US)) {
+    hrefBack = supportLinkURL;
+  } else if (req.path.endsWith(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)) {
+    if (req.query.fromURL && req.query.theme === ZENDESK_THEMES.ID_CHECK_APP) {
+      hrefBack = supportLinkURL;
+    } else {
+      hrefBack = PATH_NAMES.CONTACT_US;
+    }
+  } else if (req.path.endsWith(PATH_NAMES.CONTACT_US_QUESTIONS)) {
+    hrefBack = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
+  } else {
+    hrefBack = PATH_NAMES.CONTACT_US;
+  }
+
+  const queryParams = new URLSearchParams();
+
+  if (validateReferer(req.query.fromURL as string, serviceDomain)) {
+    queryParams.append("fromURL", req.query.fromURL as string);
+  }
+
+  if (
+    req.query.theme &&
+    Object.values(ZENDESK_THEMES).includes(req.query.theme as string)
+  ) {
+    queryParams.append("theme", req.query.theme as string);
+  }
+
+  return queryParams.toString().length > 0
+    ? hrefBack + "?" + queryParams.toString()
+    : hrefBack;
 }
 
 export function contactUsGetFromTriagePage(req: Request, res: Response): void {
@@ -261,12 +305,12 @@ export function contactUsFormPost(req: Request, res: Response): void {
 }
 
 export function furtherInformationGet(req: Request, res: Response): void {
+  const supportLinkURL = getSupportLinkUrl();
+  const backLinkHref = prepareBackLink(req, supportLinkURL, serviceDomain);
+
   if (!req.query.theme) {
     return res.redirect(PATH_NAMES.CONTACT_US);
   }
-
-  const backLinkHref =
-    validateReferer(req.get("referer"), serviceDomain) || PATH_NAMES.CONTACT_US;
 
   if (isAppJourney(req.query.appSessionId as string)) {
     return res.render("contact-us/further-information/index.njk", {
@@ -328,6 +372,9 @@ export function setContactFormSubmissionUrlBasedOnClientName(
 }
 
 export function contactUsQuestionsGet(req: Request, res: Response): void {
+  const supportLinkURL = getSupportLinkUrl();
+  const backLinkHref = prepareBackLink(req, supportLinkURL, serviceDomain);
+
   const formSubmissionUrl = setContactFormSubmissionUrlBasedOnClientName(
     req?.session?.client?.name,
     getClientNameThatDirectsAllContactFormSubmissionsToSmartAgent()
@@ -349,7 +396,7 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     formSubmissionUrl: formSubmissionUrl,
     theme: req.query.theme,
     subtheme: req.query.subtheme,
-    backurl: validateReferer(req.headers.referer, serviceDomain),
+    backurl: backLinkHref,
     referer: validateReferer(req.query.referer as string, serviceDomain),
     ...(validateReferer(req.query.fromURL as string, serviceDomain) && {
       fromURL: validateReferer(req.query.fromURL as string, serviceDomain),

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -6,7 +6,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}
-{% set hrefBack = referer %}
 {% set pageTitleName = 'pages.contactUsPublic.title' | translateEnOnly %}
 
 {% block content %}

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -16,6 +16,7 @@ import {
   contactUsGetFromTriagePage,
   setContactFormSubmissionUrlBasedOnClientName,
   validateReferer,
+  prepareBackLink,
 } from "../contact-us-controller";
 import {
   PATH_NAMES,
@@ -24,6 +25,7 @@ import {
   CONTACT_US_REFERER_ALLOWLIST,
 } from "../../../app.constants";
 import { RequestGet, ResponseRedirect } from "../../../types";
+import { getServiceDomain, getSupportLinkUrl } from "../../../config";
 
 describe("contact us controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -35,6 +37,7 @@ describe("contact us controller", () => {
     sandbox = sinon.createSandbox();
 
     req = {
+      path: PATH_NAMES.CONTACT_US,
       body: {},
       query: {},
       headers: {},
@@ -396,6 +399,100 @@ describe("appErrorCode and appSessionId query parameters", () => {
           encodedItem
         );
       });
+    });
+  });
+});
+
+describe("prepareBackLink", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let supportLinkURL: string;
+  let serviceDomain: string;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    serviceDomain = getServiceDomain();
+    supportLinkURL = getSupportLinkUrl();
+
+    req = {
+      url: "",
+      path: "",
+      body: {},
+      query: {},
+      headers: {},
+      get: sandbox.fake() as unknown as RequestGet,
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return the supportLinkURL when the req.path ends with the CONTACT_US path", () => {
+    req.path = PATH_NAMES.CONTACT_US;
+    expect(
+      prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+    ).to.equal(supportLinkURL);
+  });
+
+  it("should return the CONTACT_US_FURTHER_INFORMATION path when the req.path ends with the CONTACT_US_QUESTIONS path", () => {
+    req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
+    expect(
+      prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+    ).to.equal(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION);
+  });
+
+  it("should return the supportLinkURL with a fromURL parameter when one is included in the req.url", () => {
+    req.query.fromURL = `https://${getServiceDomain()}${PATH_NAMES.CONTACT_US}`;
+    const fromURL =
+      "?fromURL=" +
+      encodeURIComponent(
+        `https://${getServiceDomain()}${PATH_NAMES.CONTACT_US}`
+      );
+
+    expect(
+      prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+    ).to.equal(supportLinkURL + fromURL);
+  });
+
+  it("should omit the fromURL from the backlink where the one included in req.url is not valid", () => {
+    req.url = `https://${getServiceDomain()}${
+      PATH_NAMES.CONTACT_US
+    }?fromURL=${encodeURIComponent("https://www.example.com")}`;
+
+    expect(
+      prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+    ).to.equal(supportLinkURL);
+  });
+
+  it("should include the `theme` where the theme is valid", () => {
+    req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
+    req.url = `https://${getServiceDomain()}${PATH_NAMES.CONTACT_US}?theme=${
+      ZENDESK_THEMES.ACCOUNT_CREATION
+    }`;
+
+    const theme = `?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`;
+
+    expect(
+      prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+    ).to.equal(supportLinkURL + theme);
+  });
+
+  describe("dynamic back links on CONTACT_US_FURTHER_INFORMATION", () => {
+    it("should default to returning the CONTACT_US path", () => {
+      req.path = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
+      expect(
+        prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+      ).to.equal(PATH_NAMES.CONTACT_US);
+    });
+    it("should return the `supportLinkURL` if there is a fromURL and the theme is ID_CHECK_APP", () => {
+      req.path = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
+      req.query.fromURL = PATH_NAMES.DOC_CHECKING_APP;
+      req.query.theme = ZENDESK_THEMES.ID_CHECK_APP;
+      expect(
+        prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+      ).to.equal(`${supportLinkURL}?theme=${ZENDESK_THEMES.ID_CHECK_APP}`);
     });
   });
 });

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -35,6 +35,7 @@ describe("contact us further information controller", () => {
     it("should render signing in further information if a problem signing in to your account radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
       furtherInformationGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
@@ -42,12 +43,13 @@ describe("contact us further information controller", () => {
         {
           theme: "signing_in",
           referer: REFERER,
-          hrefBack: PATH_NAMES.CONTACT_US,
+          hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         }
       );
     });
 
     it("should render account creation further information if a creating an account radio option was chosen", () => {
+      req.path = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.referer = REFERER;
       furtherInformationGet(req as Request, res as Response);
@@ -57,12 +59,13 @@ describe("contact us further information controller", () => {
         {
           theme: "account_creation",
           referer: REFERER,
-          hrefBack: PATH_NAMES.CONTACT_US,
+          hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         }
       );
     });
 
     it("should redirect to contact-us when no theme is present in request", () => {
+      req.path = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
       furtherInformationGet(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith("/contact-us");

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -22,7 +22,6 @@ describe("contact us questions controller", () => {
   let res: Partial<Response>;
   const REFERER = "http://localhost:3000/enter-email";
   const REFERER_HEADER = "http://localhost/contact-us-further-information";
-  const BACKURL = "http://localhost:3000/contact-us";
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -48,15 +47,16 @@ describe("contact us questions controller", () => {
   describe("contactUsQuestionsGetFromContactUsPage", () => {
     it("should render contact-us-questions if a 'another problem using your account' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SOMETHING_ELSE;
-      req.headers.referer = BACKURL;
+      req.headers.referer = REFERER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "something_else",
         subtheme: undefined,
-        backurl: BACKURL,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SOMETHING_ELSE}`,
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -68,15 +68,16 @@ describe("contact us questions controller", () => {
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS;
-      req.headers.referer = BACKURL;
+      req.headers.referer = REFERER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "email_subscriptions",
         subtheme: undefined,
-        backurl: BACKURL,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -88,15 +89,16 @@ describe("contact us questions controller", () => {
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SUGGESTIONS_FEEDBACK;
-      req.headers.referer = BACKURL;
+      req.headers.referer = REFERER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "suggestions_feedback",
         subtheme: undefined,
-        backurl: BACKURL,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SUGGESTIONS_FEEDBACK}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -109,15 +111,16 @@ describe("contact us questions controller", () => {
 
     it("should render contact-us-questions if a 'A problem proving your identity' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.PROVING_IDENTITY;
-      req.headers.referer = BACKURL;
+      req.headers.referer = REFERER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "proving_identity",
         subtheme: undefined,
-        backurl: BACKURL,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.PROVING_IDENTITY}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -129,6 +132,7 @@ describe("contact us questions controller", () => {
     });
 
     it("should redirect to contact-us when no theme is present in request", () => {
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith("/contact-us");
@@ -141,13 +145,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "no_security_code",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -162,13 +167,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "invalid_security_code",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -183,13 +189,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.NO_PHONE_NUMBER_ACCESS;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "no_phone_number_access",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -204,13 +211,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.FORGOTTEN_PASSWORD;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "forgotten_password",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -225,13 +233,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.ACCOUNT_NOT_FOUND;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "account_not_found",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -246,13 +255,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "technical_error",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -267,13 +277,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "something_else",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.SIGNING_IN}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -291,13 +302,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "no_security_code",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -312,13 +324,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "invalid_security_code",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -333,13 +346,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.SIGN_IN_PHONE_NUMBER_ISSUE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "sign_in_phone_number_issue",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         referer: REFERER,
         pageTitleHeading:
           "pages.contactUsQuestions.signInPhoneNumberIssue.title",
@@ -355,13 +369,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "technical_error",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -376,13 +391,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "something_else",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -397,13 +413,14 @@ describe("contact us questions controller", () => {
       req.query.subtheme = ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
+      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "authenticator_app_problem",
-        backurl: REFERER_HEADER,
+        backurl: `/contact-us-further-information?theme=${ZENDESK_THEMES.ACCOUNT_CREATION}`,
         referer: REFERER,
         pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,


### PR DESCRIPTION
## What?

Fixes Contact Forms "Back" links issues that have emerged since the Triage Page was introduced.

## Why (and how)?

The changes to make "Back" links work are quite involved (much less straightforward than I'd anticipated), so I've tried to set out all the relevant context. Let me know if you'd like me to talk you through it - I'd be very happy to. 

### How the Triage Page works has complicated "Back" links
The programme introducing a Triage Page that sits outside the `di-authentication-frontend` repository has introduced some complexity for determining the correct destination for "Back" links presented to users presented to users in the Contact Forms. Significant contributors to this are that:

1. there are Triage Pages for most, but not all, our environments 
2. the Triage Page includes a single link to the Contact Forms that **does** include a `fromURL` parameter and _may_ include a `theme=id_check_app` parameter. 

Where the `theme=id_check_app` parameter exists, we route the user to Contact Form options specific to the ID Check App. The logic to achieve the necessary redirect is in a new [contactUsGetFromTriagePage](https://github.com/govuk-one-login/authentication-frontend/blob/ca3136cf5ca878f4912db9d5ecd7cc2ec2701c66/src/components/contact-us/contact-us-controller.ts#L128) controller method.

<img width="1091" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/3bb628db-911c-4430-99d6-585b325b6839">

### The new `prepareBackLink()` function
A new `prepareBackLink()` function has been created to:
1. return an appropriate "Back" link based on the value of `req.path` (logic described below)
2. append the `fromURL` and `theme` parameter, where applicable. 

Because `prepareBackLink()` inspects `req.path` and changes the destination of "Back" links, it has been necessary to update existing tests to accommodate this.

#### Back link on `/contact-us`
The "Back" link on `/contact-us` goes to the destination returned by `getSupportLinkUrl()` which returns the `url_for_support_links` environment variable (set to the corresponding Triage Page in all environments)

#### Dynamic back link on `/contact-us-further-information`
Because users visiting `/contact-us-further-information` may have come direct from the Triage Page, the "Back" link on `/contact-us-further-information` needs to be dynamic, taking users to:

1. the Triage Page _if_ we can infer the user bypassed `/contact-us` (which we can do by checking for the existence of both a `fromURL` and a `theme=id_check_app` parameter)
5. `/contact-us` in all other cases

#### Back link on `/contact-us-questions`
The "Back link on `/contact-us-questions` goes to `/contact-us-further-information`

#### Other cases
If none of the conditions are met, `prepareBackLink()` defaults to returning `/contact-us`

<img width="642" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1f7463a0-af9c-4934-9e0f-546873cc6ba1">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

**Note:** while this PR does not change the UI, it does have potential to impact user journeys, so it has been shown to UCD colleagues. 

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
