### PR TITLE
AUT-2104: Remove "Email" radio button from "A problem signing in" forms

### DIFF
--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -49,11 +49,6 @@
     {% if theme == 'signing_in' %}
         {% set items = [
             {
-                value: "email",
-                checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translateEnOnly
-            },
-            {
                 value: "text_message_uk_number",
                 checked: securityCodeSentMethod === 'text_message_uk_number',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly


### PR DESCRIPTION
## What?

Removes the "Email" option from forms under "A problem signing in" while retaining it for the "A problem creating a GOV.UK One Login" forms.

### Screenshots after change (Email radio option removed)

<details>
<summary>You’ve changed your phone number or lost your phone (under "A problem signing in") - 'Email' option removed</summary>

#### English

<img width="792" alt="Screenshot of You’ve changed your phone number or lost your phone - 'Email' option removed" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/50f4cb16-41cd-4457-9aad-fe7bdd2672d0">

#### Welsh

<img width="790" alt="Screenshot of You’ve changed your phone number or lost your phone - 'Email' option removed" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/ec512c40-5a3f-4bb8-9b1d-dff2befbc84a">


</details>

<details>

<summary>The security code does not work (under "A problem signing in") - 'Email' option removed</summary>

#### English

<img width="663" alt="Screenshot of the form with the 'Email' option having been removed" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/449ade89-8658-4b5e-9dff-df22f22fa2cf">

#### Welsh

![Screenshot 2023-12-20 at 14 48 52](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/bce154fc-43c0-47c6-ae11-25fe096423e8)

</details>

<details>

<summary>You did not get a security code (under "A problem signing in") - 'Email' radio option removed</summary>

#### English

<img width="659" alt="Screenshot of the form with the 'Email' option having been removed" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/b16e9f9c-63bb-4ca4-bddd-716abe346736">

#### Welsh 

![Screenshot 2023-12-20 at 14 50 16](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/a2bd1e8e-48e6-485c-bc75-c2a0d5a79908)


</details>

### Screenshots after changed (Email retained)

To demonstrate that the changes are limited to the relevant forms, I've included screenshots of their counterparts in the account creation journey to demonstrate that they are not changed.

<details>

<summary>The security code does not work (under "A problem creating a GOV.UK One Login") - 'Email' radio option retained</summary>

#### English

<img width="656" alt="Screeshot of the form with the 'Email' option retained" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/d5a461ad-b449-4b9c-91ca-45f126eba107">

#### Welsh

![security-code-not-working_account-creation](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/03a2c7dc-44c4-4b06-a2f0-b16c2e858d83)

</details>


<details>

<summary>You did not get a security code  (under "A problem creating a GOV.UK One Login") - 'Email' radio option retained</summary>

#### English

<img width="663" alt="did-not-get-a-code" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/431d5361-a2e1-4097-a990-bbde918608a9">

#### Welsh 

![did-not-get-a-code_account-creation](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/a3d4771d-8be9-4581-9952-ce8e03566a7c)

</details>

## Why?

A user will not receive a security code via email when signing in, only via SMS or auth app.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change