### PR TITLE
BAU: Add coverage report task to pre-merge checks

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -36,6 +36,8 @@ jobs:
         run: yarn build
       - name: Run unit tests
         run: yarn test:unit
+      - name: Run test coverage
+        run: yarn test:coverage
       - name: Run integration tests
         run: yarn test:integration
       - name: Run lint


### PR DESCRIPTION
## What?

Add coverage report task to pre-merge checks.

## Why?

Task was removed because it was only reporting on integration test coverage as running tests removes all previous coverage tracking. Adding the task back in a different place so it reports on unit test coverage only.

