### PR TITLE
AUT-2213: Rework login MFA skip functionality for MFA PW reset journey

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -538,10 +538,6 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
-              target: [PATH_NAMES.AUTH_CODE],
-              cond: "support2FABeforePasswordReset",
-            },
-            {
               target: [PATH_NAMES.GET_SECURITY_CODES],
               cond: "isAccountPartCreated",
             },

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { describe } from "mocha";
 import { getNextState, USER_JOURNEY_EVENTS } from "../state-machine";
-import { PATH_NAMES } from "../../../../app.constants";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../../app.constants";
 
 describe("state-machine", () => {
   describe("getNextState - login journey (2fa)", () => {
@@ -170,6 +170,69 @@ describe("state-machine", () => {
         { isAuthenticated: true }
       );
       expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
+    });
+  });
+
+  describe("getNextState - password reset", () => {
+    [
+      {
+        context: {
+          requiresTwoFactorAuth: true,
+          isMfaMethodVerified: false,
+          mfaMethodType: MFA_METHOD_TYPE.SMS,
+        },
+        destination: PATH_NAMES.GET_SECURITY_CODES,
+      },
+      {
+        context: {
+          requiresTwoFactorAuth: true,
+          mfaMethodType: MFA_METHOD_TYPE.SMS,
+          isLatestTermsAndConditionsAccepted: false,
+        },
+        destination: PATH_NAMES.ENTER_MFA,
+      },
+      {
+        context: {
+          requiresTwoFactorAuth: true,
+          mfaMethodType: MFA_METHOD_TYPE.AUTH_APP,
+          isLatestTermsAndConditionsAccepted: false,
+        },
+        destination: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+      },
+      {
+        context: {
+          requiresTwoFactorAuth: false,
+          isLatestTermsAndConditionsAccepted: false,
+        },
+        destination: PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS,
+      },
+      {
+        context: { requiresTwoFactorAuth: false, isMfaMethodVerified: false },
+        destination: PATH_NAMES.GET_SECURITY_CODES,
+      },
+      {
+        context: {
+          requiresTwoFactorAuth: false,
+          mfaMethodType: MFA_METHOD_TYPE.SMS,
+        },
+        destination: PATH_NAMES.AUTH_CODE,
+      },
+      {
+        context: {
+          requiresTwoFactorAuth: false,
+          mfaMethodType: MFA_METHOD_TYPE.AUTH_APP,
+        },
+        destination: PATH_NAMES.AUTH_CODE,
+      },
+    ].forEach((test) => {
+      it(`should move from ${PATH_NAMES.RESET_PASSWORD} to ${test.destination}`, () => {
+        const nextState = getNextState(
+          PATH_NAMES.RESET_PASSWORD,
+          USER_JOURNEY_EVENTS.PASSWORD_CREATED,
+          test.context
+        );
+        expect(nextState.value).to.equal(test.destination);
+      });
     });
   });
 });

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -141,12 +141,11 @@ export function resetPasswordPost(
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           isConsentRequired: req.session.user.isConsentRequired,
-          requiresTwoFactorAuth: true,
+          requiresTwoFactorAuth: !support2FABeforePasswordReset(),
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
-          support2FABeforePasswordReset: support2FABeforePasswordReset(),
         },
         res.locals.sessionId
       )


### PR DESCRIPTION
## What?

Functionality to skip subsequent paths from the reset password screen has been removed and instead MFA is instead disabled if MFA has previously been completed as part of the new journey.

## Why?

Current MFA PW reset functionality skipped login MFA after password reset as expected but it also skipped 