### PR TITLE
AUT-1884: Enable SmartAgent and Welsh in production Contact Forms

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -10,10 +10,10 @@ frontend_auto_scaling_max_count                                     = 12
 ecs_desired_count                                                   = 4
 support_international_numbers                                       = "1"
 support_account_recovery                                            = "1"
-support_smart_agent                                                 = "0"
+support_smart_agent                                                 = "1"
 support_account_interventions                                       = "0"
 client_name_that_directs_all_contact_form_submissions_to_smartagent = "di-auth-stub-relying-party-production"
-support_welsh_language_in_support_forms                             = "0"
+support_welsh_language_in_support_forms                             = "1"
 url_for_support_links                                               = "https://home.account.gov.uk/contact-gov-uk-one-login"
 
 logging_endpoint_arns = [


### PR DESCRIPTION
## What?

Production environment variable changes to enable SmartAgent and Welsh language.

## Why?

The new Contact Centre expects submissions to SmartAgent (rather than Zendesk) and will support Welsh language. 