### PR TITLE
AUT-1553: Change error screens for new journeys with block in place

### DIFF
--- a/src/components/account-recovery/check-your-email-security-codes/send-email-otp-middleware.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/send-email-otp-middleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { sendNotificationService } from "../../common/send-notification/send-notification-service";
 import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../../app.constants";
-import { getErrorPathByCode } from "../../common/constants";
+import { ERROR_CODES, getErrorPathByCode } from "../../common/constants";
 import { BadRequestError } from "../../../utils/error";
 import xss from "xss";
 import { ExpressRouteFunc } from "../../../types";
@@ -31,6 +31,13 @@ export function sendEmailOtp(
 
     if (sendNotificationResponse.success) {
       return next();
+    }
+
+    if (
+      sendNotificationResponse.data?.code ===
+      ERROR_CODES.VERIFY_CHANGE_HOW_GET_SECURITY_CODES_CODE_REQUEST_BLOCKED
+    ) {
+      return res.render("security-code-error/index-wait.njk");
     }
 
     const path = sendNotificationResponse.data?.code

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -6,7 +6,10 @@ import {
   getNextPathAndUpdateJourney,
   pathWithQueryParam,
 } from "../common/constants";
-import { supportAccountRecovery } from "../../config";
+import {
+  getCodeEnteredWrongBlockDurationInMinutes,
+  supportAccountRecovery,
+} from "../../config";
 import { VerifyMfaCodeInterface } from "./types";
 import { AccountRecoveryInterface } from "../common/account-recovery/types";
 import { accountRecoveryService } from "../common/account-recovery/account-recovery-service";
@@ -129,6 +132,15 @@ export const enterAuthenticatorAppCodePost = (
           )
         );
         return renderBadRequest(res, req, template, error);
