### PR TITLE
AUT-1895: Remove whitespace from OTP field entires

### DIFF
--- a/src/components/check-your-email/check-your-email-validation.ts
+++ b/src/components/check-your-email/check-your-email-validation.ts
@@ -1,9 +1,13 @@
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
-import { validateCode } from "../common/verify-code/verify-code-validation";
+import {
+  validateCode,
+  whitespaceSanitizer,
+} from "../common/verify-code/verify-code-validation";
 
 export function validateCheckYourEmailRequest(): ValidationChainFunc {
   return [
+    whitespaceSanitizer(),
     validateCode({
       requiredKey: "pages.checkYourEmail.code.validationError.required",
       maxLengthKey: "pages.checkYourEmail.code.validationError.maxLength",

--- a/src/components/common/verify-code/tests/verify-code-validation.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-validation.test.ts
@@ -1,0 +1,81 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { removeWhiteSpace } from "../verify-code-validation";
+
+describe("removeWhiteSpace", () => {
+  it("should return the provided string if it is just 6 digits", () => {
+    const input = "123456";
+
+    expect(removeWhiteSpace(input)).to.equal(input);
+  });
+
+  it("should not return the provided string if it is not 6 digits", () => {
+    const input = "123 456";
+
+    expect(removeWhiteSpace(input)).to.not.equal(input);
+  });
+
+  it("should strip whitespace wherever it appears in the given value", () => {
+    const items = [
+      { input: " 123456", expected: "123456" },
+      { input: "1 23456", expected: "123456" },
+      { input: "12 3456", expected: "123456" },
+      { input: "123 456", expected: "123456" },
+      { input: "1234 56", expected: "123456" },
+      { input: "12345 6", expected: "123456" },
+      { input: "123456 ", expected: "123456" },
+    ];
+
+    items.forEach((i) => {
+      expect(removeWhiteSpace(i.input)).to.equal(i.expected);
+    });
+  });
+
+  it("should strip repeated whitespace wherever it appears in the given value", () => {
+    const items = [
+      { input: "   123456", expected: "123456" },
+      { input: "1   23456", expected: "123456" },
+      { input: "12   3456", expected: "123456" },
+      { input: "123   456", expected: "123456" },
+      { input: "1234   56", expected: "123456" },
+      { input: "12345   6", expected: "123456" },
+      { input: "123456   ", expected: "123456" },
+    ];
+
+    items.forEach((i) => {
+      expect(removeWhiteSpace(i.input)).to.equal(i.expected);
+    });
+  });
+
+  it("should strip multiple instances of repeated whitespace wherever it appears", () => {
+    const items = [
+      { input: "   123456   ", expected: "123456" },
+      { input: "1   2345   6", expected: "123456" },
+      { input: "12   34   56", expected: "123456" },
+      { input: "123   456", expected: "123456" },
+      { input: "123   4   56", expected: "123456" },
+      { input: "12   345   6", expected: "123456" },
+      { input: "1   23456   ", expected: "123456" },
+    ];
+
+    items.forEach((i) => {
+      expect(removeWhiteSpace(i.input)).to.equal(i.expected);
+    });
+  });
+
+  it("should strip different types of whitespace", () => {
+    const items = [
+      { input: "   123456   ", expected: "123456" },
+      { input: "1\v23\n4 5\t6 ", expected: "123456" },
+      { input: "\r123\n4 5\t6 ", expected: "123456" },
+      { input: "\r1\v234 5\t6 ", expected: "123456" },
+      { input: "\r1\v23\n4 56 ", expected: "123456" },
+      { input: "\r1234 5\t6\f ", expected: "123456" },
+      { input: "\r1234 5\t6 ", expected: "123456" },
+    ];
+
+    items.forEach((i) => {
+      expect(removeWhiteSpace(i.input)).to.equal(i.expected);
+    });
+  });
+});

--- a/src/components/common/verify-code/verify-code-validation.ts
+++ b/src/components/common/verify-code/verify-code-validation.ts
@@ -1,6 +1,16 @@
 import { body, ValidationChain } from "express-validator";
 import { containsNumbersOnly } from "../../../utils/strings";
 
+export function removeWhiteSpace(value: string): string {
+  const re = /[\r\n\t\f\v\s]/g;
+
+  return value.replace(re, "");
+}
+
+export function whitespaceSanitizer(): ValidationChain {
+  return body("code").customSanitizer(removeWhiteSpace);
+}
+
 export function validateCode(validationMessageKeys: {
   requiredKey: string;
   maxLengthKey: string;


### PR DESCRIPTION
## What?

Introduces a custom sanitizer to remove whitespace from OTP fields before they are passed to validation functions. This validator captures the all instances of the following types of whitespace: 

* Whitespace and line terminator characters 
* Horizontal and vertical tabs
* New lines
* Carriage returns
* Form feeds

## Why?

Recent advice from Accessibility Specialists has revealed that users of some assistive technologies may find their input mechanism injects whitespace into fields. Prior to this PR, user entries that included whitespace would have failed validation. 