### PR TITLE
Aut 2113/handle auth params

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -117,6 +117,7 @@ export function authorizeGet(
       startAuthResponse.data.user.docCheckingAppUser;
 
     req.session.user.isAccountCreationJourney = undefined;
+    req.session.user.reauthenticate = claims.reauthenticate;
 
     if (startAuthResponse.data.featureFlags) {
       req.session.user.featureFlags = startAuthResponse.data.featureFlags;

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -72,7 +72,8 @@ export function authorizeGet(
       sessionId,
       clientSessionId,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      claims.reauthenticate
     );
 
     if (!startAuthResponse.success) {

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -7,6 +7,7 @@ import {
   http,
   Http,
 } from "../../utils/http";
+import { supportReauthentication } from "../../config";
 
 export function authorizeService(
   axios: Http = http
@@ -15,8 +16,13 @@ export function authorizeService(
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    reauthenticate?: string
   ): Promise<ApiResponseResult<StartAuthResponse>> {
+    let reauthenticateOption = undefined;
+    if (supportReauthentication() && reauthenticate) {
+      reauthenticateOption = reauthenticate !== "";
+    }
     const response = await axios.client.get<StartAuthResponse>(
       API_ENDPOINTS.START,
       getRequestConfig({
@@ -24,6 +30,7 @@ export function authorizeService(
         clientSessionId: clientSessionId,
         sourceIp: sourceIp,
         persistentSessionId: persistentSessionId,
+        reauthenticate: reauthenticateOption,
       })
     );
 

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -30,6 +30,7 @@ export type Claims = {
   client_id: string;
   redirect_uri: string;
   rp_sector_host: string;
+  reauthenticate?: string;
   claim?: string;
 };
 

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -213,6 +213,49 @@ describe("authorize controller", () => {
       );
     });
 
+    it("should redirect to sign in when reauthentication is requested and user is not authenticated and support reauthenticate feature flag is on", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "1";
+      mockClaims.reauthenticate = "123456";
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: false,
+        upliftRequired: false,
+        authenticated: false,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
+
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
+    });
+
+    //note that this is currently the same behaviour with the feature flag on or off. This will change if we decide on a different initial page for the reauth journey
+    it("should redirect to sign in when reauthentication is requested and user has an existing session but support reauthenticate feature flag is off", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "0";
+      mockClaims.reauthenticate = "123456";
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: false,
+        upliftRequired: false,
+        authenticated: false,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
+
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
+    });
+
     it("should redirect to /enter-password page when prompt is login", async () => {
       req.query.prompt = OIDC_PROMPT.LOGIN;
 
@@ -351,6 +394,7 @@ describe("authorize controller", () => {
     });
 
     it("should set session reauthenticate session field from jwt claims when claim is present", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "1";
       req.query.request = "JWE";
       mockClaims.reauthenticate = "123456";
 
@@ -363,6 +407,20 @@ describe("authorize controller", () => {
       expect(req.session.user.reauthenticate).to.equal(
         mockClaims.reauthenticate
       );
+    });
+
+    it("should not set session reauthenticate session field from jwt claims when claim is present", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "0";
+      req.query.request = "JWE";
+      mockClaims.reauthenticate = "123456";
+
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
+      expect(req.session.user.reauthenticate).to.eq(null);
     });
 
     it("claims should be undefined when optional claims missing", async () => {

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -342,11 +342,27 @@ describe("authorize controller", () => {
       expect(req.session.client.isOneLoginService).to.equal(
         mockClaims.is_one_login_service
       );
+
       expect(req.session.client.claim).to.be.deep.equal([
         "email_verified",
         "public_subject_id",
         "email",
       ]);
+    });
+
+    it("should set session reauthenticate session field from jwt claims when claim is present", async () => {
+      req.query.request = "JWE";
+      mockClaims.reauthenticate = "123456";
+
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
+      expect(req.session.user.reauthenticate).to.equal(
+        mockClaims.reauthenticate
+      );
     });
 
     it("claims should be undefined when optional claims missing", async () => {

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -1,0 +1,78 @@
+import { describe } from "mocha";
+import { expect } from "chai";
+import { Http } from "../../../utils/http";
+import { authorizeService } from "../authorize-service";
+import { sinon } from "../../../../test/utils/test-utils";
+import { API_ENDPOINTS } from "../../../app.constants";
+import { SinonStub } from "sinon";
+import { AuthorizeServiceInterface } from "../types";
+
+describe("authorize service", () => {
+  const sessionId = "some-session-id";
+  const clientSessionId = "client-session-id";
+  const ip = "123.123.123.123";
+  const persistentSessionId = "persistent-session-id";
+  let getStub: SinonStub;
+  let service: AuthorizeServiceInterface;
+
+  beforeEach(() => {
+    process.env.API_KEY = "api-key";
+    process.env.FRONTEND_API_BASE_URL = "some-base-url";
+    process.env.API_BASE_URL = "another-base-url";
+    const httpInstance = new Http();
+    service = authorizeService(httpInstance);
+    getStub = sinon.stub(httpInstance.client, "get");
+  });
+
+  afterEach(() => {
+    getStub.reset();
+  });
+
+  it("sends a request with the reauth header set to true when reauth is requested and the feature flag is set", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    service.start(
+      sessionId,
+      clientSessionId,
+      ip,
+      persistentSessionId,
+      "123456"
+    );
+
+    expect(
+      getStub.calledWithMatch(API_ENDPOINTS.START, {
+        headers: { Reauthenticate: true },
+        proxy: false,
+      })
+    ).to.be.true;
+  });
+
+  it("sends a request without a reauth header when reauth is requested but the feature flag is not set", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "0";
+    service.start(
+      sessionId,
+      clientSessionId,
+      ip,
+      persistentSessionId,
+      "123456"
+    );
+
+    expect(
+      getStub.calledWithMatch(API_ENDPOINTS.START, {
+        headers: { Reauthenticate: undefined },
+        proxy: false,
+      })
+    ).to.be.true;
+  });
+
+  it("sends a request without a reauth header when reauth is not requested", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    service.start(sessionId, clientSessionId, ip, persistentSessionId);
+
+    expect(
+      getStub.calledWithMatch(API_ENDPOINTS.START, {
+        headers: { Reauthenticate: undefined },
+        proxy: false,
+      })
+    ).to.be.true;
+  });
+});

--- a/src/components/authorize/tests/jwt-service.test.ts
+++ b/src/components/authorize/tests/jwt-service.test.ts
@@ -35,6 +35,15 @@ describe("JWT service", () => {
       expect(result).to.deep.equal(createmockclaims());
     });
 
+    it("should consider a jwt with a reautheticate claim as valid", async () => {
+      const jwtWithReautheticateClaim = createmockclaims();
+      jwtWithReautheticateClaim.reauthenticate = "123456";
+      const jwt = await createJwt(jwtWithReautheticateClaim, privateKey);
+
+      const result = await jwtService.getPayloadWithValidation(jwt);
+      expect(result).to.deep.equal(jwtWithReautheticateClaim);
+    });
+
     describe("Validate jwt", () => {
       it("should throw an error when passed non-JWT format", async () => {
         try {

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -22,7 +22,8 @@ export interface AuthorizeServiceInterface {
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    reauthenticate?: string
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -73,6 +73,7 @@ const authStateMachine = createMachine(
       isMfaMethodVerified: true,
       isPasswordChangeRequired: false,
       isAccountRecoveryJourney: false,
+      isReauthenticationRequired: false,
     },
     states: {
       [PATH_NAMES.START]: {
@@ -124,9 +125,17 @@ const authStateMachine = createMachine(
               target: [PATH_NAMES.SHARE_INFO],
               cond: "isConsentRequired",
             },
+            {
+              target: [PATH_NAMES.SIGN_IN_OR_CREATE],
+              cond: "isReauthenticationRequired",
+            },
             { target: [PATH_NAMES.AUTH_CODE], cond: "isAuthenticated" },
           ],
           [USER_JOURNEY_EVENTS.NO_EXISTING_SESSION]: [
+            {
+              target: [PATH_NAMES.SIGN_IN_OR_CREATE],
+              cond: "isReauthenticationRequired",
+            },
             {
               target: [PATH_NAMES.DOC_CHECKING_APP],
               cond: "skipAuthentication",
@@ -703,6 +712,8 @@ const authStateMachine = createMachine(
         context.requiresTwoFactorAuth === true,
       isPasswordChangeRequired: (context) => context.isPasswordChangeRequired,
       isAccountRecoveryJourney: (context) => context.isAccountRecoveryJourney,
+      isReauthenticationRequired: (context) =>
+        context.isReauthenticationRequired,
     },
   }
 );

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -144,5 +144,32 @@ describe("state-machine", () => {
       );
       expect(nextState.value).to.equal(PATH_NAMES.CHECK_YOUR_EMAIL);
     });
+
+    it("should move from authorize to sign or create when reauthentication is requested and the user is already logged in", () => {
+      const nextState = getNextState(
+        PATH_NAMES.AUTHORIZE,
+        USER_JOURNEY_EVENTS.EXISTING_SESSION,
+        { isAuthenticated: true, isReauthenticationRequired: true }
+      );
+      expect(nextState.value).to.equal(PATH_NAMES.SIGN_IN_OR_CREATE);
+    });
+
+    it("should move from authorize to sign or create when reauthentication is requested and the user is not logged in", () => {
+      const nextState = getNextState(
+        PATH_NAMES.AUTHORIZE,
+        USER_JOURNEY_EVENTS.NO_EXISTING_SESSION,
+        { isReauthenticationRequired: true }
+      );
+      expect(nextState.value).to.equal(PATH_NAMES.SIGN_IN_OR_CREATE);
+    });
+
+    it("should move from authorize to auth code create when the user is already logged in", () => {
+      const nextState = getNextState(
+        PATH_NAMES.AUTHORIZE,
+        USER_JOURNEY_EVENTS.EXISTING_SESSION,
+        { isAuthenticated: true }
+      );
+      expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
+    });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface UserSession {
   isAccountRecoveryJourney?: boolean;
   isAccountRecoveryCodeResent?: boolean;
   accountRecoveryVerifiedMfaType?: string;
+  reauthenticate?: string;
 }
 
 export interface UserSessionClient {

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -25,6 +25,7 @@ export interface ConfigOptions {
   persistentSessionId?: string;
   baseURL?: string;
   userLanguage?: string;
+  reauthenticate?: boolean;
 }
 
 export function createApiResponse<T>(
@@ -69,6 +70,10 @@ export function getRequestConfig(options: ConfigOptions): AxiosRequestConfig {
 
   if (options.baseURL) {
     config.baseURL = options.baseURL;
+  }
+
+  if (options.reauthenticate) {
+    config.headers["Reauthenticate"] = options.reauthenticate;
   }
 
   if (options.userLanguage) {


### PR DESCRIPTION
## What?

In order to implement re-authentication, we need to respond to a claim sent to us by orchestration which signals that reauthentication should occur.

This PR:
* checks for the existence of the `reauthenticate` claim
* If it's present, and if the user is currently logged in, then upon the call to /authorize we will redirect the user to the sign in page

This claim will contain the user's RP pairwise ID. In this PR, we don't do anything with this beyond check for the existence of the claim. Work to check this pairwise ID against what we hold for the user will be implemented in [this ticket](https://govukverify.atlassian.net/browse/AUT-2127).

For the moment, we redirect to the existing sign in page screen. It's possible that we will amend this in future to point to a new page, this is still being agreed.

## Why?

To enable RPs to enforce re-authentication mid-journey for a user.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3710

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
