### PR TITLE
AUT-1862: Created Page and Route for Temporary Suspended Page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -69,6 +69,7 @@ export const PATH_NAMES = {
   CHANGE_SECURITY_CODES_CONFIRMATION: "/change-codes-confirmed",
   PASSWORD_RESET_REQUIRED: "/password-reset-required",
   UNAVAILABLE_PERMANENT: "/unavailable-permanent",
+  UNAVAILABLE_TEMPORARY: "/unavailable-temporary",
 };
 
 export const HREF_BACK = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,6 +86,7 @@ import { changeSecurityCodesConfirmationRouter } from "./components/account-reco
 import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-us-links-middleware";
 import { accountInterventionRouter } from "./components/account-intervention/password-reset-required/password-reset-required-router";
 import { permanentlyBlockedRouter } from "./components/account-intervention/permanently-blocked/permanently-blocked-router";
+import { temporarilyBlockedRouter } from "./components/account-intervention/temporarily-blocked/temporarily-blocked-router";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -138,6 +139,7 @@ function registerRoutes(app: express.Application) {
   if (supportAccountInterventions()) {
     app.use(accountInterventionRouter);
     app.use(permanentlyBlockedRouter);
+    app.use(temporarilyBlockedRouter);
   }
 }
 

--- a/src/components/account-intervention/temporarily-blocked/index.njk
+++ b/src/components/account-intervention/temporarily-blocked/index.njk
@@ -1,0 +1,18 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block content %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.suspendedPageScreen.heading' | translate }}</h1>
+
+    <p class="govuk-body">{{'pages.suspendedPageScreen.section1.paragraph1' | translate }}</p>
+
+    <h3 class="govuk-heading-m">
+      {{'pages.suspendedPageScreen.section2.heading' | translate}}
+    </h3>
+
+    <p class="govuk-body">{{'pages.suspendedPageScreen.section2.paragraph1' | translate }}</p>
+
+    <p class="govuk-body">{{'pages.suspendedPageScreen.section2.paragraph2' | translate }}</p>
+
+{% endblock %}

--- a/src/components/account-intervention/temporarily-blocked/temporarily-blocked-controller.ts
+++ b/src/components/account-intervention/temporarily-blocked/temporarily-blocked-controller.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from "express";
+
+export function temporarilyBlockedGet(req: Request, res: Response): void {
+  res.render("account-intervention/temporarily-blocked/index.njk");
+}

--- a/src/components/account-intervention/temporarily-blocked/temporarily-blocked-router.ts
+++ b/src/components/account-intervention/temporarily-blocked/temporarily-blocked-router.ts
@@ -1,0 +1,14 @@
+import { PATH_NAMES } from "../../../app.constants";
+import * as express from "express";
+import { validateSessionMiddleware } from "../../../middleware/session-middleware";
+import { temporarilyBlockedGet } from "./temporarily-blocked-controller";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.UNAVAILABLE_TEMPORARY,
+  validateSessionMiddleware,
+  temporarilyBlockedGet
+);
+
+export { router as temporarilyBlockedRouter };

--- a/src/components/account-intervention/temporarily-blocked/tests/temporarily-blocked-controller.test.ts
+++ b/src/components/account-intervention/temporarily-blocked/tests/temporarily-blocked-controller.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../../test/utils/test-utils";
+
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { temporarilyBlockedGet } from "../temporarily-blocked-controller";
+import { PATH_NAMES } from "../../../../app.constants";
+
+describe("temporarily blocked controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.UNAVAILABLE_TEMPORARY,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("temporarilyBlockedGet", () => {
+    it("should render the temporarily blocked view", () => {
+      temporarilyBlockedGet(req, res);
+
+      expect(res.render).to.have.calledWith(
+        "account-intervention/temporarily-blocked/index.njk"
+      );
+    });
+  });
+});

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2211,6 +2211,17 @@
         "paragraph1": "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK.",
         "paragraph2": "Gallwch greu GOV.UK One Login newydd gyda chyfeiriad e-bost gwahanol."
       }
+    },
+    "suspendedPageScreen": {
+      "heading": "Mae’n ddrwg gennym, mae problem",
+      "section1": {
+        "paragraph1": "Nid yw eich GOV.UK One Login ar gael ar hyn o bryd."
+      },
+      "section2": {
+        "heading": "Beth allwch chi ei wneud",
+        "paragraph1": "Dewch yn ôl yn nes ymlaen. Dylai eich GOV.UK One Login fod ar gael eto mewn [3 diwrnod gwaith].",
+        "paragraph2": "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK."
+      }
     }
   },
   "abTestPages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2211,6 +2211,17 @@
         "paragraph1": "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK  homepage.",
         "paragraph2": "You can create a new GOV.UK  One Login with a different email address."
       }
+    },
+    "suspendedPageScreen": {
+      "heading": "Sorry, there is a problem",
+      "section1": {
+        "paragraph1": "Your GOV.UK  One Login is not available at the moment."
+      },
+      "section2": {
+        "heading": "What you can do",
+        "paragraph1": "Come back later. Your GOV.UK  One Login should be available again in [3 working days].",
+        "paragraph2": "You can also go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage."
+      }
     }
   },
   "abTestPages": {


### PR DESCRIPTION
## What?

Added template, route, unit test and translations for the Temporary Suspended page.

## Why?

The changes are necessary to be implemented as part of the account interventions user journey.

## Change have been demonstrated

- [x] Changes to the user interface have been demonstrated

| English Translation | Welsh Translation | 
| --------------- | --------------- | 
| <img width="1440" alt="English Translation" src="https://github.com/govuk-one-login/authentication-frontend/assets/65968889/73a619b6-be6d-4304-a05f-fafe3bb6fe67">  | <img width="1440" alt="welsh-temporary-blocked-screenshot" src="https://github.com/govuk-one-login/authentication-frontend/assets/65968889/4c910c1a-839b-4402-b016-ff2262fc0975">  |

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change
