### PR TITLE
AUT-1978: Use local dockerfile when pushing to authdevs

### DIFF
--- a/deploy-authdevs.sh
+++ b/deploy-authdevs.sh
@@ -81,7 +81,7 @@ aws ecr get-login-password --region eu-west-2 --profile di-tools-dev | docker lo
 
 if [[ $BUILD == "1" ]]; then
   echo "Building image..."
-  docker buildx build --platform=linux/amd64 -t "${REPO_NAME}" .
+  docker buildx build --platform=linux/amd64 --file sandpit.Dockerfile -t "${REPO_NAME}" .
   echo "Tagging image..."
   docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
 


### PR DESCRIPTION

## What?

Use local dockerfile when pushing to authdevs.

## Why?

Uses an image not including Dynatrace, which cannot be built locally.

## Related

#1237 