### PR TITLE
AUT-2116: Integrate 'Enter password' into the frontend re-authentication flow

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -115,6 +115,7 @@ export const API_ENDPOINTS = {
   IPV_PROCESSING_IDENTITY: "/processing-identity",
   VERIFY_MFA_CODE: "/verify-mfa-code",
   ACCOUNT_RECOVERY: "/account-recovery",
+  CHECK_REAUTH_USERS: "/check-reauth-users",
 };
 
 export const ERROR_MESSAGES = {

--- a/src/components/check-reauth-users/check-reauth-users-service.ts
+++ b/src/components/check-reauth-users/check-reauth-users-service.ts
@@ -1,0 +1,41 @@
+import {
+  createApiResponse,
+  getRequestConfig,
+  Http,
+  http,
+} from "../../utils/http";
+import { API_ENDPOINTS } from "../../app.constants";
+import { CheckReauthServiceInterface } from "./types";
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+
+export function checkReauthUsersService(
+  axios: Http = http
+): CheckReauthServiceInterface {
+  const checkReauthUsers = async function (
+    sessionId: string,
+    emailAddress: string,
+    sourceIp: string,
+    clientSessionId: string,
+    persistentSessionId: string
+  ): Promise<ApiResponseResult<DefaultApiResponse>> {
+    const lowerCaseEmail = emailAddress.toLowerCase();
+    const config = getRequestConfig({
+      sessionId,
+      sourceIp,
+      clientSessionId,
+      persistentSessionId,
+    });
+
+    const response = await axios.client.post<DefaultApiResponse>(
+      API_ENDPOINTS.CHECK_REAUTH_USERS,
+      { email: lowerCaseEmail },
+      config
+    );
+
+    return createApiResponse<DefaultApiResponse>(response);
+  };
+
+  return {
+    checkReauthUsers,
+  };
+}

--- a/src/components/check-reauth-users/types.ts
+++ b/src/components/check-reauth-users/types.ts
@@ -1,0 +1,11 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+
+export interface CheckReauthServiceInterface {
+  checkReauthUsers: (
+    sessionId: string,
+    email: string,
+    sourceIp: string,
+    clientSessionId: string,
+    persistentSessionId: string
+  ) => Promise<ApiResponseResult<DefaultApiResponse>>;
+}

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -127,7 +127,7 @@ const authStateMachine = createMachine(
               cond: "isConsentRequired",
             },
             {
-              target: [PATH_NAMES.SIGN_IN_OR_CREATE],
+              target: [PATH_NAMES.ENTER_PASSWORD],
               cond: "isReauthenticationRequired",
             },
             { target: [PATH_NAMES.AUTH_CODE], cond: "isAuthenticated" },

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -151,7 +151,7 @@ describe("state-machine", () => {
         USER_JOURNEY_EVENTS.EXISTING_SESSION,
         { isAuthenticated: true, isReauthenticationRequired: true }
       );
-      expect(nextState.value).to.equal(PATH_NAMES.SIGN_IN_OR_CREATE);
+      expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
     });
 
     it("should move from authorize to sign or create when reauthentication is requested and the user is not logged in", () => {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -19,6 +19,9 @@ import { MFA_METHOD_TYPE } from "../../app.constants";
 import xss from "xss";
 import { EnterEmailServiceInterface } from "../enter-email/types";
 import { enterEmailService } from "../enter-email/enter-email-service";
+import { supportReauthentication } from "../../config";
+import { CheckReauthServiceInterface } from "../check-reauth-users/types";
+import { checkReauthUsersService } from "../check-reauth-users/check-reauth-users-service";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
 const ENTER_PASSWORD_VALIDATION_KEY =
@@ -29,8 +32,33 @@ const ENTER_PASSWORD_ACCOUNT_EXISTS_TEMPLATE =
 const ENTER_PASSWORD_ACCOUNT_EXISTS_VALIDATION_KEY =
   "pages.enterPasswordAccountExists.password.validationError.incorrectPassword";
 
-export function enterPasswordGet(req: Request, res: Response): void {
-  res.render(ENTER_PASSWORD_TEMPLATE);
+export function enterPasswordGet(
+  service: CheckReauthServiceInterface = checkReauthUsersService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const isReauthenticationRequired = req.session.user.reauthenticate;
+
+    if (!supportReauthentication() || !isReauthenticationRequired) {
+      return res.render(ENTER_PASSWORD_TEMPLATE);
+    }
+
+    const email = req.session.user.email.toLowerCase();
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const checkReauthUserResponse = await service.checkReauthUsers(
+      sessionId,
+      email,
+      req.ip,
+      clientSessionId,
+      persistentSessionId
+    );
+
+    if (!checkReauthUserResponse.success) {
+      return res.render("common/errors/500.njk");
+    }
+
+    return res.render(ENTER_PASSWORD_TEMPLATE);
+  };
 }
 
 export function enterSignInRetryBlockedGet(

--- a/src/components/enter-password/enter-password-routes.ts
+++ b/src/components/enter-password/enter-password-routes.ts
@@ -22,7 +22,7 @@ router.get(
   PATH_NAMES.ENTER_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  enterPasswordGet
+  asyncHandler(enterPasswordGet())
 );
 
 router.get(

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -20,6 +20,7 @@ import {
 } from "mock-req-res";
 import { EnterEmailServiceInterface } from "../../enter-email/types";
 import { ERROR_CODES } from "../../common/constants";
+import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
 
 describe("enter password controller", () => {
   let req: RequestOutput;
@@ -39,10 +40,77 @@ describe("enter password controller", () => {
   });
 
   describe("enterPasswordGet", () => {
-    it("should render enter password view", () => {
-      enterPasswordGet(req as Request, res as Response);
+    const fakeService: CheckReauthServiceInterface = {
+      checkReauthUsers: sinon.fake.returns({
+        success: true,
+      }),
+    } as unknown as CheckReauthServiceInterface;
+
+    it("should render enter password view", async () => {
+      await enterPasswordGet(fakeService)(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("enter-password/index.njk");
+    });
+
+    it("should render enter password view when supportReauthentication flag is switched off", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "0";
+
+      await enterPasswordGet(fakeService)(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("enter-password/index.njk");
+    });
+
+    it("should render enter password view when isReautheticationRequired is false", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "1";
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+
+      await enterPasswordGet(fakeService)(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("enter-password/index.njk");
+    });
+
+    it("should render enter password view when isReautheticationRequired is true and check service returns successfully", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "1";
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+        reauthenticate: "12345",
+      };
+
+      await enterPasswordGet(fakeService)(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("enter-password/index.njk");
+    });
+
+    it("should render 500 error view when isReautheticationRequired is true and check service fails", async () => {
+      const unsuccessfulFakeService: CheckReauthServiceInterface = {
+        checkReauthUsers: sinon.fake.returns({
+          success: false,
+        }),
+      } as unknown as CheckReauthServiceInterface;
+
+      process.env.SUPPORT_REAUTHENTICATION = "1";
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+        reauthenticate: "12345",
+      };
+
+      await enterPasswordGet(unsuccessfulFakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.calledWith("common/errors/500.njk");
     });
   });
 

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -4,8 +4,16 @@ import { expect, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
-import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
 import { ERROR_CODES } from "../../common/constants";
+import { AxiosResponse } from "axios";
+import { createApiResponse } from "../../../utils/http";
+import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
+import { DefaultApiResponse } from "../../../types";
 
 describe("Integration::enter password", () => {
   let token: string | string[];
@@ -19,6 +27,7 @@ describe("Integration::enter password", () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
+    const checkReauthUsersService = require("../../check-reauth-users/check-reauth-users-service");
 
     sinon
       .stub(sessionMiddleware, "validateSessionMiddleware")
@@ -32,9 +41,24 @@ describe("Integration::enter password", () => {
           journey: {
             nextPath: PATH_NAMES.ENTER_PASSWORD,
           },
+          reauthenticate: true,
         };
 
         next();
+      });
+
+    sinon
+      .stub(checkReauthUsersService, "checkReauthUsersService")
+      .callsFake((): CheckReauthServiceInterface => {
+        async function checkReauthUsers() {
+          const fakeAxiosResponse: AxiosResponse = {
+            status: HTTP_STATUS_CODES.OK,
+          } as AxiosResponse;
+
+          return createApiResponse<DefaultApiResponse>(fakeAxiosResponse);
+        }
+
+        return { checkReauthUsers };
       });
 
     app = await require("../../../app").createApp();
@@ -59,6 +83,11 @@ describe("Integration::enter password", () => {
   });
 
   it("should return enter password page", (done) => {
+    request(app).get(ENDPOINT).expect(200, done);
+  });
+
+  it("should return enter password page when support reauthentication flag is on and check reauth users api call is successfull", (done) => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
     request(app).get(ENDPOINT).expect(200, done);
   });
 


### PR DESCRIPTION
## What?

Temporarily redirect the user to /enter-password during the re-authenticate journey only when feature flag is on
- Update state machine
- Update enter-password GET controller method
- Call new CheckReauthUsers API endpoint

## Why?

Temporarily redirect to /enter-password page whilst discussions are ongoing with HMRC regarding the new reauth screen