### PR TITLE
AUT-2253: Remove `reauthenticate` property from user session once auth journey finishes

### DIFF
--- a/src/components/auth-code/auth-code-controller.ts
+++ b/src/components/auth-code/auth-code-controller.ts
@@ -24,7 +24,9 @@ export function authCodeGet(
       req.session.client,
       req.session.user
     );
+
     req.session.user.authCodeReturnToRP = false;
+    delete req.session.user.reauthenticate;
 
     if (!result.success) {
       throw new BadRequestError(result.data.message, result.data.code);

--- a/src/components/auth-code/tests/auth-code-controller.test.ts
+++ b/src/components/auth-code/tests/auth-code-controller.test.ts
@@ -45,6 +45,30 @@ describe("auth code controller", () => {
   });
 
   describe("authCodeGet", () => {
+    it("should remove the reauthenticate user session property", async () => {
+      const fakeAuthCodeService: AuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as AuthCodeServiceInterface;
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake.returns({
+          cookie_consent: COOKIE_CONSENT.ACCEPT,
+        }),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      req.session.user.reauthenticate = "test_data";
+
+      await authCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(req.session.user.reauthenticate).to.equal(undefined);
+    });
+
     it("should redirect to the auth code url with cookie consent param set as not-engaged", async () => {
       req.cookies = {};
       const fakeAuthCodeService: AuthCodeServiceInterface = {


### PR DESCRIPTION
## What?

When the auth controller is hit, this removes the `reauthenticate` property from the users session.

## Why?

This is to ensure we don’t use it incorrectly in later journeys. Reauthenticate here indicates the RP requested that the user reauthenticate before performing an action on the RP.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.

- https://github.com/govuk-one-login/authentication-frontend/pull/1290
- https://github.com/govuk-one-login/authentication-frontend/pull/1297
