### PR TITLE
AUT-2231: Fixed Account Interventions/Change MFA Method Journeys

### DIFF
--- a/src/components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-controller.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-controller.ts
@@ -9,6 +9,8 @@ import { codeService } from "../../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../../common/verify-code/verify-code-controller";
 import { ExpressRouteFunc } from "../../../types";
 import { ERROR_CODES } from "../../common/constants";
+import { AccountInterventionsInterface } from "../../account-intervention/types";
+import { accountInterventionService } from "../../account-intervention/account-intervention-service";
 
 const TEMPLATE_NAME =
   "account-recovery/check-your-email-security-codes/index.njk";
@@ -30,9 +32,10 @@ export function checkYourEmailSecurityCodesGet(
 }
 
 export const checkYourEmailSecurityCodesPost = (
-  service: VerifyCodeInterface = codeService()
+  service: VerifyCodeInterface = codeService(),
+  accountInterventionsService: AccountInterventionsInterface = accountInterventionService()
 ): ExpressRouteFunc => {
-  return verifyCodePost(service, {
+  return verifyCodePost(service, accountInterventionsService, {
     notificationType: NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
     template: TEMPLATE_NAME,
     validationKey:

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -5,6 +5,8 @@ import { codeService } from "../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
 import { ExpressRouteFunc } from "../../types";
 import { ERROR_CODES } from "../common/constants";
+import { AccountInterventionsInterface } from "../account-intervention/types";
+import { accountInterventionService } from "../account-intervention/account-intervention-service";
 
 const TEMPLATE_NAME = "check-your-email/index.njk";
 
@@ -15,9 +17,10 @@ export function checkYourEmailGet(req: Request, res: Response): void {
 }
 
 export const checkYourEmailPost = (
-  service: VerifyCodeInterface = codeService()
+  service: VerifyCodeInterface = codeService(),
+  accountInterventionsService: AccountInterventionsInterface = accountInterventionService()
 ): ExpressRouteFunc => {
-  return verifyCodePost(service, {
+  return verifyCodePost(service, accountInterventionsService, {
     notificationType: NOTIFICATION_TYPE.VERIFY_EMAIL,
     template: TEMPLATE_NAME,
     validationKey: "pages.checkYourEmail.code.validationError.invalidCode",

--- a/src/components/check-your-email/tests/check-your-email-controller.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-controller.test.ts
@@ -55,6 +55,7 @@ describe("check your email controller", () => {
 
       req.body.code = "123456";
       req.session.id = "123456-djjad";
+      req.session.user.email = "test@test.com";
 
       await checkYourEmailPost(fakeService)(req as Request, res as Response);
 
@@ -74,6 +75,7 @@ describe("check your email controller", () => {
 
       req.body.code = "678988";
       req.session.id = "123456-djjad";
+      req.session.user.email = "test@test.com";
 
       await checkYourEmailPost(fakeService)(req as Request, res as Response);
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -688,6 +688,12 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.EMAIL_SECURITY_CODES_CODE_VERIFIED]: [
             PATH_NAMES.GET_SECURITY_CODES,
           ],
+          [USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_TEMPORARY,
+          ],
+          [USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_PERMANENT,
+          ],
         },
         meta: {
           optionalPaths: [

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -150,6 +150,7 @@ describe("enter mfa controller", () => {
       req.body.code = "123456";
       res.locals.sessionId = "123456-djjad";
       req.session.user.reauthenticate = "test_data";
+      req.session.user.email = "test@test.com";
 
       await enterMfaPost(fakeService)(req as Request, res as Response);
 
@@ -181,6 +182,7 @@ describe("enter mfa controller", () => {
 
       req.body.code = "123456";
       res.locals.sessionId = "123456-djjad";
+      req.session.user.email = "test@test.com";
 
       await enterMfaPost(fakeService)(req as Request, res as Response);
 
@@ -201,6 +203,7 @@ describe("enter mfa controller", () => {
       req.t = sinon.fake.returns("translated string");
       req.body.code = "678988";
       res.locals.sessionId = "123456-djjad";
+      req.session.user.email = "test@test.com";
 
       await enterMfaPost(fakeService)(req as Request, res as Response);
 
@@ -222,6 +225,7 @@ describe("enter mfa controller", () => {
       req.t = sinon.fake.returns("translated string");
       req.body.code = "678988";
       res.locals.sessionId = "123456-djjad";
+      req.session.user.email = "test@test.com";
 
       await enterMfaPost(fakeService)(req as Request, res as Response);
 

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -9,6 +9,8 @@ import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
 import { VerifyCodeInterface } from "../common/verify-code/types";
 import { codeService } from "../common/verify-code/verify-code-service";
+import { AccountInterventionsInterface } from "../account-intervention/types";
+import { accountInterventionService } from "../account-intervention/account-intervention-service";
 
 const TEMPLATE_NAME = "reset-password-2fa-sms/index.njk";
 export function resetPassword2FASmsGet(
@@ -42,9 +44,10 @@ export function resetPassword2FASmsGet(
   };
 }
 export function resetPassword2FASmsPost(
-  service: VerifyCodeInterface = codeService()
+  service: VerifyCodeInterface = codeService(),
+  accountInterventionsService: AccountInterventionsInterface = accountInterventionService()
 ): ExpressRouteFunc {
-  return verifyCodePost(service, {
+  return verifyCodePost(service, accountInterventionsService, {
     notificationType: NOTIFICATION_TYPE.MFA_SMS,
     template: TEMPLATE_NAME,
     validationKey: "pages.passwordResetMfaSms.code.validationError.invalidCode",

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -9,6 +9,8 @@ import { codeService } from "../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
 import { NOTIFICATION_TYPE } from "../../app.constants";
 import { support2FABeforePasswordReset } from "../../config";
+import { AccountInterventionsInterface } from "../account-intervention/types";
+import { accountInterventionService } from "../account-intervention/account-intervention-service";
 
 const TEMPLATE_NAME = "reset-password-check-email/index.njk";
 
@@ -88,9 +90,10 @@ export function resetPasswordCheckEmailGet(
 }
 
 export function resetPasswordCheckEmailPost(
-  service: VerifyCodeInterface = codeService()
+  service: VerifyCodeInterface = codeService(),
+  accountInterventionsService: AccountInterventionsInterface = accountInterventionService()
 ): ExpressRouteFunc {
-  return verifyCodePost(service, {
+  return verifyCodePost(service, accountInterventionsService, {
     notificationType: NOTIFICATION_TYPE.RESET_PASSWORD_WITH_CODE,
     template: TEMPLATE_NAME,
     validationKey:


### PR DESCRIPTION
## What?

Added to the verify code controller to handle a user requesting a change in MFA method while having account interventions against their account.

## Why?

How AIS had been implemented thus far had not met the acceptance criteria for the scenarios outlined in AUT-2331

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1249