+      }
+
+      if (
+        result.data.code ===
+        ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED
+      ) {
+        req.session.user.wrongCodeEnteredLock = new Date(
+          Date.now() + getCodeEnteredWrongBlockDurationInMinutes() * 60000
+        ).toUTCString();
       }
 
       const path = getErrorPathByCode(result.data.code);

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -40,7 +40,7 @@ export function enterEmailPost(
 
     if (!result.success) {
       if (result.data.code === ERROR_CODES.ACCOUNT_LOCKED) {
-        return res.redirect(getErrorPathByCode(result.data.code));
+        return res.render("enter-password/index-sign-in-retry-blocked.njk");
       }
       throw new BadRequestError(result.data.message, result.data.code);
     }

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -144,7 +144,9 @@ describe("enter email controller", () => {
 
       await enterEmailPost(fakeService)(req as Request, res as Response);
 
-      expect(res.redirect).to.have.calledWith(PATH_NAMES.ACCOUNT_LOCKED);
+      expect(res.render).to.have.calledWith(
+        "enter-password/index-sign-in-retry-blocked.njk"
+      );
       expect(fakeService.userExists).to.have.been.calledOnce;
     });
   });

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -152,6 +152,16 @@ export function enterPasswordPost(
       );
 
       if (!result.success) {
+        if (result.data.code === ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED) {
+          return res.render("security-code-error/index-wait.njk");
+        }
+
+        if (result.data.code === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES) {
+          return res.render(
+            "security-code-error/index-security-code-entered-exceeded.njk"
+          );
+        }
+
         const path = getErrorPathByCode(result.data.code);
 
         if (path) {

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -64,10 +64,21 @@ export function resetPasswordCheckEmailGet(
         ERROR_CODES.ENTERED_INVALID_PASSWORD_RESET_CODE_MAX_TIMES,
       ].includes(result.data.code)
     ) {
-      const errorTemplate =
+      let errorTemplate: string;
+
+      if (
         result.data.code === ERROR_CODES.RESET_PASSWORD_LINK_MAX_RETRIES_REACHED
-          ? "security-code-error/index-too-many-requests.njk"
-          : "security-code-error/index-wait.njk";
+      ) {
+        errorTemplate = "security-code-error/index-too-many-requests.njk";
+      } else if (
+        result.data.code ===
+        ERROR_CODES.ENTERED_INVALID_PASSWORD_RESET_CODE_MAX_TIMES
+      ) {
+        errorTemplate =
+          "security-code-error/index-security-code-entered-exceeded.njk";
+      } else {
+        errorTemplate = "security-code-error/index-wait.njk";
+      }
 
       return res.render(errorTemplate);
     } else {


### PR DESCRIPTION
## What?

Applies '15-min block' error screens consistently when user exits journey and restarts across scenarios:

- [x] Restarting a journey having entered more than 5 incorrect SMS OTP codes during sign in
- [x] Restarting a journey having requested more than 5 SMS OTP codes during sign in
- [x] Restarting a journey having entered more than 5 incorrect email OTP codes during a password reset journey
- [x] Restarting a journey having entered their password incorrectly more than 5 times
- [x] Restarting a journey having entered more than 5 incorrect Authenticator App codes during sign in
- [x] Restarting a journey having requested more than 5 email OTP codes during a password reset journey
- [x] Restarting a journey having requested more than 5 email OTP codes during a 2FA reset journey

## Why?

So that the error screens are consistent across all scenarios when a user:

1. triggers a 15-min block error, and
2. then exits the journey and restarts it before the 15-min block has passed

## Screenshots

### Restarting a journey having entered more than 5 incorrect SMS OTP codes during sign in

The user first encounters this screen at the point they submit an incorrect SMS OTP for the 5th time.

<img  alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/59f70815-f9d9-4480-ba3b-98ac1327d252">

Restarting a journey while the block is still in place will result in this screen being shown when they submit their password.

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/fd233af8-2d69-408f-94b1-e14b6fb47b9b">

### Restarting a journey having requested more than 5 SMS OTP codes during sign in

The user first encounters this screen at the point they request the 5th SMS OTP code

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/bc2862db-b563-4732-a46d-387eeae3001e">

Restarting a journey while the block is still in place will result in this screen being shown at the point they submit their password

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/68a46bc5-e0bf-4f96-90d9-77d4e63df0c6">

### Restarting a journey having entered more than 5 incorrect email OTP codes during a password reset journey

The user first encounters this screen at the point they submit an incorrect email OTP for the 5th time. 

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/bb20e945-cc6b-4bd0-ae61-66ce3d2a0e4f">

Restarting a journey while the block is still in place and clicking "I've forgotten my password" will result in this screen being shown

<img  alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/11102940-03b9-40de-adb0-82d92eda423d">

### Restarting a journey having entered their password incorrectly more than 5 times

The user first encounters this screen at the point they enter the password incorrectly for the 5th time

<img  alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/0c0bee7b-dbc3-41da-9d70-2ea8f2e6e9a6">

Restarting a journey while the block is still in place, the user will be presented with this screen when they submit their email address

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/d94f6b43-ff9d-4ccf-a415-3b90fee6bbb8">

### Restarting a journey having entered more than 5 incorrect Authenticator App codes during sign in

The user first encounters this screen at the point they enter the code incorrectly for the 5th time

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/bf2d368f-14b3-4aec-8ef0-9591e7d942fb">

Restarting a journey while the block is still in place, the user will be presented with this screen when they attempt to enter the authenticator app code for the first time. 

![Screenshot 2024-01-10 at 10 47 44](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/d16487f7-7c21-4104-b806-10375c49746f)

### Restarting a journey having requested more than 5 email OTP codes during a password reset journey

The user first encounters this screen at the point they enter the code incorrectly for the 5th time 

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/0cc8183d-48eb-442d-abe5-098499ac4daa">

Restarting a journey while the block is still in place and clicking "I've forgotten my password" will result in this screen being shown

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/41e9b916-eeb2-4c00-86bd-155e185715b5">

### Restarting a journey having requested more than 5 email OTP codes during a 2FA reset journey

The user first encounters this screen at the point they enter the code incorrectly for the 5th time 

<img alt="" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/bd553d47-954b-4046-ba0e-6582f0c8a3f2">

Restarting a journey while the block is still in place and clicking "Change how you get security codes" will result in this screen being shown 

![Screenshot 2024-01-10 at 13 32 33](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/fd60f213-0547-4bcd-a93d-42b7868401c0)


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Demonstrated to QA

On 11 January, I ran through all the scenarios with QA. They are content for the change to be merged.
