### PR TITLE
AUT-1993: Create SUPPORT_2FA_B4_PASSWORD_RESET feature flag

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -172,6 +172,10 @@ locals {
         name  = "FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS"
         value = var.frame_ancestors_form_actions_csp_headers
       },
+      {
+        name  = "SUPPORT_2FA_B4_PASSWORD_RESET"
+        value = var.support_2fa_b4_password_reset
+      }
     ]
 
     secrets = [

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -264,3 +264,9 @@ variable "frame_ancestors_form_actions_csp_headers" {
 
 variable "dynatrace_secret_arn" {
 }
+
+variable "support_2fa_b4_password_reset" {
+  description = "When true enables 2FA before password reset"
+  type        = string
+  default     = "0"
+}

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -7,6 +7,7 @@ import { SinonStub } from "sinon";
 import { API_ENDPOINTS } from "../../../app.constants";
 import { AuthCodeServiceInterface } from "../types";
 import { Http } from "../../../utils/http";
+import { support2FABeforePasswordReset } from "../../../config";
 
 describe("authentication auth code service", () => {
   const redirectUriSentToAuth = "/redirect-uri";
@@ -119,6 +120,26 @@ describe("authentication auth code service", () => {
       ).to.be.true;
       expect(postStub.notCalled).to.be.true;
       expect(result.data.location).to.deep.eq(redirectUriReturnedFromResponse);
+    });
+  });
+
+  describe("support2FABeforePasswordReset() with the support 2FA before password reset feature flag on", () => {
+    it("should return true when SUPPORT_2FA_B4_PASSWORD_RESET is set to '1'", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
+      expect(support2FABeforePasswordReset()).to.be.true;
+    });
+
+    it("should return false  when SUPPORT_2FA_B4_PASSWORD_RESET is set to '0'", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
+
+      expect(support2FABeforePasswordReset()).to.be.false;
+    });
+
+    it("should return false when SUPPORT_2FA_B4_PASSWORD_RESET is undefined", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = undefined;
+
+      expect(support2FABeforePasswordReset()).to.be.false;
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -195,3 +195,7 @@ export function getPasswordResetCodeEnteredWrongBlockDurationInMinutes(): number
 export function supportFrameAncestorsFormActionsCspHeaders(): boolean {
   return process.env.FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS === "1";
 }
+
+export function support2FABeforePasswordReset(): boolean {
+  return process.env.SUPPORT_2FA_B4_PASSWORD_RESET === "1";
+}


### PR DESCRIPTION
## What?

- [x] Add config method to `config.ts` and associated unit tests
- [x] Default the variable to "0" in `variables.tf`
- [x] Set the environment variable in ECS task config `ecs.tf`

## Why?

Please include reason for the change and any other relevant context.