### PR TITLE
AUT-2048: Improve support form submission error logging

### DIFF
--- a/src/utils/smartAgent.ts
+++ b/src/utils/smartAgent.ts
@@ -39,7 +39,7 @@ export class SmartAgentService {
 
         logger.error(error.toJSON());
         throw new Error(
-          `${error?.response?.status} ${error?.response?.statusText}`
+          `Failed contact form submission to SmartAgent: ${error?.response?.status} ${error?.response?.statusText}. Ticket identifier: ${payload.customAttributes["sa-ticket-id"]}`
         );
       });
   }

--- a/src/utils/zendesk.ts
+++ b/src/utils/zendesk.ts
@@ -31,11 +31,7 @@ export class ZendeskService implements ZendeskInterface {
 
     await instance.post("/tickets.json", form).catch((error) => {
       throw new Error(
-        error.response.status +
-          " " +
-          error.response.statusText +
-          " - ticketIdentifier: " +
-          ticketIdentifier
+        `Failed contact form submission to Zendesk: ${error.response.status} ${error.response.statusText}. TicketIdentifier: ${ticketIdentifier}`
       );
     });
   }


### PR DESCRIPTION
## What?

Extends logging in response to a failed support form submission to include additional information that will support investigation of issues. This includes:

- Which service could not be submitted to (SmartAgent or Zendesk)
- The status code and status text
- The ticket identifier

## Why?

A recent incident revealed the need to make it easier to identify failed contact form submissions in the logs. 
