### PR TITLE
ATO-331: Redirect to RP on identity error, not orchestration

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -107,6 +107,7 @@ export function authorizeGet(
     req.session.client.state = claims.state;
     req.session.client.isOneLoginService = claims.is_one_login_service;
     req.session.client.rpSectorHost = claims.rp_sector_host;
+    req.session.client.rpRedirectUri = claims.rp_redirect_uri;
 
     req.session.client.consentEnabled =
       startAuthResponse.data.user.consentRequired;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -30,6 +30,7 @@ export type Claims = {
   client_id: string;
   redirect_uri: string;
   rp_sector_host: string;
+  rp_redirect_uri: string;
   reauthenticate?: string;
   claim?: string;
 };

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -9,6 +9,7 @@ import {
 import { proveIdentityCallbackService } from "./prove-identity-callback-service";
 import { IPV_ERROR_CODES, OIDC_ERRORS } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
+import { supportAuthOrchSplit } from "../../config";
 
 export function proveIdentityCallbackGet(
   service: ProveIdentityCallbackServiceInterface = proveIdentityCallbackService()
@@ -46,7 +47,9 @@ export function proveIdentityCallbackGet(
       );
     } else {
       redirectPath = createServiceRedirectErrorUrl(
-        req.session.client.redirectUri,
+        supportAuthOrchSplit()
+          ? req.session.client.rpRedirectUri
+          : req.session.client.redirectUri,
         OIDC_ERRORS.ACCESS_DENIED,
         IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT,
         req.session.client.state

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,4 +93,5 @@ export interface UserSessionClient {
   isOneLoginService?: boolean;
   claim?: string[];
   rpSectorHost?: string;
+  rpRedirectUri?: string;
 }


### PR DESCRIPTION
## What?
During the release of the phase 1 split, an increase in errors was seen on the orchestration redirect endpoint. This was caused by incorrect behaviour in the authentication frontend. When a user clicks the browser back button to return to auth from IPV, they land on the processing identity page and receive a NO_ENTRY response from the processing identity lambda, as no data has been sent to SPOT. In this case, the auth frontend should return the user to the RP with an error, but was incorrectly returning the user to the orchestration redirect. 