### PR TITLE
AUT-1497: Fix [undefined] service field for contact support forms 

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -494,6 +494,10 @@ export function getQuestionsFromFormTypeForMessageBody(
         "pages.contactUsQuestions.accountCreationProblem.section1.paragraph1",
         { lng: "en" }
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
     },
     accountNotFound: {
       issueDescription: req.t(
@@ -622,6 +626,10 @@ export function getQuestionsFromFormTypeForMessageBody(
         "pages.contactUsQuestions.signignInProblem.section1.header",
         { lng: "en" }
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
     },
     suggestionFeedback: {
       issueDescription: req.t(
@@ -640,6 +648,10 @@ export function getQuestionsFromFormTypeForMessageBody(
       ),
       optionalDescription: req.t(
         "pages.contactUsQuestions.technicalError.section3.header",
+        { lng: "en" }
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
         { lng: "en" }
       ),
     },


### PR DESCRIPTION
## What?

This populates the service field in the support tickets with the correct value for the "something else" and "technical error" support pages. 

## Why?

After merging the previous branch for the same user story, it was noticed that the requests sent from the "something else" and "technical error" had the value of service field as [undefined].

## Change have been demonstrated

These changes have been verified locally, by checking if the value of the required field changed from [undefined] to the correct value.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1214
