### PR TITLE
Aut 2287: Switch on autoscaling v2 in int and prod

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,9 +1,10 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled   = false
-frontend_task_definition_cpu    = 512
-frontend_task_definition_memory = 1024
+frontend_auto_scaling_enabled    = false
+frontend_auto_scaling_v2_enabled = true
+frontend_task_definition_cpu     = 512
+frontend_task_definition_memory  = 1024
 
 support_welsh_language_in_support_forms                             = "1"
 support_international_numbers                                       = "1"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -3,10 +3,11 @@ common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
 frontend_auto_scaling_enabled                                       = false
+frontend_auto_scaling_v2_enabled                                    = true
 frontend_task_definition_cpu                                        = 1024
 frontend_task_definition_memory                                     = 2048
 frontend_auto_scaling_min_count                                     = 4
-frontend_auto_scaling_max_count                                     = 12
+frontend_auto_scaling_max_count                                     = 60
 ecs_desired_count                                                   = 4
 support_international_numbers                                       = "1"
 support_account_recovery                                            = "1"


### PR DESCRIPTION
## What?

Switch on autoscaling v2 in int and prod

## Why?

Increase max task count to 60 in prod.
Applies step scaling rules as used in performance testing.
