### PR TITLE
Set up ‘Check your phone’ and 'Auth app' flows for Password Reset Required

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -72,6 +72,7 @@ export const PATH_NAMES = {
   PASSWORD_RESET_REQUIRED: "/password-reset-required",
   UNAVAILABLE_PERMANENT: "/unavailable-permanent",
   UNAVAILABLE_TEMPORARY: "/unavailable-temporary",
+  RESET_PASSWORD_2FA_AUTH_APP: "/reset-password-2fa-auth-app",
 };
 
 export const HREF_BACK = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -89,6 +89,7 @@ import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-
 import { accountInterventionRouter } from "./components/account-intervention/password-reset-required/password-reset-required-router";
 import { permanentlyBlockedRouter } from "./components/account-intervention/permanently-blocked/permanently-blocked-router";
 import { temporarilyBlockedRouter } from "./components/account-intervention/temporarily-blocked/temporarily-blocked-router";
+import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -130,6 +131,7 @@ function registerRoutes(app: express.Application) {
   app.use(resetPasswordRouter);
   if (support2FABeforePasswordReset()) {
     app.use(resetPassword2FARouter);
+    app.use(resetPassword2FAAuthAppRouter);
   }
   app.use(upliftJourneyRouter);
   app.use(contactUsRouter);

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -588,51 +588,7 @@ const authStateMachine = createMachine(
           ],
         },
       },
