### PR TITLE
AUT-2228: Remove Temporary Suspension Brackets

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2255,7 +2255,7 @@
       },
       "section2": {
         "heading": "Beth allwch chi ei wneud",
-        "paragraph1": "Dewch yn ôl yn nes ymlaen. Dylai eich GOV.UK One Login fod ar gael eto mewn [3 diwrnod gwaith].",
+        "paragraph1": "Dewch yn ôl yn nes ymlaen. Dylai eich GOV.UK One Login fod ar gael eto mewn 3 diwrnod gwaith.",
         "paragraph2": "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK."
       }
     }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2255,7 +2255,7 @@
       },
       "section2": {
         "heading": "What you can do",
-        "paragraph1": "Come back later. Your GOV.UK  One Login should be available again in [3 working days].",
+        "paragraph1": "Come back later. Your GOV.UK  One Login should be available again in 3 working days.",
         "paragraph2": "You can also go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage."
       }
     }


### PR DESCRIPTION
## What?

Remove brackets around temporary suspension time.

## Why?

Brackets shouldn't be around the suspension duration.