### PR TITLE
ATO-224: Return to orchestration on ID journeys

### DIFF
--- a/src/components/prove-identity/prove-identity-controller.ts
+++ b/src/components/prove-identity/prove-identity-controller.ts
@@ -5,11 +5,36 @@ import { proveIdentityService } from "./prove-identity-service";
 import { ProveIdentityServiceInterface } from "./types";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { supportAuthOrchSplit } from "../../config";
+import { authCodeGet } from "../auth-code/auth-code-controller";
+import { AuthCodeServiceInterface } from "../auth-code/types";
+import { authCodeService } from "../auth-code/auth-code-service";
 
 export function proveIdentityGet(
-  service: ProveIdentityServiceInterface = proveIdentityService()
+  service: ProveIdentityServiceInterface = proveIdentityService(),
+  authCode: AuthCodeServiceInterface = authCodeService()
 ): ExpressRouteFunc {
+  const returnToOrchestration = async (
+    req: Request,
+    res: Response
+  ): Promise<void> => {
+    const { sessionId } = res.locals;
+    getNextPathAndUpdateJourney(
+      req,
+      req.path,
+      USER_JOURNEY_EVENTS.PROVE_IDENTITY_INIT,
+      null,
+      sessionId
+    );
+
+    return authCodeGet(authCode)(req, res);
+  };
+
   return async function (req: Request, res: Response) {
+    if (supportAuthOrchSplit()) {
+      return returnToOrchestration(req, res);
+    }
+
     const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const result = await service.ipvAuthorize(

--- a/src/components/prove-identity/tests/prove-identity-controller.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-controller.test.ts
@@ -12,7 +12,13 @@ import {
   RequestOutput,
   ResponseOutput,
 } from "mock-req-res";
-import { PATH_NAMES } from "../../../app.constants";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
+import { SinonStub } from "sinon";
+import { AuthCodeServiceInterface } from "../../auth-code/types";
+import { Http } from "../../../utils/http";
+import { authCodeService } from "../../auth-code/auth-code-service";
+import { ExpressRouteFunc } from "../../../types";
+import { proveIdentityService } from "../prove-identity-service";
 
 describe("prove identity controller", () => {
   let req: RequestOutput;
@@ -68,6 +74,84 @@ describe("prove identity controller", () => {
       await expect(
         proveIdentityGet(fakeService)(req as Request, res as Response)
       ).to.be.rejectedWith("1222:Error occurred");
+    });
+  });
+
+  describe("with auth orch split feature flag on", () => {
+    const redirectUriSentToAuth = "/redirect-uri";
+    const rpSectorHostSentToAuth = "https://rp.redirect.uri";
+    const isAccountCreationJourneyUserSession = true;
+    const redirectUriReturnedFromResponse =
+      "/redirect-here?with-some-params=added-by-the-endpoint";
+    const frontendBaseUrl = "/frontend-base-url";
+
+    const axiosResponse = Promise.resolve({
+      data: {
+        location: redirectUriReturnedFromResponse,
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {},
+    });
+    let postStub: SinonStub;
+    let service: AuthCodeServiceInterface;
+    let controller: ExpressRouteFunc;
+
+    beforeEach(() => {
+      process.env.API_KEY = "api-key";
+      process.env.FRONTEND_API_BASE_URL = frontendBaseUrl;
+      const httpInstance = new Http();
+      service = authCodeService(httpInstance);
+      controller = proveIdentityGet(proveIdentityService(), service);
+      postStub = sinon.stub(httpInstance.client, "post");
+      postStub.resolves(axiosResponse);
+      res.locals.sessionId = "s-123456-djjad";
+      res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
+    });
+
+    afterEach(() => {
+      postStub.reset();
+    });
+
+    it("it should make a post request to the orch auth endpoint with claim, state and redirect uri in the body", async () => {
+      process.env.SUPPORT_AUTH_ORCH_SPLIT = "1";
+
+      const claim = ["phone_number", "phone_number_verified"];
+      const state = "state";
+      req.session.client = {
+        claim: claim,
+        state: state,
+        redirectUri: redirectUriSentToAuth,
+        rpSectorHost: rpSectorHostSentToAuth,
+      };
+
+      req.session.user = {
+        isAccountCreationJourney: isAccountCreationJourneyUserSession,
+      };
+
+      await controller(req as Request, res as Response);
+
+      const expectedBody = {
+        claims: claim,
+        state: state,
+        "redirect-uri": redirectUriSentToAuth,
+        "rp-sector-uri": rpSectorHostSentToAuth,
+        "is-new-account": isAccountCreationJourneyUserSession,
+      };
+
+      expect(
+        postStub.calledOnceWithExactly(
+          API_ENDPOINTS.ORCH_AUTH_CODE,
+          expectedBody,
+          {
+            headers: sinon.match.object,
+            proxy: sinon.match.bool,
+            baseURL: frontendBaseUrl,
+          }
+        )
+      ).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## What?

Invoke the auth code logic in provide identity when the auth-orch split is enabled

## Why?

When the auth orch split is enabled, we should return to orchestration rather than redirecting to IPV.
