### PR TITLE
AUT-2241: Scale ECS staging up and out

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -3,10 +3,10 @@ common_state_bucket = "di-auth-staging-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
 frontend_auto_scaling_v2_enabled                                    = true
-frontend_task_definition_cpu                                        = 512
-frontend_task_definition_memory                                     = 1024
+frontend_task_definition_cpu                                        = 1024
+frontend_task_definition_memory                                     = 2048
 frontend_auto_scaling_min_count                                     = 3
-frontend_auto_scaling_max_count                                     = 12
+frontend_auto_scaling_max_count                                     = 30
 ecs_desired_count                                                   = 3
 support_welsh_language_in_support_forms                             = "1"
 support_language_cy                                                 = "1"


### PR DESCRIPTION
## What?

Scale ECS staging up and out.
Doubling both cpu and memory, more than doubling max number of tasks to 30.  IPV has max of 60 but will retest with 30 first to see.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size

Applies to staging only.

## Why?

Performance test achieved 8 tps vs target of 30 tps. Could not scale beyond 12 tasks.

## Related PRs

#1288 