### PR TITLE
AUT-2287: Switch off autoscaling v1 in integration and prod

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,7 +1,7 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled   = true
+frontend_auto_scaling_enabled   = false
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -2,7 +2,7 @@ environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled                                       = true
+frontend_auto_scaling_enabled                                       = false
 frontend_task_definition_cpu                                        = 1024
 frontend_task_definition_memory                                     = 2048
 frontend_auto_scaling_min_count                                     = 4


### PR DESCRIPTION

## What?

Switch off autoscaling v1 in integration and prod.

## Why?

Precursor to switching on autoscaling v2 as a single deployment switching v1 off and v2 on does not work. Default task counts will apply while scaling is switched off. To be followed by a PR switching on v2.
