### PR TITLE
AUT-1997: Setup Password Reset Enter Authenticator App Code flow

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -72,6 +72,7 @@ export const PATH_NAMES = {
   PASSWORD_RESET_REQUIRED: "/password-reset-required",
   UNAVAILABLE_PERMANENT: "/unavailable-permanent",
   UNAVAILABLE_TEMPORARY: "/unavailable-temporary",
+  RESET_PASSWORD_2FA_AUTH_APP: "/reset-password-2fa-auth-app",
 };
 
 export const HREF_BACK = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -89,6 +89,7 @@ import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-
 import { accountInterventionRouter } from "./components/account-intervention/password-reset-required/password-reset-required-router";
 import { permanentlyBlockedRouter } from "./components/account-intervention/permanently-blocked/permanently-blocked-router";
 import { temporarilyBlockedRouter } from "./components/account-intervention/temporarily-blocked/temporarily-blocked-router";
+import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -130,6 +131,7 @@ function registerRoutes(app: express.Application) {
   app.use(resetPasswordRouter);
   if (support2FABeforePasswordReset()) {
     app.use(resetPassword2FARouter);
+    app.use(resetPassword2FAAuthAppRouter);
   }
   app.use(upliftJourneyRouter);
   app.use(contactUsRouter);

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -507,7 +507,11 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.RESET_PASSWORD_CODE_VERIFIED]: [
             {
               target: [PATH_NAMES.RESET_PASSWORD_2FA_SMS],
-              cond: "support2FABeforePasswordReset",
+              cond: "requiresResetPasswordMFASmsCode",
+            },
+            {
+              target: [PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP],
+              cond: "requiresResetPasswordMFAAuthAppCode",
             },
             {
               target: [PATH_NAMES.RESET_PASSWORD],
@@ -516,6 +520,11 @@ const authStateMachine = createMachine(
         },
         meta: {
           optionalPaths: [PATH_NAMES.RESET_PASSWORD_RESEND_CODE],
+        },
+      },
+      [PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP]: {
+        on: {
+          [USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED]: [PATH_NAMES.RESET_PASSWORD],
         },
       },
       [PATH_NAMES.RESET_PASSWORD_2FA_SMS]: {
@@ -738,6 +747,12 @@ const authStateMachine = createMachine(
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.requiresTwoFactorAuth === true,
+      requiresResetPasswordMFAAuthAppCode: (context) =>
+        context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
+        context.support2FABeforePasswordReset === true,
+      requiresResetPasswordMFASmsCode: (context) =>
+        context.mfaMethodType === MFA_METHOD_TYPE.SMS &&
+        context.support2FABeforePasswordReset === true,
       isPasswordChangeRequired: (context) => context.isPasswordChangeRequired,
       isAccountRecoveryJourney: (context) => context.isAccountRecoveryJourney,
       support2FABeforePasswordReset: (context) =>

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -91,6 +91,7 @@ export function verifyCodePost(
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
           support2FABeforePasswordReset: support2FABeforePasswordReset(),
+          mfaMethodType: req.session.user.enterEmailMfaType,
         },
         res.locals.sessionId
       )

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -44,7 +44,7 @@ export function enterEmailPost(
       }
       throw new BadRequestError(result.data.message, result.data.code);
     }
-
+    req.session.user.enterEmailMfaType = result.data.mfaMethodType;
     const nextState = result.data.doesUserExist
       ? USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS
       : USER_JOURNEY_EVENTS.ACCOUNT_NOT_FOUND;

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -3,6 +3,7 @@ import { ApiResponseResult, DefaultApiResponse } from "../../types";
 export interface UserExists extends DefaultApiResponse {
   email: string;
   doesUserExist: boolean;
+  mfaMethodType: string;
 }
 
 export interface EnterEmailServiceInterface {

--- a/src/components/reset-password-2fa-auth-app/index.njk
+++ b/src/components/reset-password-2fa-auth-app/index.njk
@@ -1,0 +1,56 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set pageTitleName = 'pages.enterAuthenticatorAppCode.title' | translate %}
+
+{% block content %}
+
+  {% include "common/errors/errorSummary.njk" %}
+
+  <form id="form-tracking" action="/reset-password-2fa-auth-app" method="post" novalidate="novalidate">
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
+    <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
+
+    {{ govukInput({
+      label: {
+        text: 'pages.enterAuthenticatorAppCode.header' | translate,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+    classes: "govuk-input--width-10",
+    id: "code",
+    name: "code",
+    inputmode: "numeric",
+    spellcheck: false,
+    autocomplete:"one-time-code",
+    errorMessage: {
+      text: errors['code'].text
+    } if (errors['code'])})
+  }}
+
+    {{ govukButton({
+    "text": "general.continue.label" | translate,
+    "type": "Submit",
+    "preventDoubleClick": true
+  }) }}
+
+  </form>
+
+  {% if isAccountRecoveryPermitted === true %}
+    {% set detailsHTML %}
+      <p class="govuk-body">
+        {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
+        <a href="{{checkEmailLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+      </p>
+    {% endset %}
+
+    {{ govukDetails({
+      summaryText: 'pages.enterAuthenticatorAppCode.details.summary' | translate,
+      html: detailsHTML
+    }) }}
+  {% endif %}
+{% endblock %}

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -1,0 +1,71 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "src/types";
+import {
+  ERROR_CODES,
+  getErrorPathByCode,
+  getNextPathAndUpdateJourney,
+} from "../common/constants";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types";
+import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
+import { JOURNEY_TYPE, MFA_METHOD_TYPE } from "../../app.constants";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../utils/validation";
+import { BadRequestError } from "../../utils/error";
+
+const TEMPLATE_NAME = "reset-password-2fa-auth-app/index.njk";
+export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    res.render(TEMPLATE_NAME, {});
+  };
+}
+export function resetPassword2FAAuthAppPost(
+  service: VerifyMfaCodeInterface = verifyMfaCodeService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const result = await service.verifyMfaCode(
+      MFA_METHOD_TYPE.AUTH_APP,
+      req.body["code"],
+      sessionId,
+      clientSessionId,
+      req.ip,
+      persistentSessionId,
+      JOURNEY_TYPE.PASSWORD_RESET_MFA
+    );
+
+    if (!result.success) {
+      if (result.data.code === ERROR_CODES.AUTH_APP_INVALID_CODE) {
+        const error = formatValidationError(
+          "code",
+          req.t(
+            "pages.enterAuthenticatorAppCode.code.validationError.invalidCode"
+          )
+        );
+        return renderBadRequest(res, req, TEMPLATE_NAME, error);
+      }
+
+      const path = getErrorPathByCode(result.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
+      throw new BadRequestError(result.data.message, result.data.code);
+    }
+    return res.redirect(
+      getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
+        {
+          isIdentityRequired: req.session.user.isIdentityRequired,
+        },
+        res.locals.sessionId
+      )
+    );
+  };
+}

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
@@ -1,0 +1,27 @@
+import { PATH_NAMES } from "../../app.constants";
+import {
+  resetPassword2FAAuthAppGet,
+  resetPassword2FAAuthAppPost,
+} from "./reset-password-2fa-auth-app-controller";
+import * as express from "express";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { asyncHandler } from "../../utils/async";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resetPassword2FAAuthAppGet())
+);
+
+router.post(
+  PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resetPassword2FAAuthAppPost())
+);
+
+export { router as resetPassword2FAAuthAppRouter };

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { PATH_NAMES } from "../../../app.constants";
+import {
+  resetPassword2FAAuthAppGet,
+  resetPassword2FAAuthAppPost,
+} from "../reset-password-2fa-auth-app-controller";
+import { VerifyMfaCodeInterface } from "../../enter-authenticator-app-code/types";
+import { ERROR_CODES } from "../../common/constants";
+
+describe("reset password 2fa auth app controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+    res.locals.sessionId = "s-123456-djjad";
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("resetPassword2FAAuthAppGet", () => {
+    it("should render reset password auth app view", async () => {
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+
+      await resetPassword2FAAuthAppGet()(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "reset-password-2fa-auth-app/index.njk"
+      );
+    });
+  });
+
+  describe("resetPassword2FAAuthAppPost", () => {
+    it("should redirect to reset-password if code entered is correct and feature flag is turned on", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as VerifyMfaCodeInterface;
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.session.user.enterEmailMfaType = "AUTH-APP";
+      req.body.code = "123456";
+      req.session.id = "123456-djjad";
+
+      await resetPassword2FAAuthAppPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith("/reset-password");
+    });
+
+    it("should render check email page with errors if incorrect code entered", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          success: false,
+          data: {
+            code: ERROR_CODES.AUTH_APP_INVALID_CODE,
+          },
+        }),
+      } as unknown as VerifyMfaCodeInterface;
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.session.user.enterEmailMfaType = "AUTH-APP";
+      req.body.code = "123456";
+      req.session.id = "123456-djjad";
+
+      await resetPassword2FAAuthAppPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.calledWith(
+        "reset-password-2fa-auth-app/index.njk"
+      );
+    });
+  });
+});

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import * as cheerio from "cheerio";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import decache from "decache";
+import nock = require("nock");
+
+describe("Integration::2fa auth app (in reset password flow)", () => {
+  let app: any;
+  let baseApi: string;
+  let token: string | string[];
+  let cookies: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+          journey: {
+            nextPath: PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    nock(baseApi).persist().post("/mfa").reply(204);
+
+    request(app)
+      .get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return check auth app page", (done) => {
+    nock(baseApi).persist().post("/mfa").reply(204);
+    request(app).get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP).expect(200, done);
+  });
+
+  it("should redirect to reset password step when valid sms code is entered", (done) => {
+    nock(baseApi)
+      .persist()
+      .post(API_ENDPOINTS.VERIFY_MFA_CODE)
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    request(app)
+      .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_NAMES.RESET_PASSWORD)
+      .expect(302, done);
+  });
+});

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -1,0 +1,87 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import decache from "decache";
+
+import cheerio from "cheerio";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import nock = require("nock");
+
+describe("Integration::reset password check email ", () => {
+  let app: any;
+  let baseApi: string;
+  let token: string | string[];
+  let cookies: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+          journey: {
+            nextPath: PATH_NAMES.ENTER_PASSWORD,
+            optionalPaths: [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL],
+          },
+        };
+        req.session.user.enterEmailMfaType = "AUTH_APP";
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    nock(baseApi).post("/reset-password-request").once().reply(204);
+
+    request(app)
+      .get(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return reset password check email page", (done) => {
+    nock(baseApi).post("/reset-password-request").once().reply(204);
+    request(app).get("/reset-password-check-email").expect(200, done);
+  });
+
+  it("should redirect to /reset-password-2fa-auth-app if user's 2FA is set to AUTH_APP", (done) => {
+    nock(baseApi)
+      .persist()
+      .post(API_ENDPOINTS.VERIFY_CODE)
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    request(app)
+      .post("/reset-password-check-email")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .expect(302, done);
+  });
+});

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -93,6 +93,7 @@ describe("reset password check email controller", () => {
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
+      req.session.user.enterEmailMfaType = "SMS";
       req.body.code = "123456";
       req.session.id = "123456-djjad";
       await resetPasswordCheckEmailPost(fakeService)(
@@ -100,7 +101,32 @@ describe("reset password check email controller", () => {
         res as Response
       );
 
-      expect(res.redirect).to.have.calledWith("/reset-password-2fa-sms");
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.RESET_PASSWORD_2FA_SMS
+      );
+    });
+
+    it("should redirect to check_auth_app if code entered is correct and feature flag is turned on", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const fakeService: VerifyCodeInterface = {
+        verifyCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as VerifyCodeInterface;
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.session.user.enterEmailMfaType = "AUTH_APP";
+      req.body.code = "123456";
+      req.session.id = "123456-djjad";
+      await resetPasswordCheckEmailPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP
+      );
     });
 
     it("should render check email page with errors if incorrect code entered", async () => {

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -146,6 +146,7 @@ export function resetPasswordPost(
             req.session.user.isLatestTermsAndConditionsAccepted,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
+          support2FABeforePasswordReset: support2FABeforePasswordReset(),
         },
         res.locals.sessionId
       )

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export interface UserSession {
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
   authCodeReturnToRP?: boolean;
+  enterEmailMfaType?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Change the screen-flow to include the Enter Authenticator App Code 2FA step in password reset when the switch is on.

## Why?

The BAU flow for the password reset is: 1.Check-email 2.Reset-Password 3.MFA. The order needs to be changed as mentioned above.

