### PR TITLE
AddingAuthdev1 and  Authdev2 Env

### DIFF
--- a/ci/terraform/authdev1.hcl
+++ b/ci/terraform/authdev1.hcl
@@ -1,0 +1,4 @@
+bucket  = "di-auth-development-tfstate"
+key     = "frontend-authdev1-terraform.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -1,0 +1,35 @@
+environment                   = "authdev1"
+common_state_bucket           = "di-auth-development-tfstate"
+aws_region                    = "eu-west-2"
+account_management_fqdn       = "acc-mgmt-fg.authdev1.sandpit.auth.ida.digital.cabinet-office.gov.uk"
+oidc_api_fqdn                 = "oidc.authdev1.sandpit.account.gov.uk"
+frontend_fqdn                 = "signin.authdev1.sandpit.account.gov.uk"
+frontend_api_fqdn             = "auth.authdev1.sandpit.account.gov.uk"
+service_domain                = "authdev1.sandpit.account.gov.uk"
+zone_id                       = "Z062000928I8D7S9X1OVA"
+session_expiry                = 300000
+gtm_id                        = ""
+support_language_cy           = "1"
+support_account_recovery      = "1"
+support_auth_orch_split       = "1"
+support_international_numbers = "1"
+
+frontend_task_definition_cpu     = 256
+frontend_task_definition_memory  = 512
+frontend_auto_scaling_v2_enabled = true
+
+support_smart_agent                     = "1"
+support_welsh_language_in_support_forms = "1"
+url_for_support_links                   = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+
+orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"
+orch_to_auth_client_id          = "orchestrationAuth"
+orch_to_auth_audience           = "https://signin.authdev1.sandpit.account.gov.uk/"
+
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2"
+]
+
+frame_ancestors_form_actions_csp_headers = "1"
+
+dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"

--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -26,9 +26,6 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.authdev1.sandpit.account.gov.uk/"
 
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2"
-]
 
 frame_ancestors_form_actions_csp_headers = "1"
 

--- a/ci/terraform/authdev2.hcl
+++ b/ci/terraform/authdev2.hcl
@@ -1,0 +1,4 @@
+bucket  = "di-auth-development-tfstate"
+key     = "frontend-authdev2-terraform.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -26,9 +26,6 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.authdev2.sandpit.account.gov.uk/"
 
-logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2"
-]
 
 frame_ancestors_form_actions_csp_headers = "1"
 

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -1,0 +1,35 @@
+environment                   = "authdev2"
+common_state_bucket           = "di-auth-development-tfstate"
+aws_region                    = "eu-west-2"
+account_management_fqdn       = "acc-mgmt-fg.authdev2.sandpit.auth.ida.digital.cabinet-office.gov.uk"
+oidc_api_fqdn                 = "oidc.authdev2.sandpit.account.gov.uk"
+frontend_fqdn                 = "signin.authdev2.sandpit.account.gov.uk"
+frontend_api_fqdn             = "auth.authdev2.sandpit.account.gov.uk"
+service_domain                = "authdev2.sandpit.account.gov.uk"
+zone_id                       = "Z062000928I8D7S9X1OVA"
+session_expiry                = 300000
+gtm_id                        = ""
+support_language_cy           = "1"
+support_account_recovery      = "1"
+support_auth_orch_split       = "1"
+support_international_numbers = "1"
+
+frontend_task_definition_cpu     = 256
+frontend_task_definition_memory  = 512
+frontend_auto_scaling_v2_enabled = true
+
+support_smart_agent                     = "1"
+support_welsh_language_in_support_forms = "1"
+url_for_support_links                   = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+
+orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"
+orch_to_auth_client_id          = "orchestrationAuth"
+orch_to_auth_audience           = "https://signin.authdev2.sandpit.account.gov.uk/"
+
+logging_endpoint_arns = [
+  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2"
+]
+
+frame_ancestors_form_actions_csp_headers = "1"
+
+dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"

