### PR TITLE
AUT-2142: Change error screen in specific scenario (Detail below)

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -15,7 +15,7 @@ import {
 } from "../common/constants";
 import { BadRequestError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { MFA_METHOD_TYPE } from "../../app.constants";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
 import xss from "xss";
 import { EnterEmailServiceInterface } from "../enter-email/types";
 import { enterEmailService } from "../enter-email/enter-email-service";
@@ -78,6 +78,16 @@ export function enterPasswordAccountExistsGet(
   res.render(ENTER_PASSWORD_ACCOUNT_EXISTS_TEMPLATE, {
     email: email,
   });
+}
+
+export function getErrorPathByCodeForPasswordFailures(
+  errorCode: number
+): string | undefined {
+  if (errorCode === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES) {
+    return PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED;
+  } else {
+    return getErrorPathByCode(errorCode);
+  }
 }
 
 export function enterPasswordPost(
@@ -152,7 +162,7 @@ export function enterPasswordPost(
       );
 
       if (!result.success) {
-        const path = getErrorPathByCode(result.data.code);
+        const path = getErrorPathByCodeForPasswordFailures(result.data.code);
 
         if (path) {
           return res.redirect(path);

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -7,6 +7,7 @@ import {
   enterPasswordGet,
   enterPasswordPost,
   enterSignInRetryBlockedGet,
+  getErrorPathByCodeForPasswordFailures,
 } from "../enter-password-controller";
 
 import { PATH_NAMES } from "../../../app.constants";
@@ -19,7 +20,7 @@ import {
   ResponseOutput,
 } from "mock-req-res";
 import { EnterEmailServiceInterface } from "../../enter-email/types";
-import { ERROR_CODES } from "../../common/constants";
+import { ERROR_CODES, getErrorPathByCode } from "../../common/constants";
 
 describe("enter password controller", () => {
   let req: RequestOutput;
@@ -302,5 +303,26 @@ describe("enter password controller", () => {
         "enter-password/index-sign-in-retry-blocked.njk"
       );
     });
+  });
+});
+
+describe("getErrorPathByCodeForPasswordFailures", () => {
+  it("should return PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED when passed ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES", () => {
+    expect(
+      getErrorPathByCodeForPasswordFailures(
+        ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES
+      )
+    ).to.eq(PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED);
+  });
+
+  it("should otherwise return the same value as getErrorPathByCode would", () => {
+    for (const [key, value] of Object.entries(ERROR_CODES)) {
+      if (value !== ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES) {
+        expect(getErrorPathByCodeForPasswordFailures(value)).to.eq(
+          getErrorPathByCode(value),
+          `Argument ${key} returned a different value`
+        );
+      }
+    }
   });
 });


### PR DESCRIPTION
## What?

Applies '15-min block' error screens consistently when user exits journey and restarts across scenarios:

- [x] Restarting a journey having **entered** more than 5 incorrect SMS OTP codes during sign in
- [x] Restarting a journey having **entered** more than 5 incorrect email OTP codes during a password reset journey
- [ ] Restarting a journey having **requested** more than 5 SMS OTP codes 

### Screenshots

#### SMS OTP

<details open>

<summary>
Screen presented when a user first triggers the 15-min block due to entering more than 5 incorrect SMS OTP codes during signing in with SMS OTP code (2FA)
</summary>

<img width="601" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1d7fb8f0-7065-468f-ac72-ecda3522ce6a">

</details>

<details open>

<summary>
Screen presented if the user has restarted their journey while the lock is still in place. Screen is presented when they submit their password
</summary>

<img width="601" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/de81ba53-5b43-4594-90c2-b0259fef06fd">

</details>

#### Password reset

<details open>

<summary>
Screen presented when a user first triggers the 15-min block having entered more than 5 incorrect email OTP codes during a password reset journey
</summary>

<img width="601" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/585d83cc-cf7b-4415-a56b-f4174c0941ae">

</details>

<details open>

<summary>
Screen presented if the user has restarted their journey while the lock is still in place and clicked "I've forgotten my password"
</summary>

<img width="601" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/54f09fd1-3a7e-462b-9350-c9a2884d9e91">

</details>

#### Send phone OTP code again

<details open>

<summary>
Screen presented when a user first triggers the 15-min block due to requesting more than 5 SMS OTP codes during sign in
</summary>

<img width="601" alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/2dbb57d6-b709-473f-991e-49f2d355c236">

</details>

## Why?

Please include reason for the change and any other relevant context.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
