### PR TITLE
AUT-2029: turn on frame ancestors feature switch on in integration

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -18,4 +18,5 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+dynatrace_secret_arn                     = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+frame_ancestors_form_actions_csp_headers = "1"


### PR DESCRIPTION
## What?

 Turn on frame ancestors feature switch on in integration.

## Why?

Before adding the Frame Ancestors Content Security Policy to production, we should first add them to integration, in order to make sure the security headers don't break any other implementations. 
