### PR TITLE
BAU: Add shutdown script for local application.

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -29,3 +29,5 @@ pre-commit run --all-files
 yarn test:unit
 
 REDIS_PORT=6389 REDIS_HOST=localhost yarn test:integration
+
+./shutdown.sh

--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "Stopping frontend services..."
+docker-compose down
+killall node || echo "No local running node processes stopped..."


### PR DESCRIPTION
## What?

Add shutdown script for local application.

## Why?

Shutsdown both local node servers started with the '-l' option and node servers running under Docker.

If using the '-l' startup option just calling docker-compose down on its own will not terminate the local node instance, so another command is needed to do this.
