### PR TITLE
Add Dynatrace integration to Dockerfile

### DIFF
--- a/.github/workflows/build-and-push-frontend.yml
+++ b/.github/workflows/build-and-push-frontend.yml
@@ -27,6 +27,12 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+    - name: Login to GDS Dev Dynatrace Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: khw46367.live.dynatrace.com
+        username: khw46367
+        password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
     - name: Build, tag, and push frontend
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ COPY ./@types ./@types
 RUN yarn install && yarn build && yarn clean-modules && yarn install --production=true
 
 FROM node:18.12.1-alpine3.16@sha256:67373bd5d90ea600cb5f0fa58d7a5a4e6ebf50b6e05c50c1d1cc22df5134db43 as final
+
+COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
+ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+
 WORKDIR /app
 COPY --chown=node:node --from=builder /app/package*.json ./
 COPY --chown=node:node --from=builder /app/node_modules/ node_modules


### PR DESCRIPTION
## What?

Adds Dynatrace integration to auth-frontend dockerfile.

## Why?

Instrumenting the nodejs frontend with Dynatrace OneAgent.

## Related PRs

<https://github.com/govuk-one-login/authentication-frontend/pull/1226>
