### PR TITLE
Adding ALB Access logging

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -107,8 +107,8 @@ resource "aws_alb_listener" "frontend_alb_listener_http" {
 data "aws_elb_service_account" "main" {}
 
 resource "aws_s3_bucket" "alb-accesslog" {
-  count  = var.environment == "production" ? 1 : 0
-  bucket = "${var.environment}-frontend-alb-access-logs"
+  count         = var.environment == "production" ? 1 : 0
+  bucket        = "${var.environment}-frontend-alb-access-logs"
   force_destroy = true
 }
 


### PR DESCRIPTION
## What?

AUT-2261

## Why?

This change is to Enable ALB access logging for frontend load balncer & pushing access logs to S3 
Only on prod 

## Change have been demonstrated
Have tested the TF on AUthdev1 to enable logging  however this  Changes is for Prod only 
<img width="1194" alt="image" src="https://github.com/govuk-one-login/authentication-frontend/assets/144677445/e03bc9a3-4270-402c-ad69-a4215fb34178">


