### PR TITLE
AUT-1995: Set up Password Reset ‘Check your phone’ flow

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -20,6 +20,7 @@ export const PATH_NAMES = {
   ENTER_PASSWORD_ACCOUNT_EXISTS: "/enter-password-account-exists",
   RESET_PASSWORD_CHECK_EMAIL: "/reset-password-check-email",
   RESET_PASSWORD: "/reset-password",
+  RESET_PASSWORD_2FA_SMS: "/reset-password-2fa-sms",
   RESET_PASSWORD_REQUIRED: "/reset-password-required",
   RESET_PASSWORD_REQUEST: "/reset-password-request",
   RESET_PASSWORD_RESEND_CODE: "/reset-password-resend-code",
@@ -212,6 +213,7 @@ export enum JOURNEY_TYPE {
   REGISTRATION = "REGISTRATION",
   ACCOUNT_RECOVERY = "ACCOUNT_RECOVERY",
   SIGN_IN = "SIGN_IN",
+  PASSWORD_RESET_MFA = "PASSWORD_RESET_MFA",
 }
 
 export const ENVIRONMENT_NAME = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import {
   getRedisPort,
   getSessionExpiry,
   getSessionSecret,
+  support2FABeforePasswordReset,
   supportAccountInterventions,
   supportAccountRecovery,
   supportAuthorizeController,
@@ -61,6 +62,7 @@ import { accountNotFoundRouter } from "./components/account-not-found/account-no
 import { resetPasswordCheckEmailRouter } from "./components/reset-password-check-email/reset-password-check-email-routes";
 import { setLocalVarsMiddleware } from "./middleware/set-local-vars-middleware";
 import { resetPasswordRouter } from "./components/reset-password/reset-password-routes";
+import { resetPassword2FARouter } from "./components/reset-password-2fa-sms/reset-password-2fa-sms-routes";
 import { noCacheMiddleware } from "./middleware/no-cache-middleware";
 import { checkYourEmailRouter } from "./components/check-your-email/check-your-email-routes";
 import { securityCodeErrorRouter } from "./components/security-code-error/security-code-error-routes";
@@ -126,6 +128,9 @@ function registerRoutes(app: express.Application) {
   app.use(shareInfoRouter);
   app.use(updatedTermsConditionsRouter);
   app.use(resetPasswordRouter);
+  if (support2FABeforePasswordReset()) {
+    app.use(resetPassword2FARouter);
+  }
   app.use(upliftJourneyRouter);
   app.use(contactUsRouter);
   app.use(healthcheckRouter);

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -9,6 +9,7 @@ import { VerifyCodeInterface } from "./types";
 import { ExpressRouteFunc } from "../../../types";
 import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine";
 import { NOTIFICATION_TYPE } from "../../../app.constants";
+import { support2FABeforePasswordReset } from "../../../config";
 
 interface Config {
   notificationType: NOTIFICATION_TYPE;
@@ -16,6 +17,7 @@ interface Config {
   validationKey: string;
   validationErrorCode: number;
   callback?: (req: Request, res: Response) => void;
+  journeyType?: string;
 }
 
 export function verifyCodePost(
@@ -32,7 +34,8 @@ export function verifyCodePost(
       options.notificationType,
       clientSessionId,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      options.journeyType
     );
 
     if (!result.success) {
@@ -87,6 +90,7 @@ export function verifyCodePost(
           isConsentRequired: req.session.user.isConsentRequired,
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
+          support2FABeforePasswordReset: support2FABeforePasswordReset(),
         },
         res.locals.sessionId
       )

--- a/src/components/reset-password-2fa-sms/index.njk
+++ b/src/components/reset-password-2fa-sms/index.njk
@@ -1,0 +1,79 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% set pageTitleName = 'pages.checkYourPhone.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate %}
+
+{% block content %}
+
+    {% include "common/errors/errorSummary.njk" %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate }}</h1>
+
+    {% set insetText %}
+        {{ 'pages.checkYourPhone.info.paragraph1' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber }}</span>
+    {% endset %}
+
+    {{ govukInsetText({
+        text: insetText | safe
+    }) }}
+
+    <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph2' | translate }}</p>
+
+    <form action="/reset-password-2fa-sms" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+
+        {{ govukInput({
+            label: {
+                text: 'pages.checkYourPhone.code.label' | translate
+            },
+            classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+            id: "code",
+            name: "code",
+            inputmode: "numeric",
+            spellcheck: false,
+            autocomplete:"one-time-code",
+            errorMessage: {
+                text: errors['code'].text
+            } if (errors['code'])})
+        }}
+
+        {% set detailsHTML %}
+            <p class="govuk-body">
+                {{'pages.checkYourPhone.details.text1' | translate}}
+                <a href="{{resendCodeLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.sendCodeLinkText'| translate}}</a>
+                {{'pages.checkYourPhone.details.text 2' | translate}}
+                <a href="{{'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changePhoneNumberLinkText'| translate}}</a>.
+            </p>
+        {% endset %}
+
+        {% set detailsHTML %}
+
+            {{detailsHTML | safe}}
+
+            <p class="govuk-body">
+                <a href="{{'pages.checkYourPhone.details.changeMfaChoiceLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changeMfaChoiceLinkText'| translate}}</a>.
+            </p>
+
+        {% endset %}
+
+        {{ govukButton({
+            "text": "general.continue.label" | translate,
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
+
+        {{ govukDetails({
+            summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
+            html: detailsHTML
+        }) }}
+
+    </form>
+
+{% endblock %}

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "src/types";
+import xss from "xss";
+import { MfaServiceInterface } from "../common/mfa/types";
+import { mfaService } from "../common/mfa/mfa-service";
+import { ERROR_CODES, getErrorPathByCode } from "../common/constants";
+import { BadRequestError } from "../../utils/error";
+import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
+import { verifyCodePost } from "../common/verify-code/verify-code-controller";
+import { VerifyCodeInterface } from "../common/verify-code/types";
+import { codeService } from "../common/verify-code/verify-code-service";
+
+const TEMPLATE_NAME = "reset-password-2fa-sms/index.njk";
+export function resetPassword2FASmsGet(
+  mfaCodeService: MfaServiceInterface = mfaService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { email } = req.session.user;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const mfaResponse = await mfaCodeService.sendMfaCode(
+      sessionId,
+      clientSessionId,
+      email,
+      req.ip,
+      persistentSessionId,
+      false,
+      xss(req.cookies.lng as string),
+      JOURNEY_TYPE.PASSWORD_RESET_MFA
+    );
+
+    if (!mfaResponse.success) {
+      const path = getErrorPathByCode(mfaResponse.data.code);
+      if (path) {
+        return res.redirect(path);
+      }
+      throw new BadRequestError(
+        mfaResponse.data.message,
+        mfaResponse.data.code
+      );
+    }
+    res.render(TEMPLATE_NAME, {});
+  };
+}
+export function resetPassword2FASmsPost(
+  service: VerifyCodeInterface = codeService()
+): ExpressRouteFunc {
+  return verifyCodePost(service, {
+    notificationType: NOTIFICATION_TYPE.MFA_SMS,
+    template: TEMPLATE_NAME,
+    validationKey: "pages.passwordResetMfaSms.code.validationError.invalidCode",
+    validationErrorCode: ERROR_CODES.INVALID_MFA_CODE,
+    journeyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
+  });
+}

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-routes.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-routes.ts
@@ -1,0 +1,27 @@
+import { PATH_NAMES } from "../../app.constants";
+import {
+  resetPassword2FASmsGet,
+  resetPassword2FASmsPost,
+} from "./reset-password-2fa-sms-controller";
+import * as express from "express";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { asyncHandler } from "../../utils/async";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RESET_PASSWORD_2FA_SMS,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resetPassword2FASmsGet())
+);
+
+router.post(
+  PATH_NAMES.RESET_PASSWORD_2FA_SMS,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resetPassword2FASmsPost())
+);
+
+export { router as resetPassword2FARouter };

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import * as cheerio from "cheerio";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import decache from "decache";
+import nock = require("nock");
+
+describe("Integration::2fa sms (in reset password flow)", () => {
+  let app: any;
+  let baseApi: string;
+  let token: string | string[];
+  let cookies: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+          journey: {
+            nextPath: PATH_NAMES.RESET_PASSWORD_2FA_SMS,
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    nock(baseApi).persist().post("/mfa").reply(204);
+
+    request(app)
+      .get(PATH_NAMES.RESET_PASSWORD_2FA_SMS)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return check your phone page", (done) => {
+    nock(baseApi).persist().post("/mfa").reply(204);
+    request(app).get("/reset-password-2fa-sms").expect(200, done);
+  });
+
+  it("should redirect to reset password step when valid sms code is entered", (done) => {
+    nock(baseApi)
+      .persist()
+      .post(API_ENDPOINTS.VERIFY_CODE)
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    request(app)
+      .post(PATH_NAMES.RESET_PASSWORD_2FA_SMS)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_NAMES.RESET_PASSWORD)
+      .expect(302, done);
+  });
+});

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -33,6 +33,7 @@ describe("reset password check email controller", () => {
     });
     res = mockResponse();
     res.locals.sessionId = "s-123456-djjad";
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
   });
 
   afterEach(() => {
@@ -80,6 +81,26 @@ describe("reset password check email controller", () => {
       );
 
       expect(res.redirect).to.have.calledWith("/reset-password");
+    });
+
+    it("should redirect to check_phone if code entered is correct and feature flag is turned on", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const fakeService: VerifyCodeInterface = {
+        verifyCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as VerifyCodeInterface;
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.body.code = "123456";
+      req.session.id = "123456-djjad";
+      await resetPasswordCheckEmailPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith("/reset-password-2fa-sms");
     });
 
     it("should render check email page with errors if incorrect code entered", async () => {

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -19,6 +19,7 @@ import { MfaServiceInterface } from "../common/mfa/types";
 import { mfaService } from "../common/mfa/mfa-service";
 import { MFA_METHOD_TYPE } from "../../app.constants";
 import xss from "xss";
+import { support2FABeforePasswordReset } from "../../config";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -107,6 +108,7 @@ export function resetPasswordPost(
     }
 
     if (
+      !support2FABeforePasswordReset() &&
       loginResponse.data.mfaMethodVerified &&
       loginResponse.data.mfaMethodType === MFA_METHOD_TYPE.SMS
     ) {
@@ -144,6 +146,7 @@ export function resetPasswordPost(
             req.session.user.isLatestTermsAndConditionsAccepted,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
+          support2FABeforePasswordReset: support2FABeforePasswordReset(),
         },
         res.locals.sessionId
       )

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -6,7 +6,7 @@ import * as cheerio from "cheerio";
 import { PATH_NAMES } from "../../../app.constants";
 import decache from "decache";
 
-describe("Integration::reset password (in 6 digit code flow)", () => {
+describe("Integration::reset password (in 2FA Before Reset Password flow)", () => {
   let token: string | string[];
   let cookies: string;
   let app: any;
@@ -15,7 +15,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
   const ENDPOINT = "/reset-password";
 
   before(async () => {
-    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -204,7 +204,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(400, done);
   });
 
-  it("should redirect to MFA step when valid password entered", (done) => {
+  it("should redirect to /auth-code when valid password entered", (done) => {
     nock(baseApi).post("/reset-password").once().reply(204);
     nock(baseApi).post("/login").once().reply(200);
     nock(baseApi).post("/mfa").once().reply(204);
@@ -218,7 +218,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
         password: "Testpassword1",
         "confirm-password": "Testpassword1",
       })
-      .expect("Location", PATH_NAMES.ENTER_MFA)
+      .expect("Location", PATH_NAMES.AUTH_CODE)
       .expect(302, done);
   });
 });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -514,6 +514,45 @@
         "sendTheCodeAgain": "Anfon y cod eto"
       }
     },
+    "passwordResetMfaSms": {
+      "title": "Gwiriwch eich ffôn",
+      "header": "Gwiriwch eich ffôn",
+      "info": {
+        "paragraph1": "Rydym wedi anfon cod i’ch rhif ffôn sy’n gorffen gyda ",
+        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
+      },
+      "resend": {
+        "link": "Gofynnwch am god newydd",
+        "paragraph1": "os nad yw’r cod yn gweithio neu mae wedi dod i ben, neu ni dderbynioch un."
+      },
+      "code": {
+        "label": "Rhowch y cod diogelwch 6 digid",
+        "validationError": {
+          "required": "Rhowch y cod diogelwch",
+          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
+          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
+          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
+          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+        }
+      },
+      "details": {
+        "summaryText": "Problemau gyda’r cod?",
+        "text1": "Gallwn ",
+        "sendCodeLinkText": "anfon y cod eto",
+        "sendCodeLinkHref": "/resend-code",
+        "text 2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn.",
+        "changeGetSecurityCodesText": "Os na allwch gyrchu’r rhif ffôn ar gyfer eich GOV.UK One Login, gallwch ",
+        "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch"
+      },
+      "upliftRequired": {
+        "title": "Mae angen i chi roi cod diogelwch",
+        "header": "Mae angen i chi roi cod diogelwch",
+        "paragraph1": "Mae hwn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
+        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
+        "paragraph3": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login.",
+        "sendTheCodeAgain": "Anfon y cod eto"
+      }
+    },
     "resendMfaCode": {
       "title": "Cael cod diogelwch",
       "header": "Cael cod diogelwch",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -514,6 +514,45 @@
         "sendTheCodeAgain": "Send the code again"
       }
     },
+    "passwordResetMfaSms": {
+      "title": "Check your phone",
+      "header": "Check your phone",
+      "info": {
+        "paragraph1": "We have sent a code to your phone number ending with ",
+        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
+      },
+      "resend": {
+        "link": "Request a new code",
+        "paragraph1": "if the code does not work or has expired, or you did not receive one."
+      },
+      "code": {
+        "label": "Enter the 6 digit security code",
+        "validationError": {
+          "required": "Enter the security code",
+          "maxLength": "Enter the security code using only 6 digits",
+          "minLength": "Enter the security code using only 6 digits",
+          "invalidFormat": "Enter the security code using only 6 digits",
+          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+        }
+      },
+      "details": {
+        "summaryText": "Problems with the code?",
+        "text1": "We can ",
+        "sendCodeLinkText": "send the code again",
+        "sendCodeLinkHref": "/resend-code",
+        "text 2": " if the code is not working or you did not receive it.",
+        "changeGetSecurityCodesText": "If you cannot access the phone number for your GOV.UK One Login, you can securely ",
+        "changeGetSecurityCodesLinkText": "change how you get security codes"
+      },
+      "upliftRequired": {
+        "title": "You need to enter a security code",
+        "header": "You need to enter a security code",
+        "paragraph1": "This helps keep your GOV.UK One Login secure.",
+        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes.",
+        "paragraph3": "We sent a code to the phone number linked to your GOV.UK One Login.",
+        "sendTheCodeAgain": "Send the code again"
+      }
+    },
     "resendMfaCode": {
       "title": "Get security code",
       "header": "Get security code",


### PR DESCRIPTION
## What?

Change the screenflow to include the SMS 2FA step in password reset when the switch is on.

## Why?
 In the existing journey where a user’s password can be reset without entering an mfa, once a user has reset their password they would then have to enter their mfa to login (for a 2fa service).  In the new journey this is not required so should be removed if the switch is off.