### PR TITLE
AUT-1934: Move 'Sign in' button on 'Create/sign in' screen

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -9,65 +9,66 @@
 {% set pageTitleName = pageTitleVariableName | translate %}
 
 {% set moreAboutTextHtml %}
-<p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph2' | translate}}</p>
-<p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph3' | translate}}</p>
+    <p class="govuk-body">{{ 'pages.signInOrCreate.moreAbout.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.signInOrCreate.moreAbout.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.signInOrCreate.moreAbout.paragraph3' | translate }}</p>
 {% endset %}
 
 {% block content %}
-  {% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.mandatory.header' | translate}}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate }}</h1>
 
-  <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
-    {% if supportInternationalNumbers %}
-      <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
-    {% else %}
-      <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
+    <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
+        {% if supportInternationalNumbers %}
+            <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
+        {% else %}
+            <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
+        {% endif %}
+    </ul>
+    {% if supportLanguageCY %}
+        {% set altLangInsetHtml %}
+            {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
+            <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
+                {{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
+                <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
+        {% endset %}
+        {{ govukInsetText({
+            html: altLangInsetHtml
+        }) }}
     {% endif %}
-  </ul>
-  {% if supportLanguageCY %}
-    {% set altLangInsetHtml %}
-    {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
-    <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
-      {{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
-      <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
-    {% endset %}
-    {{ govukInsetText({
-      html: altLangInsetHtml
+
+    <form action="/sign-in-or-create" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="supportInternationalNumbers" value="{{ supportInternationalNumbers }}" />
+
+        {{ govukButton({
+            text: 'pages.signInOrCreate.createButtonText' | translate,
+            value: "create",
+            name: "optionSelected",
+            classes: "govuk-!-margin-right-3",
+            attributes: {
+                "id": "create-account-link"
+            }
+        }) }}
+        <div>
+            {{ govukButton({
+                text: 'pages.signInOrCreate.signInText' | translate,
+                classes: "govuk-button--secondary",
+                attributes: {
+                    "id": "sign-in-button"
+                }
+            }) }}
+        </div>
+
+    </form>
+
+    {{ govukDetails({
+        summaryText: 'pages.signInOrCreate.moreAbout.header' | translate,
+        html: moreAboutTextHtml
     }) }}
-  {% endif %}
-
-  <form action="/sign-in-or-create" method="post" novalidate="novalidate">
-
-    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-    <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
-
-    {{ govukButton({
-    text: 'pages.signInOrCreate.createButtonText' | translate,
-    value: "create",
-    name: "optionSelected",
-    classes: "govuk-!-margin-right-3",
-    attributes: {
-      "id": "create-account-link"
-    }
-  }) }}
-
-    {{ govukButton({
-      text: 'pages.signInOrCreate.signInText' | translate,
-      classes: "govuk-button--secondary",
-      attributes: {
-        "id": "sign-in-button"
-      }
-    }) }}
-
-  </form>
-
-  {{ govukDetails({
-  summaryText: 'pages.signInOrCreate.moreAbout.header' | translate,
-  html: moreAboutTextHtml
-  }) }}
 
 {% endblock %}


### PR DESCRIPTION
## What?

This PR simply left aligns the "Sign in" button on larger screens without impacting the presentation on smaller screens. This button is presented to users during the "Create / Sign in" journey. I've also formatted the related Nunjucks template to fix indentation issues etc. You can view the diff without whitespace changes [here](https://github.com/govuk-one-login/authentication-frontend/pull/1250/files?diff=split&w=1)

### Screenshots

<details>

<summary>Button presentation on larger screens (details component expanded)</summary>

<img width="993" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/ade1c5e2-9fe2-4615-821c-a06aa570442f">

</details>

<details>

<summary>Button presentation on smaller screens (details component expanded)</summary>

<img width="486" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/13bda25c-d168-4585-8694-2144051bdf99">

</details>

## How?

I've simply wrapped it in a block-level element. This seemed the simplest way to achieve consistent results. 

### Cross-browser testing 

This change has been tested in the following browsers

OS | Browser | Versions tested |
-- | -- | --
Windows | Edge (latest versions) | 119, 118
Windows | Google Chrome (latest versions) | 120, 119
Windows | Mozilla Firefox (latest versions) | 120, 119
macOS | Safari 12 and later | 12.1, 13.1, 14.1, 15.6, 16.5, 17
macOS | Google Chrome (latest versions) | 120, 119
macOS | Mozilla Firefox (latest versions) | 120, 119
iOS | Safari for iOS 12.1 and later | iPad tested with iOS versions 16.0, 15.3 (Browserstack was unable to connect to localhost for earlier versions)
iOS | Google Chrome (latest versions) | iPad tested with iOS versions 16, 15, 14
Android | Google Chrome (latest versions) | 12, 13, 11
Android | Samsung Internet (latest versions) | BrowserStack unable to connect to localhost

## Why?

User-centred design continuous improvement.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