-      [PATH_NAMES.RESET_PASSWORD_REQUIRED]: {
-        on: {
-          [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
-            {
-              target: [PATH_NAMES.GET_SECURITY_CODES],
-              cond: "isAccountPartCreated",
-            },
-            {
-              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
-              cond: "requiresMFAAuthAppCode",
-            },
-            { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
-            {
-              target: [PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS],
-              cond: "isLatestTermsAndConditionsAccepted",
-            },
-            {
-              target: [PATH_NAMES.SHARE_INFO],
-              cond: "isConsentRequired",
-            },
-            { target: [PATH_NAMES.AUTH_CODE] },
-          ],
-        },
-        [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER]: {
-          on: {
-            [USER_JOURNEY_EVENTS.VERIFY_PHONE_NUMBER]: [
-              PATH_NAMES.CHECK_YOUR_PHONE,
-            ],
-          },
-          meta: {
-            optionalPaths: [
-              PATH_NAMES.SECURITY_CODE_WAIT,
-              PATH_NAMES.SECURITY_CODE_INVALID,
-              PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
-            ],
-          },
-        },
-        meta: {
-          optionalPaths: [
-            PATH_NAMES.ENTER_EMAIL_SIGN_IN,
-            PATH_NAMES.ACCOUNT_LOCKED,
-            PATH_NAMES.SIGN_IN_OR_CREATE,
-          ],
-        },
-      },
+      [PATH_NAMES.RESET_PASSWORD_REQUIRED]: {},
       [PATH_NAMES.PROVE_IDENTITY]: {
         on: {
           [USER_JOURNEY_EVENTS.PROVE_IDENTITY_INIT]: [

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -507,7 +507,11 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.RESET_PASSWORD_CODE_VERIFIED]: [
             {
               target: [PATH_NAMES.RESET_PASSWORD_2FA_SMS],
-              cond: "support2FABeforePasswordReset",
+              cond: "requiresResetPasswordMFASmsCode",
+            },
+            {
+              target: [PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP],
+              cond: "requiresResetPasswordMFAAuthAppCode",
             },
             {
               target: [PATH_NAMES.RESET_PASSWORD],
@@ -516,6 +520,11 @@ const authStateMachine = createMachine(
         },
         meta: {
           optionalPaths: [PATH_NAMES.RESET_PASSWORD_RESEND_CODE],
+        },
+      },
+      [PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP]: {
+        on: {
+          [USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED]: [PATH_NAMES.RESET_PASSWORD],
         },
       },
       [PATH_NAMES.RESET_PASSWORD_2FA_SMS]: {
@@ -738,6 +747,15 @@ const authStateMachine = createMachine(
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.requiresTwoFactorAuth === true,
+      requiresMFASmsCode: (context) =>
+        context.mfaMethodType === MFA_METHOD_TYPE.SMS &&
+        context.requiresTwoFactorAuth === true,
+      requiresResetPasswordMFAAuthAppCode: (context) =>
+        context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
+        context.support2FABeforePasswordReset === true,
+      requiresResetPasswordMFASmsCode: (context) =>
+        context.mfaMethodType === MFA_METHOD_TYPE.SMS &&
+        context.support2FABeforePasswordReset === true,
       isPasswordChangeRequired: (context) => context.isPasswordChangeRequired,
       isAccountRecoveryJourney: (context) => context.isAccountRecoveryJourney,
       support2FABeforePasswordReset: (context) =>

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -91,6 +91,7 @@ export function verifyCodePost(
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
           support2FABeforePasswordReset: support2FABeforePasswordReset(),
+          mfaMethodType: req.session.user.enterEmailMfaType,
         },
         res.locals.sessionId
       )

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -44,7 +44,7 @@ export function enterEmailPost(
       }
       throw new BadRequestError(result.data.message, result.data.code);
     }
-
+    req.session.user.enterEmailMfaType = result.data.mfaMethodType;
     const nextState = result.data.doesUserExist
       ? USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS
       : USER_JOURNEY_EVENTS.ACCOUNT_NOT_FOUND;

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -3,6 +3,7 @@ import { ApiResponseResult, DefaultApiResponse } from "../../types";
 export interface UserExists extends DefaultApiResponse {
   email: string;
   doesUserExist: boolean;
+  mfaMethodType: string;
 }
 
 export interface EnterEmailServiceInterface {

--- a/src/components/reset-password-2fa-auth-app/index.njk
+++ b/src/components/reset-password-2fa-auth-app/index.njk
@@ -1,0 +1,56 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set pageTitleName = 'pages.enterAuthenticatorAppCode.title' | translate %}
+
+{% block content %}
+
+  {% include "common/errors/errorSummary.njk" %}
+
+  <form id="form-tracking" action="/reset-password-2fa-auth-app" method="post" novalidate="novalidate">
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
+    <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
+
+    {{ govukInput({
+      label: {
+        text: 'pages.enterAuthenticatorAppCode.header' | translate,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+    classes: "govuk-input--width-10",
+    id: "code",
+    name: "code",
+    inputmode: "numeric",
+    spellcheck: false,
+    autocomplete:"one-time-code",
+    errorMessage: {
+      text: errors['code'].text
+    } if (errors['code'])})
+  }}
+
+    {{ govukButton({
+    "text": "general.continue.label" | translate,
+    "type": "Submit",
+    "preventDoubleClick": true
+  }) }}
+
+  </form>
+
+  {% if isAccountRecoveryPermitted === true %}
+    {% set detailsHTML %}
+      <p class="govuk-body">
+        {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
+        <a href="{{checkEmailLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+      </p>
+    {% endset %}
+
+    {{ govukDetails({
+      summaryText: 'pages.enterAuthenticatorAppCode.details.summary' | translate,
+      html: detailsHTML
+    }) }}
+  {% endif %}
+{% endblock %}

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "src/types";
+import {
+  ERROR_CODES,
+  getErrorPathByCode,
+  getNextPathAndUpdateJourney,
+} from "../common/constants";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types";
+import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
+import { JOURNEY_TYPE, MFA_METHOD_TYPE } from "../../app.constants";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../utils/validation";
+import { BadRequestError } from "../../utils/error";
+
+const TEMPLATE_NAME = "reset-password-2fa-auth-app/index.njk";
+export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    res.render(TEMPLATE_NAME, {});
+  };
+}
+export function resetPassword2FAAuthAppPost(
+  service: VerifyMfaCodeInterface = verifyMfaCodeService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const result = await service.verifyMfaCode(
+      MFA_METHOD_TYPE.AUTH_APP,
+      req.body["code"],
+      sessionId,
+      clientSessionId,
+      req.ip,
+      persistentSessionId,
+      JOURNEY_TYPE.PASSWORD_RESET_MFA,
+      "false"
+    );
+
+    if (!result.success) {
+      if (result.data.code === ERROR_CODES.AUTH_APP_INVALID_CODE) {
+        const error = formatValidationError(
+          "code",
+          req.t(
+            "pages.enterAuthenticatorAppCode.code.validationError.invalidCode"
+          )
+        );
+        return renderBadRequest(res, req, TEMPLATE_NAME, error);
+      }
+
+      const path = getErrorPathByCode(result.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
+      throw new BadRequestError(result.data.message, result.data.code);
+    }
+    return res.redirect(
+      getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
+        {
+          isIdentityRequired: req.session.user.isIdentityRequired,
+          isAccountRecoveryJourney: true,
+        },
+        res.locals.sessionId
+      )
+    );
+  };
+}

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
@@ -1,0 +1,27 @@
+import { PATH_NAMES } from "../../app.constants";
+import {
+  resetPassword2FAAuthAppGet,
+  resetPassword2FAAuthAppPost,
+} from "./reset-password-2fa-auth-app-controller";
+import * as express from "express";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { asyncHandler } from "../../utils/async";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resetPassword2FAAuthAppGet())
+);
+
+router.post(
+  PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resetPassword2FAAuthAppPost())
+);
+
+export { router as resetPassword2FAAuthAppRouter };

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { PATH_NAMES } from "../../../app.constants";
+import {
+  resetPassword2FAAuthAppGet,
+  resetPassword2FAAuthAppPost,
+} from "../reset-password-2fa-auth-app-controller";
+import { VerifyMfaCodeInterface } from "../../enter-authenticator-app-code/types";
+import { ERROR_CODES } from "../../common/constants";
+
+describe("reset password 2fa auth app controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+    res.locals.sessionId = "s-123456-djjad";
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("resetPassword2FAAuthAppGet", () => {
+    it("should render reset password auth app view", async () => {
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+
+      await resetPassword2FAAuthAppGet()(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "reset-password-2fa-auth-app/index.njk"
+      );
+    });
+  });
+
+  describe("resetPassword2FAAuthAppPost", () => {
+    it("should redirect to reset-password if code entered is correct and feature flag is turned on", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as VerifyMfaCodeInterface;
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.session.user.enterEmailMfaType = "AUTH-APP";
+      req.body.code = "123456";
+      req.session.id = "123456-djjad";
+
+      await resetPassword2FAAuthAppPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith("/reset-password");
+    });
+
+    it("should render check email page with errors if incorrect code entered", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          success: false,
+          data: {
+            code: ERROR_CODES.AUTH_APP_INVALID_CODE,
+          },
+        }),
+      } as unknown as VerifyMfaCodeInterface;
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.session.user.enterEmailMfaType = "AUTH-APP";
+      req.body.code = "123456";
+      req.session.id = "123456-djjad";
+
+      await resetPassword2FAAuthAppPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.calledWith(
+        "reset-password-2fa-auth-app/index.njk"
+      );
+    });
+  });
+});

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import * as cheerio from "cheerio";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import decache from "decache";
+import nock = require("nock");
+
+describe("Integration::2fa auth app (in reset password flow)", () => {
+  let app: any;
+  let baseApi: string;
+  let token: string | string[];
+  let cookies: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+          journey: {
+            nextPath: PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    nock(baseApi).persist().post("/mfa").reply(204);
+
+    request(app)
+      .get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return check auth app page", (done) => {
+    nock(baseApi).persist().post("/mfa").reply(204);
+    request(app).get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP).expect(200, done);
+  });
+
+  it("should redirect to reset password step when valid sms code is entered", (done) => {
+    nock(baseApi)
+      .persist()
+      .post(API_ENDPOINTS.VERIFY_MFA_CODE)
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    request(app)
+      .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_NAMES.RESET_PASSWORD)
+      .expect(302, done);
+  });
+});

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -1,0 +1,87 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import decache from "decache";
+
+import cheerio from "cheerio";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import nock = require("nock");
+
+describe("Integration::reset password check email ", () => {
+  let app: any;
+  let baseApi: string;
+  let token: string | string[];
+  let cookies: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+          journey: {
+            nextPath: PATH_NAMES.ENTER_PASSWORD,
+            optionalPaths: [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL],
+          },
+        };
+        req.session.user.enterEmailMfaType = "AUTH_APP";
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    nock(baseApi).post("/reset-password-request").once().reply(204);
+
+    request(app)
+      .get(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return reset password check email page", (done) => {
+    nock(baseApi).post("/reset-password-request").once().reply(204);
+    request(app).get("/reset-password-check-email").expect(200, done);
+  });
+
+  it("should redirect to /reset-password-2fa-auth-app if user's 2FA is set to AUTH_APP", (done) => {
+    nock(baseApi)
+      .persist()
+      .post(API_ENDPOINTS.VERIFY_CODE)
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    request(app)
+      .post("/reset-password-check-email")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .expect(302, done);
+  });
+});

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -93,6 +93,7 @@ describe("reset password check email controller", () => {
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
+      req.session.user.enterEmailMfaType = "SMS";
       req.body.code = "123456";
       req.session.id = "123456-djjad";
       await resetPasswordCheckEmailPost(fakeService)(

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -146,6 +146,7 @@ export function resetPasswordPost(
             req.session.user.isLatestTermsAndConditionsAccepted,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
+          support2FABeforePasswordReset: support2FABeforePasswordReset(),
         },
         res.locals.sessionId
       )

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -79,59 +79,67 @@ export function resetPasswordPost(
         );
       }
     }
