### PR TITLE
AUT-2244: Send user journey to backend API when logging in during reauthentication

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -118,6 +118,10 @@ export function enterPasswordPost(
     const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
+    const journeyType = getJourneyTypeFromUserSession(req.session.user, {
+      includeReauthentication: true,
+    });
+
     const userLogin = await service.loginUser(
       sessionId,
       email,
@@ -125,9 +129,7 @@ export function enterPasswordPost(
       clientSessionId,
       req.ip,
       persistentSessionId,
-      getJourneyTypeFromUserSession(req.session.user, {
-        includeReauthentication: true,
-      })
+      journeyType
     );
 
     if (!userLogin.success) {
@@ -181,9 +183,7 @@ export function enterPasswordPost(
         persistentSessionId,
         false,
         xss(req.cookies.lng as string),
-        getJourneyTypeFromUserSession(req.session.user, {
-          includeReauthentication: true,
-        })
+        journeyType
       );
 
       if (!result.success) {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -124,7 +124,10 @@ export function enterPasswordPost(
       req.body["password"],
       clientSessionId,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      getJourneyTypeFromUserSession(req.session.user, {
+        includeReauthentication: true,
+      })
     );
 
     if (!userLogin.success) {

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -4,7 +4,11 @@ import {
   Http,
   http,
 } from "../../utils/http";
-import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  JOURNEY_TYPE,
+} from "../../app.constants";
 import { EnterPasswordServiceInterface, UserLoginResponse } from "./types";
 import { ApiResponseResult } from "../../types";
 
@@ -17,14 +21,25 @@ export function enterPasswordService(
     password: string,
     clientSessionId: string,
     sourceIp: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    journeyType?: JOURNEY_TYPE
   ): Promise<ApiResponseResult<UserLoginResponse>> {
+    const payload: {
+      email: string;
+      password: string;
+      journeyType?: JOURNEY_TYPE;
+    } = {
+      email: emailAddress,
+      password: password,
+    };
+
+    if (journeyType) {
+      payload.journeyType = journeyType;
+    }
+
     const response = await axios.client.post<UserLoginResponse>(
       API_ENDPOINTS.LOG_IN_USER,
-      {
-        email: emailAddress,
-        password: password,
-      },
+      payload,
       getRequestConfig({
         sessionId: sessionId,
         clientSessionId: clientSessionId,

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -240,6 +240,11 @@ describe("enter password controller", () => {
         }),
       } as unknown as MfaServiceInterface;
 
+      const getJourneyTypeFromUserSessionSpy = sinon.spy(
+        journey,
+        "getJourneyTypeFromUserSession"
+      );
+
       res.locals.sessionId = "123456-djjad";
       res.locals.clientSessionId = "00000-djjad";
       res.locals.persistentSessionId = "dips-123456-abc";
@@ -255,6 +260,14 @@ describe("enter password controller", () => {
         fakeMfaService
       )(req as Request, res as Response);
 
+      expect(
+        getJourneyTypeFromUserSessionSpy
+      ).to.have.been.calledOnceWithExactly(req.session.user, {
+        includeReauthentication: true,
+      });
+      expect(getJourneyTypeFromUserSessionSpy.getCall(0).returnValue).to.equal(
+        JOURNEY_TYPE.REAUTHENTICATION
+      );
       expect(fakeService.loginUser).to.have.calledWith(
         sinon.match.any,
         sinon.match.any,

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -219,6 +219,53 @@ describe("enter password controller", () => {
       });
     });
 
+    it("can send the journeyType when sending the password", async () => {
+      const fakeService: EnterPasswordServiceInterface = {
+        loginUser: sinon.fake.returns({
+          data: {
+            redactedPhoneNumber: "3456",
+            mfaRequired: true,
+            consentRequired: false,
+            latestTermsAndConditionsAccepted: true,
+            mfaMethodVerified: true,
+            mfaMethodType: "SMS",
+          },
+          success: true,
+        }),
+      } as unknown as EnterPasswordServiceInterface;
+
+      const fakeMfaService: MfaServiceInterface = {
+        sendMfaCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as MfaServiceInterface;
+
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+        reauthenticate: "test_data",
+      };
+      req.body["password"] = "password";
+
+      await enterPasswordPost(
+        false,
+        fakeService,
+        fakeMfaService
+      )(req as Request, res as Response);
+
+      expect(fakeService.loginUser).to.have.calledWith(
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        sinon.match.any,
+        JOURNEY_TYPE.REAUTHENTICATION
+      );
+    });
+
     it("should redirect to enter-code when the password is correct", async () => {
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -1,4 +1,5 @@
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { JOURNEY_TYPE } from "../../app.constants";
 
 export interface UserLoginResponse extends DefaultApiResponse {
   redactedPhoneNumber?: string;
@@ -17,6 +18,7 @@ export interface EnterPasswordServiceInterface {
     password: string,
     clientSessionId: string,
     sourceIp: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    journeyType?: JOURNEY_TYPE
   ) => Promise<ApiResponseResult<UserLoginResponse>>;
 }


### PR DESCRIPTION
## What?

Send the user journey to the backend API when they log in during a reauthentication journey.

## Why?

We need to increment a relevant counter on the backend when the user logs in during reauthentication.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
- https://github.com/govuk-one-login/authentication-frontend/pull/1290