### PR TITLE
AUT-2229: Fixed Page Titles Not Displaying In Tab Heading

### DIFF
--- a/src/components/account-intervention/password-reset-required/index.njk
+++ b/src/components/account-intervention/password-reset-required/index.njk
@@ -1,5 +1,6 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.needToResetPassword.title' | translate %}
 
 {% block content %}
 

--- a/src/components/account-intervention/permanently-blocked/index.njk
+++ b/src/components/account-intervention/permanently-blocked/index.njk
@@ -1,4 +1,5 @@
 {% extends "common/layout/base.njk" %}
+{% set pageTitleName = 'pages.permanentlyLockedScreen.title' | translate %}
 
 {% block content %}
 

--- a/src/components/account-intervention/temporarily-blocked/index.njk
+++ b/src/components/account-intervention/temporarily-blocked/index.njk
@@ -1,5 +1,6 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% set pageTitleName = 'pages.suspendedPageScreen.title' | translate %}
 
 {% block content %}
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2233,11 +2233,13 @@
       }
     },
     "needToResetPassword": {
+      "title": "Mae angen i chi ailosod eich cyfrinair",
       "header": "Mae angen i chi ailosod eich cyfrinair",
       "paragraph1": "Er mwyn cadw eich GOV.UK One Login yn ddiogel, mae angen i chi ailosod eich cyfrinair.",
       "paragraph2": "Byddwn yn anfon cod i’ch cyfeiriad e-bost, y gallwch ei ddefnyddio i ailosod eich cyfrinair."
     },
     "permanentlyLockedScreen": {
+      "title": "Mae eich GOV.UK One Login wedi ei gloi yn barhaol",
       "header": "Mae eich GOV.UK One Login wedi ei gloi yn barhaol",
       "section1": {
         "paragraph1": "Ni allwch fewngofnodi ac ni allwch ddefnyddio eich GOV.UK One Login i gael mynediad at wasanaethau’r llywodraeth."
@@ -2249,6 +2251,7 @@
       }
     },
     "suspendedPageScreen": {
+      "title": "Mae’n ddrwg gennym, mae problem",
       "heading": "Mae’n ddrwg gennym, mae problem",
       "section1": {
         "paragraph1": "Nid yw eich GOV.UK One Login ar gael ar hyn o bryd."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2233,12 +2233,14 @@
       }
     },
     "needToResetPassword": {
+      "title": "You need to reset your password",
       "header": "You need to reset your password",
       "paragraph1": "To keep your GOV.UK One Login safe, you need to reset your password.",
       "paragraph2": "We’ll send a code to your email address, which you can use to reset your password."
     },
     "permanentlyLockedScreen": {
-      "header": "Your GOV.UK  One Login has been permanently locked",
+      "title": "Your GOV.UK One Login has been permanently locked",
+      "header": "Your GOV.UK One Login has been permanently locked",
       "section1": {
         "paragraph1": "You cannot sign in and you cannot use your GOV.UK  One Login to access government services."
       },
@@ -2249,6 +2251,7 @@
       }
     },
     "suspendedPageScreen": {
+      "title": "Sorry, there is a problem",
       "heading": "Sorry, there is a problem",
       "section1": {
         "paragraph1": "Your GOV.UK  One Login is not available at the moment."


### PR DESCRIPTION
## What?

Account Interventions - Page titles for suspended/blocked/pw reset not displayed in the tab heading like it is for other screens.

## Why?

Acceptance tests use the name in the tab to determine if correct page is displayed.