--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -1,16 +1,16 @@
 #Otheenv are Dev,build,Integration & Staging 
 
 locals {
-  prod        = var.environment == "production" ? "account.gov.uk" : ""
-  sandpitdevs = var.environment == "authdev1" || var.environment == "authdev2" ? "${var.environment}.sandpit.account.gov.uk" : ""
-  otherenv    = var.environment != "production" && var.environment != "authdev1" && var.environment != "authdev2" ? "${var.environment}.account.gov.uk" : ""
+  prod           = var.environment == "production" ? "account.gov.uk" : ""
+  sandpitdevs    = var.environment == "authdev1" || var.environment == "authdev2" ? "${var.environment}.sandpit.account.gov.uk" : ""
+  otherenv       = var.environment != "production" && var.environment != "authdev1" && var.environment != "authdev2" ? "${var.environment}.account.gov.uk" : ""
   service_domain = coalesce(local.prod, local.sandpitdevs, local.otherenv)
 
   account_management_fqdn = var.environment == "production" ? "home.account.gov.uk" : "home.${var.environment}.account.gov.uk"
-  
-  frontend_fqdn           = "signin.${local.service_domain}"
-  frontend_api_fqdn       = "auth.${local.service_domain}"
-  oidc_api_fqdn           = "oidc.${local.service_domain}"
+
+  frontend_fqdn     = "signin.${local.service_domain}"
+  frontend_api_fqdn = "auth.${local.service_domain}"
+  oidc_api_fqdn     = "oidc.${local.service_domain}"
 }
 
 data "aws_route53_zone" "service_domain" {

--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -1,6 +1,13 @@
+#Otheenv are Dev,build,Integration & Staging 
+
 locals {
-  service_domain          = var.environment == "production" ? "account.gov.uk" : "${var.environment}.account.gov.uk"
+  prod        = var.environment == "production" ? "account.gov.uk" : ""
+  sandpitdevs = var.environment == "authdev1" || var.environment == "authdev2" ? "${var.environment}.sandpit.account.gov.uk" : ""
+  otherenv    = var.environment != "production" && var.environment != "authdev1" && var.environment != "authdev2" ? "${var.environment}.account.gov.uk" : ""
+  service_domain = coalesce(local.prod, local.sandpitdevs, local.otherenv)
+
   account_management_fqdn = var.environment == "production" ? "home.account.gov.uk" : "home.${var.environment}.account.gov.uk"
+  
   frontend_fqdn           = "signin.${local.service_domain}"
   frontend_api_fqdn       = "auth.${local.service_domain}"
   oidc_api_fqdn           = "oidc.${local.service_domain}"

--- a/deploy-authdevs.sh
+++ b/deploy-authdevs.sh
@@ -21,8 +21,8 @@ for (( i = 0; i < ${#envvalue[@]}; ++i )); do
     if (( i == user_in )); then
         printf 'You picked "%s"\n' "${envvalue[$i]}"
         export env=${envvalue[$i]}
-        printf "deploying in enviorment $env\n"
-        read -p "Press enter to continue or ctr c to abort"
+        printf "deploying in enviorment %s\n" "$env"
+        read -r -p "Press enter to continue or ctr c to abort"
     fi
 done
 
@@ -104,8 +104,8 @@ if [[ $TERRAFORM == "1" ]]; then
   echo "Running Terraform..."
   pushd "${DIR}/ci/terraform" >/dev/null
   rm -rf .terraform/
-  terraform init -backend-config=$env.hcl
-  terraform apply ${TERRAFORM_OPTS} -var-file $env.tfvars -var "image_uri=${REPO_URL}" -var "image_digest=${IMAGE_DIGEST}"
+  terraform init -backend-config="$env".hcl
+  terraform apply ${TERRAFORM_OPTS} -var-file "$env".tfvars -var "image_uri=${REPO_URL}" -var "image_digest=${IMAGE_DIGEST}"
 
   if [[ $TERRAFORM_OPTS != "-destroy" ]]; then
     echo -n "Waiting for ECS deployment to complete ... "

--- a/deploy-authdevs.sh
+++ b/deploy-authdevs.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -eu
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_NAME="frontend-image-repository"
+REPO_URL="706615647326.dkr.ecr.eu-west-2.amazonaws.com/frontend-image-repository"
+IMAGE_TAG=latest
+
+envvalue=( "authdev1" "authdev2"  )
+
+select word in "${envvalue[@]}"; do
+    if [[ -z "$word" ]]; then
+        printf '"%s" is not a valid choice\n' "$REPLY" >&2
+    else
+        user_in="$(( REPLY - 1 ))"
+        break
+    fi
+done
+
+for (( i = 0; i < ${#envvalue[@]}; ++i )); do
+    if (( i == user_in )); then
+        printf 'You picked "%s"\n' "${envvalue[$i]}"
+        export env=${envvalue[$i]}
+        printf "deploying in enviorment $env\n"
+        read -p "Press enter to continue or ctr c to abort"
+    fi
+done
+
+
+function usage() {
+  cat <<USAGE
+  A script to deploy the GOV.UK Sign in APIs to the $env environment.
+  Requires a GDS CLI, AWS CLI and jq installed and configured.
+
+  Usage:
+    $0 [-b|--build] [-t|--terraform] [--destroy] [-p|--prompt]
+
+  Options:
+    -b, --build               run docker build and push new version (default)
+    -t, --terraform           run terraform to deploy changes (default)
+    --destroy                 run terraform with the -destroy flag (destroys all managed resources)
+    -p, --prompt              will prompt for plan review before applying any terraform
+
+    If no options specified the default actions above will be carried out without prompting.
+USAGE
+}
+
+BUILD=0
+TERRAFORM=0
+TERRAFORM_OPTS="-auto-approve"
+if [[ $# == 0 ]]; then
+  BUILD=1
+  TERRAFORM=1
+fi
+while [[ $# -gt 0 ]]; do
+  case $1 in
+  -b | --build)
+    BUILD=1
+    ;;
+  -t | --terraform)
+    # shellcheck disable=SC2034
+    TERRAFORM=1
+    ;;
+  --destroy)
+    TERRAFORM_OPTS="-destroy"
+    ;;
+  -p | --prompt)
+    TERRAFORM_OPTS=""
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+echo "Generating temporary ECR credentials..."
+#Add you Tools DEV account Profile if diffrent name in below command 
+aws ecr get-login-password --region eu-west-2 --profile di-tools-dev | docker login --username AWS --password-stdin "${REPO_URL}"
+
+if [[ $BUILD == "1" ]]; then
+  echo "Building image..."
+  docker buildx build --platform=linux/amd64 -t "${REPO_NAME}" .
+  echo "Tagging image..."
+  docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
+
+  echo "Pushing image..."
+  docker push "${REPO_URL}:${IMAGE_TAG}"
+  IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
+  echo "Digest = ${IMAGE_DIGEST}"
+  echo "Complete"
+else
+  docker pull "${REPO_URL}:${IMAGE_TAG}"
+  IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
+fi
+
+if [[ $TERRAFORM == "1" ]]; then
+  echo -n "Getting AWS credentials ... "
+  ###Export The di-Auth-devlopment account profile below 
+  export AWS_PROFILE=di-auth-dev
+  echo "done!"
+
+  echo "Running Terraform..."
+  pushd "${DIR}/ci/terraform" >/dev/null
+  rm -rf .terraform/
+  terraform init -backend-config=$env.hcl
+  terraform apply ${TERRAFORM_OPTS} -var-file $env.tfvars -var "image_uri=${REPO_URL}" -var "image_digest=${IMAGE_DIGEST}"
+
+  if [[ $TERRAFORM_OPTS != "-destroy" ]]; then
+    echo -n "Waiting for ECS deployment to complete ... "
+    aws ecs wait services-stable --services "$env-frontend-ecs-service" --cluster "$env-app-cluster"
+    echo "done!"
+  fi
+
+fi
+
+echo "Deployment complete!"
+popd >/dev/null


### PR DESCRIPTION
## What?
 Adding Authdev1 and  Authdev2 env  based on sandpit Env for locally deployment in new development aws account 

(https://github.com/govuk-one-login/authentication-api/pull/3638)

## Why?

Please include reason for the change and any other relevant context.

## Change have been demonstrated

