### PR TITLE
ATO-260: generate an orch->rp authcode after identity callback

### DIFF
--- a/src/components/auth-code/auth-code-controller.ts
+++ b/src/components/auth-code/auth-code-controller.ts
@@ -24,6 +24,7 @@ export function authCodeGet(
       req.session.client,
       req.session.user
     );
+    req.session.user.authCodeReturnToRP = false;
 
     if (!result.success) {
       throw new BadRequestError(result.data.message, result.data.code);

--- a/src/components/auth-code/auth-code-service.ts
+++ b/src/components/auth-code/auth-code-service.ts
@@ -23,7 +23,7 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
     clientSession: UserSessionClient,
     userSession: UserSession
   ): Promise<ApiResponseResult<AuthCodeResponse>> {
-    const baseUrl = supportAuthOrchSplit()
+    const baseUrl = shouldCallOrchAuthCode(userSession)
       ? getFrontendApiBaseUrl()
       : getApiBaseUrl();
     const config = getRequestConfig({
@@ -36,7 +36,7 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
 
     let response: AxiosResponse;
 
-    if (supportAuthOrchSplit()) {
+    if (shouldCallOrchAuthCode(userSession)) {
       const body = {
         claims: clientSession.claim,
         state: clientSession.state,
@@ -55,6 +55,10 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
 
     return createApiResponse<AuthCodeResponse>(response);
   };
+
+  function shouldCallOrchAuthCode(userSession: UserSession) {
+    return supportAuthOrchSplit() && !userSession.authCodeReturnToRP;
+  }
 
   return {
     getAuthCode,

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -96,6 +96,29 @@ describe("authentication auth code service", () => {
       expect(getStub.notCalled).to.be.true;
       expect(result.data.location).to.deep.eq(redirectUriReturnedFromResponse);
     });
+
+    it("should make a request for an RP auth code following the prove identity callback page", async () => {
+      process.env.SUPPORT_AUTH_ORCH_SPLIT = "1";
+
+      const result = await service.getAuthCode(
+        "sessionId",
+        "clientSessionId",
+        "sourceIp",
+        "persistentSessionId",
+        {},
+        { authCodeReturnToRP: true }
+      );
+
+      expect(
+        getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
+          headers: sinon.match.object,
+          baseURL: apiBaseUrl,
+          proxy: sinon.match.bool,
+        })
+      ).to.be.true;
+      expect(postStub.notCalled).to.be.true;
+      expect(result.data.location).to.deep.eq(redirectUriReturnedFromResponse);
+    });
   });
 
   describe("with auth orch split feature flag off", () => {

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -35,6 +35,8 @@ export function proveIdentityCallbackGet(
     let redirectPath;
 
     if (response.data.status === IdentityProcessingStatus.COMPLETED) {
+      req.session.user.authCodeReturnToRP = true;
+
       redirectPath = getNextPathAndUpdateJourney(
         req,
         req.path,

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface UserSession {
   isAccountRecoveryCodeResent?: boolean;
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
+  authCodeReturnToRP?: boolean;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Call the "old" auth code endpoint after prove identity callback

## Why?

To minimise the number of changes applied at the same time, the split will initially use the authentication identity callback page. To enable this, the auth code endpoint has been modified to generate an orch->rp authcode after identity proving instead of an auth-orch authcode.