### PR TITLE
AUT-2118: Create a new frontend feature switch SUPPORT_REAUTHENTICATION

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -179,6 +179,10 @@ locals {
       {
         name  = "SUPPORT_ACCOUNT_INTERVENTIONS"
         value = var.support_account_interventions
+      },
+      {
+        name  = "SUPPORT_REAUTHENTICATION"
+        value = var.support_reauthentication
       }
     ]
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -276,3 +276,9 @@ variable "support_account_interventions" {
   type        = string
   default     = "0"
 }
+
+variable "support_reauthentication" {
+  description = "When true, turns on re-authentication in environment"
+  type        = string
+  default     = "0"
+}

--- a/src/components/check-reauth-users/tests/check-reauth-user-service.test.ts
+++ b/src/components/check-reauth-users/tests/check-reauth-user-service.test.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { supportReauthentication } from "../../../config";
+
+describe("re-authentication service", () => {
+  describe("with auth re-authentication feature flag on", () => {
+    it("should return true", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "1";
+
+      expect(supportReauthentication()).to.be.true;
+    });
+  });
+
+  describe("with auth re-authentication feature flag off", () => {
+    it("should return false", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "0";
+
+      expect(supportReauthentication()).to.be.false;
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -203,3 +203,7 @@ export function support2FABeforePasswordReset(): boolean {
 export function supportAccountInterventions(): boolean {
   return process.env.SUPPORT_ACCOUNT_INTERVENTIONS === "1";
 }
+
+export function supportReauthentication(): boolean {
+  return process.env.SUPPORT_REAUTHENTICATION === "1";
+}


### PR DESCRIPTION
## What?

Create a new frontend feature switch SUPPORT_REAUTHENTICATION
- Write unit tests to verify the feature flag is configured correctly

## Why?

Feature flag to support re-authentication until it's fully implemented and integrated
