### PR TITLE
AUT-1712: Remove the translateEnOnly nunjucks filter

### DIFF
--- a/src/components/contact-us/common-english-only/errors/errorSummary.njk
+++ b/src/components/contact-us/common-english-only/errors/errorSummary.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {{ govukErrorSummary({
-titleText: 'general.errorSummaryTitle' | translateEnOnly,
+titleText: 'general.errorSummaryTitle' | translate,
 errorList: errorList
 }) if (errorList) }}

--- a/src/components/contact-us/common-english-only/layout/banner.njk
+++ b/src/components/contact-us/common-english-only/layout/banner.njk
@@ -1,35 +1,35 @@
 {% set html %}
-<p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph1' | translateEnOnly }}</p>
-<p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph2' | translateEnOnly }}</p>
+<p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph1' | translate }}</p>
+<p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set acceptHtml %}
-  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translateEnOnly }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translateEnOnly }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translateEnOnly }}</p>
+  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set rejectedHtml %}
-  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translateEnOnly }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translateEnOnly }}</a> {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translateEnOnly }}</p>
+  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
 {% endset %}
 
 {{ govukCookieBanner({
-  ariaLabel: 'general.cookie.cookieBanner.title' | translateEnOnly,
+  ariaLabel: 'general.cookie.cookieBanner.title' | translate,
   name: "gov-uk-cookie-banner",
   messages: [
     {
-      headingText: 'general.cookie.cookieBanner.heading' | translateEnOnly,
+      headingText: 'general.cookie.cookieBanner.heading' | translate,
       html: html,
       attributes: {
                   "id": "cookies-banner-main"
                 },
       actions: [
         {
-          text: 'general.cookie.cookieBanner.buttonAcceptText' | translateEnOnly,
+          text: 'general.cookie.cookieBanner.buttonAcceptText' | translate,
           type: "button",
           name: "cookiesAccept",
           value: "accept"
         },
         {
-          text: 'general.cookie.cookieBanner.buttonRejectText' | translateEnOnly,
+          text: 'general.cookie.cookieBanner.buttonRejectText' | translate,
           type: "button",
           name: "cookiesReject",
           value: "reject"
@@ -47,12 +47,12 @@
       },
       actions: [
         {
-          text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translateEnOnly,
+          text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translate,
           href: "#",
           type: "button",
           classes:"cookie-hide-button",
           attributes: {
-            "aria-label": 'general.cookie.cookieBanner.cookieBannerHideLink' | translateEnOnly
+            "aria-label": 'general.cookie.cookieBanner.cookieBannerHideLink' | translate
           }
         }
       ],
@@ -65,12 +65,12 @@
       },
       actions: [
         {
-          text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translateEnOnly,
+          text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translate,
           href: "#",
           type: "button",
           classes:"cookie-hide-button",
           attributes: {
-            "aria-label": 'general.cookie.cookieBanner.cookieBannerHideLink' | translateEnOnly
+            "aria-label": 'general.cookie.cookieBanner.cookieBannerHideLink' | translate
           }
         }
       ],

--- a/src/components/contact-us/common-english-only/layout/base.njk
+++ b/src/components/contact-us/common-english-only/layout/base.njk
@@ -26,14 +26,14 @@
 
 {% block pageTitle %}
     {% if error or errors %}
-        {{ 'general.errorTitlePrefix' | translateEnOnly }}
+        {{ 'general.errorTitlePrefix' | translate }}
         -
     {% endif %}
     {% if pageTitleName %}
         {{ pageTitleName }}
         -
     {% endif %}
-    {{ 'general.serviceNameTitle' | translateEnOnly }}
+    {{ 'general.serviceNameTitle' | translate }}
 {% endblock %}
 
 {% block bodyStart %}
@@ -42,26 +42,26 @@
 
 {% block header %}
   {{ govukHeader({
-  homepageUrl: 'general.header.homepageHref' | translateEnOnly
+  homepageUrl: 'general.header.homepageHref' | translate
 }) }}
 {% endblock %}
 
 {% set phaseBannerText %}
-    {{ 'general.phaseBanner.message.start' | translateEnOnly }} <a href="{{ contactUsLinkUrl }}" class="govuk-link" rel="noopener" target="_blank">{{ 'general.phaseBanner.message.linkText' | translateEnOnly }}</a> {{ 'general.phaseBanner.message.end' | translateEnOnly }}
+    {{ 'general.phaseBanner.message.start' | translate }} <a href="{{ contactUsLinkUrl }}" class="govuk-link" rel="noopener" target="_blank">{{ 'general.phaseBanner.message.linkText' | translate }}</a> {{ 'general.phaseBanner.message.end' | translate }}
 {% endset %}
 
 {% block main %}
       <div class="govuk-width-container {{ containerClasses }}">
         {{ govukPhaseBanner({
           tag: {
-            text: 'general.phaseBanner.tag' | translateEnOnly
+            text: 'general.phaseBanner.tag' | translate
           },
-          html: phaseBannerText | translateEnOnly
+          html: phaseBannerText | translate
         }) }}
 	      {% block beforeContent %}{% endblock %}
 	      {% if showBack %}
 	        {{ govukBackLink({
-                text: "general.back" | translateEnOnly,
+                text: "general.back" | translate,
                 href: hrefBack
             }) }}
           {% endif %}
@@ -81,32 +81,32 @@
         items: [
           {
             href: "/accessibility-statement",
-            text: 'general.footer.accessibilityStatement.linkText' | translateEnOnly
+            text: 'general.footer.accessibilityStatement.linkText' | translate
           },
           {
             href: "/cookies",
-            text: 'general.footer.cookies.linkText' | translateEnOnly
+            text: 'general.footer.cookies.linkText' | translate
           },
           {
             href: "/terms-and-conditions",
-            text: 'general.footer.terms.linkText' | translateEnOnly
+            text: 'general.footer.terms.linkText' | translate
           },
           {
               href: "/privacy-notice",
-              text: 'general.footer.privacy.linkText' | translateEnOnly
+              text: 'general.footer.privacy.linkText' | translate
           },
           {
               href: contactUsLinkUrl,
               attributes: {target: "_blank"},
-              text: 'general.footer.support.linkText' | translateEnOnly
+              text: 'general.footer.support.linkText' | translate
           }
         ]
       },
       contentLicence: {
-        text: 'general.footer.contentLicence.linkText' | translateEnOnly | safe
+        text: 'general.footer.contentLicence.linkText' | translate | safe
       },
       copyright: {
-        text: 'general.footer.copyright.linkText' | translateEnOnly
+        text: 'general.footer.copyright.linkText' | translate
       }
     }) }}
     {% endblock %}

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsFurtherInformation.accountCreation.header' | translateEnOnly }}
+  {{ 'pages.contactUsFurtherInformation.accountCreation.header' | translate }}
 </h1>
 
 <form action="/contact-us-further-information" method="post" novalidate>
@@ -14,27 +14,27 @@
         {% set items = [
                 {
                     value: "no_security_code",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio1' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio1' | translate
                 },
                 {
                     value: "invalid_security_code",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translate
                 },
                 {
                     value: "sign_in_phone_number_issue",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translate
                 },
                 {
                     value: "authenticator_app_problem",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio6' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio6' | translate
                 },
                 {
                     value: "technical_error",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio4' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio4' | translate
                 },
                 {
                     value: "something_else",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio5' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio5' | translate
                 }
             ]
         %}
@@ -43,7 +43,7 @@
         name: "subtheme",
         fieldset: {
             legend: {
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.header' | translateEnOnly,
+                text: 'pages.contactUsFurtherInformation.accountCreation.section1.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }
@@ -56,7 +56,7 @@
 
 
 {{ govukButton({
-    "text": "general.continue.label" | translateEnOnly,
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsFurtherInformation.idCheckApp.header' | translateEnOnly }}
+  {{ 'pages.contactUsFurtherInformation.idCheckApp.header' | translate }}
 </h1>
 
 <form action="/contact-us-further-information" method="post" novalidate>
@@ -13,23 +13,23 @@
         {% set items = [
                 {
                     value: "linking_problem",
-                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.linkingProblem' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.linkingProblem' | translate
                 },
                 {
                     value: "taking_photo_of_id_problem",
-                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.photoProblem' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.photoProblem' | translate
                 },
                 {
                     value: "face_scanning_problem",
-                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.faceScanningProblem' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.faceScanningProblem' | translate
                 },
                 {
                     value: "id_check_app_technical_problem",
-                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.technicalError' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.technicalError' | translate
                 },
                 {
                     value: "id_check_app_something_else",
-                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.somethingElse' | translateEnOnly
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.somethingElse' | translate
                 }
             ]
         %}
@@ -38,7 +38,7 @@
         name: "subtheme",
         fieldset: {
             legend: {
-                text: 'pages.contactUsFurtherInformation.idCheckApp.section1.header' | translateEnOnly,
+                text: 'pages.contactUsFurtherInformation.idCheckApp.section1.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }
@@ -51,7 +51,7 @@
 
 
 {{ govukButton({
-    "text": "general.continue.label" | translateEnOnly,
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/further-information/_proving-identity-post-office-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-post-office-further-information.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ "pages.contactUsFurtherInformation.provingIdentityFaceToFace.header" | translateEnOnly }}
+    {{ "pages.contactUsFurtherInformation.provingIdentityFaceToFace.header" | translate }}
 </h1>
 
 <form action="/contact-us-further-information" method="post" novalidate>
@@ -15,7 +15,7 @@
         name: "subtheme",
         fieldset: {
             legend: {
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.header" | translateEnOnly,
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.header" | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }
@@ -23,31 +23,31 @@
         items: [
             {
                 value: "face_to_face_details",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemEnteringDetails" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemEnteringDetails" | translate
             },
             {
                 value: "face_to_face_letter",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemPostOfficeLetter" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemPostOfficeLetter" | translate
             },
             {
                 value: "face_to_face_post_office",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemAtPostOffice" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemAtPostOffice" | translate
             },
             {
                 value: "face_to_face_post_office_id_results",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemFindingResult" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemFindingResult" | translate
             },
             {
                 value: "face_to_face_post_office_service",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemContinuing" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.problemContinuing" | translate
             },
             {
                 value: "face_to_face_technical_problem",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.technicalProblem" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.technicalProblem" | translate
             },
             {
                 value: "face_to_face_something_else",
-                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.anotherProblem" | translateEnOnly
+                text: "pages.contactUsFurtherInformation.provingIdentityFaceToFace.section1.anotherProblem" | translate
             }
         ],
         errorMessage: {
@@ -57,7 +57,7 @@
 
 
     {{ govukButton({
-        "text": "general.continue.label" | translateEnOnly,
+        "text": "general.continue.label" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/further-information/_signing-in-further-information.njk
+++ b/src/components/contact-us/further-information/_signing-in-further-information.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsFurtherInformation.signingIn.header' | translateEnOnly }}
+  {{ 'pages.contactUsFurtherInformation.signingIn.header' | translate }}
 </h1>
 
 <form action="/contact-us-further-information" method="post" novalidate>
@@ -15,7 +15,7 @@
         name: "subtheme",
         fieldset: {
             legend: {
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.header' | translateEnOnly,
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }
@@ -23,31 +23,31 @@
         items: [
             {
                 value: "no_security_code",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio1' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio1' | translate
             },
             {
                 value: "invalid_security_code",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio2' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio2' | translate
             },
             {
                 value: "forgotten_password",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio4' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio4' | translate
             },
             {
                 value: "no_phone_number_access",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio3' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio3' | translate
             },
             {
                 value: "account_not_found",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio5' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio5' | translate
             },
             {
                 value: "technical_error",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio6' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio6' | translate
             },
             {
                 value: "something_else",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio7' | translateEnOnly
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio7' | translate
             }
         ],
           errorMessage: {
@@ -57,7 +57,7 @@
 
 
 {{ govukButton({
-    "text": "general.continue.label" | translateEnOnly,
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/further-information/index.njk
+++ b/src/components/contact-us/further-information/index.njk
@@ -1,4 +1,4 @@
-{% extends "contact-us/common-english-only/layout/base.njk" %}
+{% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
@@ -8,23 +8,23 @@
 {% set showBack = true %}
 
 {% if theme == 'signing_in' %}
-    {% set pageTitleName = 'pages.contactUsFurtherInformation.signingIn.title' | translateEnOnly %}
+    {% set pageTitleName = 'pages.contactUsFurtherInformation.signingIn.title' | translate %}
 {% endif %}
 
 {% if theme == 'account_creation' %}
-    {% set pageTitleName = 'pages.contactUsFurtherInformation.accountCreation.title' | translateEnOnly %}
+    {% set pageTitleName = 'pages.contactUsFurtherInformation.accountCreation.title' | translate %}
 {% endif %}
 
 {% if theme == 'id_check_app' %}
-    {% set pageTitleName = 'pages.contactUsFurtherInformation.idCheckApp.title' | translateEnOnly %}
+    {% set pageTitleName = 'pages.contactUsFurtherInformation.idCheckApp.title' | translate %}
 {% endif %}
 
 {% if theme == 'id_face_to_face' %}
-    {% set pageTitleName = 'pages.contactUsFurtherInformation.provingIdentityFaceToFace.title' | translateEnOnly %}
+    {% set pageTitleName = 'pages.contactUsFurtherInformation.provingIdentityFaceToFace.title' | translate %}
 {% endif %}
 
 {% block content %}
-{% include "contact-us/common-english-only/errors/errorSummary.njk" %}
+{% include "common/errors/errorSummary.njk" %}
 
     {% if theme == 'signing_in' %}
         {% include 'contact-us/further-information/_signing-in-further-information.njk' %}

--- a/src/components/contact-us/index-gov-service-contact-us.njk
+++ b/src/components/contact-us/index-gov-service-contact-us.njk
@@ -1,36 +1,36 @@
-{% extends "contact-us/common-english-only/layout/base.njk" %}
+{% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% set showBack = true %}
 {% set hrefBack = 'support' %}
-{% set pageTitleName = 'pages.contactUsGov.title' | translateEnOnly  %}
+{% set pageTitleName = 'pages.contactUsGov.title' | translate  %}
 
 {% block content %}
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsGov.header' | translateEnOnly  }}
+  {{ 'pages.contactUsGov.header' | translate  }}
 </h1>
 
-<p class="govuk-body">{{'pages.contactUsGov.paragraph1' | translateEnOnly  }}</p>
+<p class="govuk-body">{{'pages.contactUsGov.paragraph1' | translate  }}</p>
 <ul class="govuk-list govuk-list--bullet">
  <li>
-    <a href="{{'pages.contactUsGov.bulletPoint1.linkHref' | translateEnOnly }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-        {{'pages.contactUsGov.bulletPoint1.linkText' | translateEnOnly }}
+    <a href="{{'pages.contactUsGov.bulletPoint1.linkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
+        {{'pages.contactUsGov.bulletPoint1.linkText' | translate }}
     </a>
-    {{ 'pages.contactUsGov.bulletPoint1.text' | translateEnOnly }}</li>
+    {{ 'pages.contactUsGov.bulletPoint1.text' | translate }}</li>
  <li>
-    <a href="{{'pages.contactUsGov.bulletPoint2.linkHref' | translateEnOnly }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-        {{'pages.contactUsGov.bulletPoint2.linkText' | translateEnOnly }}
+    <a href="{{'pages.contactUsGov.bulletPoint2.linkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
+        {{'pages.contactUsGov.bulletPoint2.linkText' | translate }}
     </a>
-    {{ 'pages.contactUsGov.bulletPoint2.text' | translateEnOnly }}</li>
+    {{ 'pages.contactUsGov.bulletPoint2.text' | translate }}</li>
  </li>
 </ul>
 
 <p class="govuk-body">
-    {{'pages.contactUsGov.paragraph2.text' | translateEnOnly  }}
-    <a href="{{'pages.contactUsGov.paragraph2.linkHref' | translateEnOnly }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-        {{'pages.contactUsGov.paragraph2.linkText' | translateEnOnly }}
+    {{'pages.contactUsGov.paragraph2.text' | translate  }}
+    <a href="{{'pages.contactUsGov.paragraph2.linkHref' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
+        {{'pages.contactUsGov.paragraph2.linkText' | translate }}
     </a>
 </p>
 

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -1,4 +1,4 @@
-{% extends "contact-us/common-english-only/layout/base.njk" %}
+{% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
@@ -6,28 +6,28 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}
-{% set pageTitleName = 'pages.contactUsPublic.title' | translateEnOnly %}
+{% set pageTitleName = 'pages.contactUsPublic.title' | translate %}
 
 {% block content %}
 
-    {% include "contact-us/common-english-only/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
 {% set html %}
-<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translateEnOnly }}</p>
-<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translateEnOnly }}</a>
+<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
 {% endset %}
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsPublic.header' | translateEnOnly }}
+  {{ 'pages.contactUsPublic.header' | translate }}
 </h1>
 
-<p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph1' | translateEnOnly }}</p>
+<p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph1' | translate }}</p>
 <ul class="govuk-list govuk-list--bullet">
- <li>{{ 'pages.contactUsPublic.section1.bulletPoint1' | translateEnOnly }}</li>
- <li>{{ 'pages.contactUsPublic.section1.bulletPoint2' | translateEnOnly }}</li>
+ <li>{{ 'pages.contactUsPublic.section1.bulletPoint1' | translate }}</li>
+ <li>{{ 'pages.contactUsPublic.section1.bulletPoint2' | translate }}</li>
 </ul>
 
-<p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph2' | translateEnOnly }}</p>
+<p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph2' | translate }}</p>
 
 <form action="/contact-us" method="post" novalidate>
 
@@ -41,35 +41,35 @@
     {% set items = [
         {
             value: "account_creation",
-            text: 'pages.contactUsPublic.section3.accountCreation' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.accountCreation' | translate
         },
         {
             value: "signing_in",
-            text: 'pages.contactUsPublic.section3.signingIn' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.signingIn' | translate
         },
         {
             value: "something_else",
-            text: 'pages.contactUsPublic.section3.somethingElse' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.somethingElse' | translate
         },
         {
             value: "id_check_app",
-            text: 'pages.contactUsPublic.section3.idCheckApp' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.idCheckApp' | translate
         },
         {
             value: "id_face_to_face",
-            text: 'pages.contactUsPublic.section3.provingIdentityFaceToFace' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.provingIdentityFaceToFace' | translate
         },
         {
             value: "proving_identity",
-            text: 'pages.contactUsPublic.section3.provingIdentity' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.provingIdentity' | translate
         },
         {
             value: "email_subscriptions",
-            text: 'pages.contactUsPublic.section3.emailSubscriptions' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.emailSubscriptions' | translate
         },
         {
             value: "suggestions_feedback",
-            text: 'pages.contactUsPublic.section3.suggestionsFeedback' | translateEnOnly
+            text: 'pages.contactUsPublic.section3.suggestionsFeedback' | translate
         }
     ] %}
 
@@ -77,7 +77,7 @@
         name: "theme",
         fieldset: {
             legend: {
-                text: 'pages.contactUsPublic.section3.header' | translateEnOnly,
+                text: 'pages.contactUsPublic.section3.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }
@@ -90,7 +90,7 @@
 
 
 {{ govukButton({
-    "text": "pages.contactUsPublic.continueLabel" | translateEnOnly,
+    "text": "pages.contactUsPublic.continueLabel" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/index-submit-success.njk
+++ b/src/components/contact-us/index-submit-success.njk
@@ -1,28 +1,28 @@
-{% extends "contact-us/common-english-only/layout/base.njk" %}
+{% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set pageTitleName = 'pages.contactUsSubmitSuccess.title' | translateEnOnly %}
+{% set pageTitleName = 'pages.contactUsSubmitSuccess.title' | translate %}
 
 {% block content %}
 
 {% set html %}
-<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translateEnOnly }}</p>
-<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translateEnOnly }}</a>
+<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
 {% endset %}
 
 {{ govukPanel({
-    titleText: 'pages.contactUsSubmitSuccess.header' | translateEnOnly
+    titleText: 'pages.contactUsSubmitSuccess.header' | translate
 }) }}
 
-<p class="govuk-body">{{'pages.contactUsSubmitSuccess.paragraph1' | translateEnOnly }}</p>
+<p class="govuk-body">{{'pages.contactUsSubmitSuccess.paragraph1' | translate }}</p>
 
-<p class="govuk-body">{{'pages.contactUsSubmitSuccess.paragraph2' | translateEnOnly }}</p>
+<p class="govuk-body">{{'pages.contactUsSubmitSuccess.paragraph2' | translate }}</p>
 
 <p class="govuk-body">
-    <a href="{{'pages.contactUsSubmitSuccess.paragraph3.linkHref' | translateEnOnly }}" class="govuk-link">
-        {{'pages.contactUsSubmitSuccess.paragraph3.linkText' | translateEnOnly }}
+    <a href="{{'pages.contactUsSubmitSuccess.paragraph3.linkHref' | translate }}" class="govuk-link">
+        {{'pages.contactUsSubmitSuccess.paragraph3.linkText' | translate }}
     </a>
 </p>
 

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.accountCreationProblem.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.accountCreationProblem.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.accountCreationProblem.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.accountCreationProblem.section1.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.accountCreationProblem.section1.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.accountCreationProblem.section1.paragraph1' | translate
       },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.accountNotFound.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.accountNotFound.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.accountNotFound.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.accountNotFound.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.accountNotFound.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.accountNotFound.section2.paragraph1' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.anotherProblem.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.anotherProblem.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,64 +15,64 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.anotherProblem.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.anotherProblem.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.anotherProblem.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.anotherProblem.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.anotherProblem.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.anotherProblem.section2.paragraph1' | translate
       },
     id: "additionalDescription",
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.authenticatorApp.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.authenticatorApp.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,64 +15,64 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.authenticatorApp.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.authenticatorApp.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.authenticatorApp.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.authenticatorApp.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.authenticatorApp.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.authenticatorApp.section2.paragraph1' | translate
       },
     id: "additionalDescription",
     name: "additionalDescription",
     value: additionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.emailSubscriptions.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.emailSubscriptions.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -14,55 +14,55 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.emailSubscriptions.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.emailSubscriptions.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.emailSubscriptions.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.emailSubscriptions.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.emailSubscriptions.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.emailSubscriptions.section2.paragraph1' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
@@ -70,7 +70,7 @@
 
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.forgottenPassword.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.forgottenPassword.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.forgottenPassword.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.forgottenPassword.section1.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.forgottenPassword.section1.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.forgottenPassword.section1.paragraph1' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.faceScanningProblem.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.faceScanningProblem.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -18,14 +18,14 @@
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.linkingProblem.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.linkingProblem.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -18,14 +18,14 @@
 {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.title' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.title' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,64 +15,64 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.header' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.header' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.paragraph1' | translateEnOnly
+            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.paragraph1' | translate
         },
         id: "additionalDescription",
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.takingPhotoOfIdProblem.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.takingPhotoOfIdProblem.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -17,17 +17,17 @@
         {
             value: 'passport',
             checked: identityDocumentUsed === 'passport',
-            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.passport' | translateEnOnly
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.passport' | translate
         },
         {
             value: 'biometricResidencePermit',
             checked: identityDocumentUsed === 'biometricResidencePermit',
-            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.biometricResidencePermit' | translateEnOnly
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.biometricResidencePermit' | translate
         },
         {
             value: 'drivingLicence',
             checked: identityDocumentUsed === 'drivingLicence',
-            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.drivingLicence' | translateEnOnly
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.drivingLicence' | translate
         }
     ] %}
 
@@ -35,7 +35,7 @@
         name: "identityDocumentUsed",
         fieldset: {
             legend: {
-                text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.header' | translateEnOnly,
+                text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--s"
             }
@@ -51,14 +51,14 @@
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.title' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.title' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,64 +15,64 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.header' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.header' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.paragraph1' | translateEnOnly
+            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.paragraph1' | translate
         },
         id: "additionalDescription",
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.invalidSecurityCode.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.invalidSecurityCode.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}?radio_buttons=true" method="post" novalidate>
@@ -13,46 +13,46 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
-{% set radioHeader = 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translateEnOnly %}
+{% set radioHeader = 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.invalidSecurityCode.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.invalidSecurityCode.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.invalidSecurityCode.section2.hintText' | translateEnOnly
+        text: 'pages.contactUsQuestions.invalidSecurityCode.section2.hintText' | translate
       },
     id: "moreDetailDescription",
     name: "moreDetailDescription",
     value: moreDetailDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['moreDetailDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['moreDetailDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['moreDetailDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.noPhoneNumberAccess.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.noPhoneNumberAccess.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}?radio_buttons=true" method="post" novalidate>
@@ -13,46 +13,46 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
-{% set radioHeader = 'pages.contactUsQuestions.noPhoneNumberAccess.section1.header' | translateEnOnly %}
+{% set radioHeader = 'pages.contactUsQuestions.noPhoneNumberAccess.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.paragraph1' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.noSecurityCode.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.noSecurityCode.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}?radio_buttons=true" method="post" novalidate>
@@ -13,46 +13,46 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
-{% set radioHeader = 'pages.contactUsQuestions.noSecurityCode.section1.header' | translateEnOnly %}
+{% set radioHeader = 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.noSecurityCode.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.noSecurityCode.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.noSecurityCode.section2.hintText' | translateEnOnly
+        text: 'pages.contactUsQuestions.noSecurityCode.section2.hintText' | translate
       },
     id: "moreDetailDescription",
     name: "moreDetailDescription",
     value: moreDetailDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['moreDetailDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['moreDetailDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['moreDetailDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section1.title' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section1.title' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,64 +15,64 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section1.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section1.header' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section2.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section2.header' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section2.paragraph1' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section2.paragraph1' | translate
         },
         id: "additionalDescription",
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.whatHappened.label' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.whatHappened.label' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.whatHappened.hint' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.whatHappened.hint' | translate
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceService.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceService.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceService.whatHappened.label' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceService.whatHappened.label' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceService.whatHappened.hint' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceService.whatHappened.hint' | translate
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.whatHappened.label' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.whatHappened.label' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.whatHappened.hint' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.whatHappened.hint' | translate
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.whatHappened.label' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.whatHappened.label' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.whatHappened.hint' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.whatHappened.hint' | translate
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.header' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.whatHappened.label' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.whatHappened.label' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.whatHappened.hint' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.whatHappened.hint' | translate
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section1.title' | translateEnOnly }}
+    {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section1.title' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,64 +15,64 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section1.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section1.header' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section2.header' | translateEnOnly,
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section2.header' | translate,
             classes: "govuk-label--s"
         },
         hint: {
-            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section2.paragraph1' | translateEnOnly
+            text: 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section2.paragraph1' | translate
         },
         id: "additionalDescription",
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
-        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
         charactersUnderLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
         },
         charactersOverLimitText: {
-            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
         },
         errorMessage: {
-            text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+            text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])
     }) }}
 
     {% include 'contact-us/questions/_service-trying-to-use.njk' %}
 
     {{ govukWarningText({
-        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 
     {{ govukButton({
-        "text": "general.sendMessage" | translateEnOnly,
+        "text": "general.sendMessage" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.provingIdentity.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.provingIdentity.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -14,56 +14,56 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.provingIdentity.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.provingIdentity.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.provingIdentity.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.provingIdentity.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.provingIdentity.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.provingIdentity.section2.paragraph1' | translate
       },
     id: "additionalDescription",
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 
 {{ govukInput({
     label: {
-        text: 'pages.contactUsQuestions.serviceTryingToUse.header' | translateEnOnly,
+        text: 'pages.contactUsQuestions.serviceTryingToUse.header' | translate,
         classes: "govuk-label--s"
     },
     id: "serviceTryingToUse",
@@ -71,7 +71,7 @@
     value: serviceTryingToUse,
     spellcheck: false,
     hint: {
-        text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translateEnOnly
+        text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translate
     },
     errorMessage: {
         text: errors['serviceTryingToUse'].text
@@ -79,14 +79,14 @@
 }) }}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_reply_by_email.njk
+++ b/src/components/contact-us/questions/_reply_by_email.njk
@@ -8,10 +8,10 @@
   spellcheck: false,
   classes: "govuk-!-width-two-thirds",
   label: {
-    text: 'pages.contactUsQuestions.emailReply.emailLabel' | translateEnOnly
+    text: 'pages.contactUsQuestions.emailReply.emailLabel' | translate
   },
   hint: {
-      text: 'pages.contactUsQuestions.emailReply.emailHint' | translateEnOnly
+      text: 'pages.contactUsQuestions.emailReply.emailHint' | translate
   },
   errorMessage: {
       text: errors['email'].text
@@ -24,18 +24,18 @@
   spellcheck: false,
   classes: "govuk-!-width-two-thirds",
   label: {
-    text: 'pages.contactUsQuestions.emailReply.nameLabel' | translateEnOnly
+    text: 'pages.contactUsQuestions.emailReply.nameLabel' | translate
   }
 }) }}
 <br />
-<p class="govuk-body">{{'pages.contactUsQuestions.emailReply.privacyNote' | translateEnOnly | replace("#PRIVACY_NOTICE_LINK", '<a class="govuk-link" href="/privacy-notice" rel="noreferrer noopener" target="_blank">privacy notice</a>') | safe }}</p>
+<p class="govuk-body">{{'pages.contactUsQuestions.emailReply.privacyNote' | translate | replace("#PRIVACY_NOTICE_LINK", '<a class="govuk-link" href="/privacy-notice" rel="noreferrer noopener" target="_blank">privacy notice</a>') | safe }}</p>
 {% endset -%}
 
 {{ govukRadios({
   name: "contact",
   fieldset: {
     legend: {
-      text: 'pages.contactUsQuestions.emailReply.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.emailReply.header' | translate,
       isPageHeading: false,
       classes: "govuk-fieldset__legend--m"
     }
@@ -43,7 +43,7 @@
   items: [
     {
       value: "true",
-      text: 'general.yes' | translateEnOnly,
+      text: 'general.yes' | translate,
       checked: contact === 'true',
       conditional: {
         html: emailHtml
@@ -51,7 +51,7 @@
     },
     {
       value: "false",
-      text: 'general.no' | translateEnOnly,
+      text: 'general.no' | translate,
       checked: contact === 'false'
     }
     ],

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -6,10 +6,10 @@
     spellcheck: false,
     classes: "govuk-!-width-two-thirds",
     label: {
-      text: 'pages.contactUsQuestions.textMessageInternationNumberConditionalSection.heading' | translateEnOnly
+      text: 'pages.contactUsQuestions.textMessageInternationNumberConditionalSection.heading' | translate
     },
     hint: {
-        text: 'pages.contactUsQuestions.textMessageInternationNumberConditionalSection.hintText' | translateEnOnly
+        text: 'pages.contactUsQuestions.textMessageInternationNumberConditionalSection.hintText' | translate
     },
     errorMessage:{
         text: errors['country'].text
@@ -23,17 +23,17 @@
             {
                 value: "email",
                 checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translate
             },
             {
                 value: "text_message_uk_number",
                 checked: securityCodeSentMethod === 'text_message_uk_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translate
             },
             {
                 value: "text_message_international_number",
                 checked: securityCodeSentMethod === 'text_message_international_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translateEnOnly,
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translate,
                 conditional:{
                     html:countryHtml
                 }
@@ -41,7 +41,7 @@
             {
                 value: "authenticator_app",
                 checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translate
             }
         ] %}
     {% endif %}
@@ -51,12 +51,12 @@
             {
                 value: "text_message_uk_number",
                 checked: securityCodeSentMethod === 'text_message_uk_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translate
             },
             {
                 value: "text_message_international_number",
                 checked: securityCodeSentMethod === 'text_message_international_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translateEnOnly,
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translate,
                 conditional:{
                     html:countryHtml
                 }
@@ -64,7 +64,7 @@
             {
                 value: "authenticator_app",
                 checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translate
             }
         ] %}
     {% endif %}
@@ -76,17 +76,17 @@
             {
                 value: "email",
                 checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translate
             },
             {
                 value: "text_message_uk_number",
                 checked: securityCodeSentMethod === 'text_message_uk_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translate
             },
             {
                 value: "text_message_international_number",
                 checked: securityCodeSentMethod === 'text_message_international_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translateEnOnly,
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translate,
                 conditional:{
                     html:countryHtml
                 }
@@ -94,7 +94,7 @@
             {
                 value: "authenticator_app",
                 checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translate
             }
         ] %}
     {% endif %}
@@ -104,17 +104,17 @@
             {
                 value: "email",
                 checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translate
             },
             {
                 value: "text_message_uk_number",
                 checked: securityCodeSentMethod === 'text_message_uk_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translate
             },
             {
                 value: "text_message_international_number",
                 checked: securityCodeSentMethod === 'text_message_international_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translateEnOnly,
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translate,
                 conditional:{
                     html:countryHtml
                 }
@@ -122,7 +122,7 @@
             {
                 value: "authenticator_app",
                 checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translate
             }
         ] %}
     {% endif %}

--- a/src/components/contact-us/questions/_service-trying-to-use.njk
+++ b/src/components/contact-us/questions/_service-trying-to-use.njk
@@ -1,6 +1,6 @@
 {{ govukInput({
     label: {
-        text: 'pages.contactUsQuestions.serviceTryingToUse.header' | translateEnOnly,
+        text: 'pages.contactUsQuestions.serviceTryingToUse.header' | translate,
         classes: "govuk-label--s"
     },
     id: "serviceTryingToUse",
@@ -8,7 +8,7 @@
     value: serviceTryingToUse,
     spellcheck: false,
     hint: {
-        text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translateEnOnly
+        text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translate
     },
     errorMessage: {
         text: errors['serviceTryingToUse'].text

--- a/src/components/contact-us/questions/_sign_in_phone_number_issue.njk
+++ b/src/components/contact-us/questions/_sign_in_phone_number_issue.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.signInPhoneNumberIssue.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.signInPhoneNumberIssue.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,78 +15,78 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section2.hintText' | translateEnOnly
+        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section2.hintText' | translate
       },
     id: "additionalDescription",
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 
 {{ govukInput({
     label: {
-        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section3.header' | translateEnOnly,
+        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section3.header' | translate,
         classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section3.hintText' | translateEnOnly
+        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section3.hintText' | translate
     },
     id: "countryPhoneNumberFrom",
     name: "countryPhoneNumberFrom",
     value: countryPhoneNumberFrom,
     errorMessage: {
-        text: errors['countryPhoneNumberFrom'].text | translateEnOnly
+        text: errors['countryPhoneNumberFrom'].text | translate
     } if (errors['countryPhoneNumberFrom'])
 }) }}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.signInPhoneNumberIssue.personalInformation.paragraph' | translateEnOnly,
+    text:'pages.contactUsQuestions.signInPhoneNumberIssue.personalInformation.paragraph' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.signignInProblem.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.signignInProblem.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,41 +15,41 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.signignInProblem.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.signignInProblem.section1.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.signignInProblem.section1.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.signignInProblem.section1.paragraph1' | translate
       },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.suggestionOrFeedback.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.suggestionOrFeedback.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -14,36 +14,36 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.suggestionOrFeedback.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.suggestionOrFeedback.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.technicalError.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.technicalError.header' | translate }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -15,63 +15,63 @@
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.technicalError.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.technicalError.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.technicalError.section2.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.technicalError.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.technicalError.section2.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.technicalError.section2.paragraph1' | translate
       },
     id: "additionalDescription",
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 
 {% include "contact-us/questions/_service-trying-to-use.njk" %}
 
 {{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
     iconFallbackText: "Warning"
 }) }}
 
 {{ govukInput({
     label: {
-      text: 'pages.contactUsQuestions.technicalError.section3.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.technicalError.section3.header' | translate,
       classes: "govuk-label--s"
     },
     id: "optionalDescription",
@@ -86,7 +86,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": "general.sendMessage" | translateEnOnly,
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_what-happened.njk
+++ b/src/components/contact-us/questions/_what-happened.njk
@@ -1,25 +1,25 @@
 {{ govukCharacterCount({
     label: {
-        text: 'pages.contactUsQuestions.whatHappened.header' | translateEnOnly,
+        text: 'pages.contactUsQuestions.whatHappened.header' | translate,
         classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.whatHappened.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.whatHappened.paragraph1' | translate
     },
     id: "issueDescription",
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
-    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
     charactersUnderLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
     },
     charactersOverLimitText: {
-        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
-        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
     },
     errorMessage: {
-        text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -1,4 +1,4 @@
-{% extends "contact-us/common-english-only/layout/base.njk" %}
+{% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
@@ -10,10 +10,10 @@
 {% set showBack = true %}
 {% set hrefBack = backurl %}
 
-{% set pageTitleName = pageTitleHeading | translateEnOnly %}
+{% set pageTitleName = pageTitleHeading | translate %}
 
 {% block content %}
-{% include "contact-us/common-english-only/errors/errorSummary.njk" %}
+{% include "common/errors/errorSummary.njk" %}
 
     {% if subtheme == 'account_not_found' %}
         {% include 'contact-us/questions/_account-not-found-questions.njk' %}

--- a/src/config/nunchucks.ts
+++ b/src/config/nunchucks.ts
@@ -2,7 +2,6 @@ import express from "express";
 import * as nunjucks from "nunjucks";
 import i18next from "i18next";
 import { Environment } from "nunjucks";
-import { supportWelshInSupportForms } from "../config";
 
 export function configureNunjucks(
   app: express.Application,
@@ -18,19 +17,6 @@ export function configureNunjucks(
     const translate = i18next.getFixedT(this.ctx.i18n.language);
     return translate(key, options);
   });
-
-  nunjucksEnv.addFilter(
-    "translateEnOnly",
-    function (key: string, options?: any) {
-      let translate;
-      if (supportWelshInSupportForms()) {
-        translate = i18next.getFixedT(this.ctx.i18n.language);
-      } else {
-        translate = i18next.getFixedT("en");
-      }
-      return translate(key, options);
-    }
-  );
 
   return nunjucksEnv;
 }


### PR DESCRIPTION
## What?

Deletes all code that relates to supporting Zendesk.

* https://github.com/govuk-one-login/authentication-frontend/pull/1296/commits/aac8913ce649f64f90d0a89d43e4e540ac386282 deletes the `translateEnOnly` filter and replacing all instances with `translate`

## Why?

SmartAgent has been in place for some time and there is no need to support dual-running in Production. 