-
-    const loginResponse = await loginService.loginUser(
-      sessionId,
-      email,
-      newPassword,
-      clientSessionId,
-      req.ip,
-      persistentSessionId
-    );
-
-    if (!loginResponse.success) {
-      throw new BadRequestError(
-        loginResponse.data.message,
-        loginResponse.data.code
-      );
-    }
-
-    req.session.user.redactedPhoneNumber =
-      loginResponse.data.redactedPhoneNumber;
-    req.session.user.isConsentRequired = loginResponse.data.consentRequired;
-    req.session.user.isLatestTermsAndConditionsAccepted =
-      loginResponse.data.latestTermsAndConditionsAccepted;
-    req.session.user.isAccountPartCreated =
-      !loginResponse.data.mfaMethodVerified;
-    if (req.session.user.isPasswordChangeRequired) {
-      req.session.user.isPasswordChangeRequired = false;
-    }
-
-    if (
-      !support2FABeforePasswordReset() &&
-      loginResponse.data.mfaMethodVerified &&
-      loginResponse.data.mfaMethodType === MFA_METHOD_TYPE.SMS
-    ) {
-      const mfaResponse = await mfaCodeService.sendMfaCode(
+    let mfaMethodType;
+    let isMfaMethodVerified;
+    if (support2FABeforePasswordReset && req.session.user.isAuthenticated) {
+      mfaMethodType = req.session.user.accountRecoveryVerifiedMfaType;
+      isMfaMethodVerified = !req.session.user.isAccountPartCreated;
+    } else {
+      const loginResponse = await loginService.loginUser(
         sessionId,
-        clientSessionId,
         email,
+        newPassword,
+        clientSessionId,
         req.ip,
-        persistentSessionId,
-        false,
-        xss(req.cookies.lng as string)
+        persistentSessionId
       );
 
-      if (!mfaResponse.success) {
-        const path = getErrorPathByCode(mfaResponse.data.code);
-        if (path) {
-          return res.redirect(path);
-        }
+      if (!loginResponse.success) {
         throw new BadRequestError(
-          mfaResponse.data.message,
-          mfaResponse.data.code
+          loginResponse.data.message,
+          loginResponse.data.code
         );
       }
+
+      req.session.user.redactedPhoneNumber =
+        loginResponse.data.redactedPhoneNumber;
+      req.session.user.isConsentRequired = loginResponse.data.consentRequired;
+      req.session.user.isLatestTermsAndConditionsAccepted =
+        loginResponse.data.latestTermsAndConditionsAccepted;
+      req.session.user.isAccountPartCreated =
+        !loginResponse.data.mfaMethodVerified;
+      if (req.session.user.isPasswordChangeRequired) {
+        req.session.user.isPasswordChangeRequired = false;
+      }
+
+      if (
+        !support2FABeforePasswordReset() &&
+        loginResponse.data.mfaMethodVerified &&
+        loginResponse.data.mfaMethodType === MFA_METHOD_TYPE.SMS
+      ) {
+        const mfaResponse = await mfaCodeService.sendMfaCode(
+          sessionId,
+          clientSessionId,
+          email,
+          req.ip,
+          persistentSessionId,
+          false,
+          xss(req.cookies.lng as string)
+        );
+
+        if (!mfaResponse.success) {
+          const path = getErrorPathByCode(mfaResponse.data.code);
+          if (path) {
+            return res.redirect(path);
+          }
+          throw new BadRequestError(
+            mfaResponse.data.message,
+            mfaResponse.data.code
+          );
+        }
+      }
+      mfaMethodType = loginResponse.data.mfaMethodType;
+      isMfaMethodVerified = loginResponse.data.mfaMethodVerified;
     }
 
     return res.redirect(
@@ -144,8 +152,8 @@ export function resetPasswordPost(
           requiresTwoFactorAuth: !support2FABeforePasswordReset(),
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
-          mfaMethodType: loginResponse.data.mfaMethodType,
-          isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
+          mfaMethodType: mfaMethodType,
+          isMfaMethodVerified: isMfaMethodVerified,
           support2FABeforePasswordReset: support2FABeforePasswordReset(),
         },
         res.locals.sessionId

--- a/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
@@ -1,0 +1,227 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { expect, sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import * as cheerio from "cheerio";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../app.constants";
+import decache from "decache";
+
+describe("Integration::reset password (in 2FA Before Reset Password flow)", () => {
+  let token: string | string[];
+  let cookies: string;
+  let app: any;
+  let baseApi: string;
+
+  const ENDPOINT = "/reset-password";
+
+  before(async () => {
+    process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "7867",
+          journey: {
+            nextPath: PATH_NAMES.RESET_PASSWORD,
+          },
+          isAuthenticated: true,
+          isAccountPartCreated: false,
+          accountRecoveryVerifiedMfaType: MFA_METHOD_TYPE.SMS,
+        };
+
+        next();
+      });
+    app = await require("../../../app").createApp();
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    request(app)
+      .get(ENDPOINT)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return reset password page", (done) => {
+    request(app).get(ENDPOINT).expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .send({
+        password: "password",
+      })
+      .expect(500, done);
+  });
+
+  it("should return validation error when password not entered", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "",
+        "confirm-password": "",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains("Enter your password");
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when passwords don't match", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "sadsadasd33da",
+        "confirm-password": "sdnnsad99d",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#confirm-password-error").text()).to.contains(
+          "Enter the same password in both fields"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when password less than 8 characters", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "dad",
+        "confirm-password": "",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Your password must be at least 8 characters long and must include letters and numbers"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when password is amongst most common passwords", (done) => {
+    nock(baseApi).post("/reset-password").once().reply(400, { code: 1040 });
+
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "password123",
+        "confirm-password": "password123",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return error when new password is the same as existing password", (done) => {
+    nock(baseApi).post("/reset-password").once().reply(400, { code: 1024 });
+
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "p@ssw0rd-123",
+        "confirm-password": "p@ssw0rd-123",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "You are already using that password. Enter a different password"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when no numbers present in password", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "testpassword",
+        "confirm-password": "testpassword",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Your password must be at least 8 characters long and must include letters and numbers"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when password all numeric", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "222222222222222",
+        "confirm-password": "222222222222222",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Your password must be at least 8 characters long and must include letters and numbers"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should redirect to /auth-code when valid password entered", (done) => {
+    nock(baseApi).post("/reset-password").once().reply(204);
+    nock(baseApi).post("/login").once().reply(200);
+    nock(baseApi).post("/mfa").once().reply(204);
+
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "Testpassword1",
+        "confirm-password": "Testpassword1",
+      })
+      .expect("Location", PATH_NAMES.AUTH_CODE)
+      .expect(302, done);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,7 @@ export interface UserSession {
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
   authCodeReturnToRP?: boolean;
+  enterEmailMfaType?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Due to the way we have completed the MFA password update journey and the way forced password reset routing works, only the password update controller required updating to handle a forced password reset journey.

## Why?

We needed to add MFA to the forced password reset journey caused by the user using a weak password during login.
At some point we used routes to route the user to existing password reset functionality despite there being a state machine flow for the forced password reset journey, this made the MFA journey change a lot more simple once the difference from normal flow was understood.

related links:
[SMS journey](https://govukverify.atlassian.net/browse/AUT-2032)
[Auth App journey](https://govukverify.atlassian.net/browse/AUT-2033)