### PR TITLE
AUT-1841: Create Frontend Middleware For Account Interventions

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -7,6 +7,7 @@ export const PATH_NAMES = {
   START: "/",
   AUTHORIZE: "/authorize",
   ACCESSIBILITY_STATEMENT: "/accessibility-statement",
+  ACCOUNT_INTERVENTIONS: "/account-interventions",
   TERMS_AND_CONDITIONS: "/terms-and-conditions",
   PRIVACY_POLICY: "/privacy-notice",
   PRIVACY_STATEMENT: "/privacy-statement",
@@ -95,6 +96,7 @@ export enum LOCALE {
 }
 
 export const API_ENDPOINTS = {
+  ACCOUNT_INTERVENTIONS: "/account-interventions",
   USER_EXISTS: "/user-exists",
   SIGNUP_USER: "/signup",
   SEND_NOTIFICATION: "/send-notification",

--- a/src/components/account-intervention/account-intervention-service.ts
+++ b/src/components/account-intervention/account-intervention-service.ts
@@ -1,0 +1,43 @@
+import {
+  createApiResponse,
+  getRequestConfig,
+  Http,
+  http,
+} from "../../utils/http";
+import { API_ENDPOINTS } from "../../app.constants";
+import {
+  AccountInterventionStatus,
+  AccountInterventionsInterface,
+} from "./types";
+import { ApiResponseResult } from "../../types";
+
+export function accountInterventionService(
+  axios: Http = http
+): AccountInterventionsInterface {
+  const accountInterventionStatus = async function (
+    sessionId: string,
+    emailAddress: string,
+    sourceIp: string,
+    clientSessionId: string,
+    persistentSessionId: string
+  ): Promise<ApiResponseResult<AccountInterventionStatus>> {
+    const response = await axios.client.post<AccountInterventionStatus>(
+      API_ENDPOINTS.ACCOUNT_INTERVENTIONS,
+      {
+        email: emailAddress.toLowerCase(),
+      },
+      getRequestConfig({
+        sessionId: sessionId,
+        sourceIp: sourceIp,
+        clientSessionId: clientSessionId,
+        persistentSessionId: persistentSessionId,
+      })
+    );
+
+    return createApiResponse<AccountInterventionStatus>(response);
+  };
+
+  return {
+    accountInterventionStatus,
+  };
+}

--- a/src/components/account-intervention/types.ts
+++ b/src/components/account-intervention/types.ts
@@ -1,0 +1,18 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+
+export interface AccountInterventionsInterface {
+  accountInterventionStatus: (
+    sessionId: string,
+    emailAddress: string,
+    sourceIp: string,
+    clientSessionId: string,
+    persistentSessionId: string
+  ) => Promise<ApiResponseResult<AccountInterventionStatus>>;
+}
+
+export interface AccountInterventionStatus extends DefaultApiResponse {
+  email: string;
+  passwordResetRequired: boolean;
+  blocked: boolean;
+  temporarilySuspended: boolean;
+}

--- a/src/components/auth-code/auth-code-routes.ts
+++ b/src/components/auth-code/auth-code-routes.ts
@@ -5,6 +5,7 @@ import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { authCodeGet } from "./auth-code-controller";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { asyncHandler } from "../../utils/async";
+import { accountInterventionsMiddleware } from "../../middleware/account-interventions-middleware";
 
 const router = express.Router();
 
@@ -12,6 +13,7 @@ router.get(
   PATH_NAMES.AUTH_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
+  asyncHandler(accountInterventionsMiddleware()),
   asyncHandler(authCodeGet())
 );
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -632,7 +632,17 @@ const authStateMachine = createMachine(
         },
       },
       [PATH_NAMES.AUTH_CODE]: {
-        type: "final",
+        on: {
+          [USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION]: [
+            PATH_NAMES.PASSWORD_RESET_REQUIRED,
+          ],
+          [USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_PERMANENT,
+          ],
+          [USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_TEMPORARY,
+          ],
+        },
       },
       [PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT]: {
         on: {

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -1,0 +1,56 @@
+import { NextFunction, Request, Response } from "express";
+import { getNextPathAndUpdateJourney } from "../components/common/constants";
+import { USER_JOURNEY_EVENTS } from "../components/common/state-machine/state-machine";
+import { accountInterventionService } from "../components/account-intervention/account-intervention-service";
+import { ExpressRouteFunc } from "../types";
+import { supportAccountInterventions } from "../config";
+
+export function accountInterventionsMiddleware(
+  service = accountInterventionService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response, next: NextFunction) {
+    if (supportAccountInterventions()) {
+      const email = req.session.user.email.toLowerCase();
+      const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+      const accountInterventionsResponse =
+        await service.accountInterventionStatus(
+          sessionId,
+          email,
+          req.ip,
+          clientSessionId,
+          persistentSessionId
+        );
+
+      if (accountInterventionsResponse.data.passwordResetRequired) {
+        res.redirect(
+          getNextPathAndUpdateJourney(
+            req,
+            req.path,
+            USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION
+          )
+        );
+      }
+      if (accountInterventionsResponse.data.blocked) {
+        res.redirect(
+          getNextPathAndUpdateJourney(
+            req,
+            req.path,
+            USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION
+          )
+        );
+      }
+      if (accountInterventionsResponse.data.temporarilySuspended) {
+        res.redirect(
+          getNextPathAndUpdateJourney(
+            req,
+            req.path,
+            USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
+          )
+        );
+      }
+    }
+
+    return next();
+  };
+}

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -1,0 +1,142 @@
+import { describe } from "mocha";
+import { mockRequest, mockResponse } from "mock-req-res";
+import { PATH_NAMES } from "../../../src/app.constants";
+import { NextFunction, Request, Response } from "express";
+import { sinon } from "../../utils/test-utils";
+import { expect } from "chai";
+import { accountInterventionsMiddleware } from "../../../src/middleware/account-interventions-middleware";
+import { AccountInterventionsInterface } from "../../../src/components/account-intervention/types";
+
+describe("accountInterventionsMiddleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
+    req = mockRequest({
+      session: {
+        user: {
+          email: "test@test.com",
+        },
+      },
+      log: { error: sinon.fake(), info: sinon.fake() },
+      path: PATH_NAMES.AUTH_CODE,
+    });
+    res = mockResponse({
+      locals: {
+        sessionId: "test-session",
+        clientSessionId: "test-client-session",
+        persistentSessionId: "test-persistent-session",
+      },
+    });
+    next = sinon.fake() as unknown as NextFunction;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
+  });
+
+  it("should call next() when no account intervention API response options are true and supportAccountInterventions() returns true", async () => {
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: false,
+          blocked: false,
+          temporarilySuspended: false,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await accountInterventionsMiddleware(fakeAccountInterventionService)(
+      req as Request,
+      res as Response,
+      next as NextFunction
+    );
+    expect(next).to.be.calledOnce;
+  });
+
+  it("should call next() when supportAccountInterventions() returns false", async () => {
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "0";
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: false,
+          blocked: false,
+          temporarilySuspended: false,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await accountInterventionsMiddleware(fakeAccountInterventionService)(
+      req as Request,
+      res as Response,
+      next as NextFunction
+    );
+    expect(next).to.be.calledOnce;
+  });
+
+  it("should redirect to getNextPathAndUpdateJourney with the journey being PASSWORD_RESET_INTERVENTION when passwordResetRequired === true in the response and supportAccountInterventions() returns true", async () => {
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: true,
+          blocked: false,
+          temporarilySuspended: false,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await accountInterventionsMiddleware(fakeAccountInterventionService)(
+      req as Request,
+      res as Response,
+      next as NextFunction
+    );
+    expect(res.redirect).to.have.been.calledWith(
+      PATH_NAMES.PASSWORD_RESET_REQUIRED
+    );
+  });
+
+  it("should redirect to getNextPathAndUpdateJourney with the journey being PERMANENTLY_BLOCKED_INTERVENTION when blocked === true in the response and supportAccountInterventions() returns true", async () => {
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: false,
+          blocked: true,
+          temporarilySuspended: false,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await accountInterventionsMiddleware(fakeAccountInterventionService)(
+      req as Request,
+      res as Response,
+      next as NextFunction
+    );
+    expect(res.redirect).to.have.been.calledWith(
+      PATH_NAMES.UNAVAILABLE_PERMANENT
+    );
+  });
+
+  it("should redirect to getNextPathAndUpdateJourney with the journey being TEMPORARILY_BLOCKED_INTERVENTION when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: false,
+          blocked: false,
+          temporarilySuspended: true,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await accountInterventionsMiddleware(fakeAccountInterventionService)(
+      req as Request,
+      res as Response,
+      next as NextFunction
+    );
+    expect(res.redirect).to.have.been.calledWith(
+      PATH_NAMES.UNAVAILABLE_TEMPORARY
+    );
+  });
+});


### PR DESCRIPTION
## What?

Created Front End Middleware for Account Interventions and associated tests. Also updated state machine to allow for account interventions user journey AUTH_CODE path.
Currently changes are a WIP but are turned off by the SUPPORT_ACCOUNT_INTERVENTIONS feature flag.

Password Reset required journey also needs linking to the following check your email page via post request as is shown on the figma:
https://www.figma.com/file/aVqNC4pKaebZchIU691f31/DI-Authentication?type=design&node-id=22785-87951&mode=design

## Why?

Middleware and state machine needed to be implemented to allow for account interventions user journeys.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1244
