### PR TITLE
Revert "ATO-255: Restrict codeowners for the duration of the deployment"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads
+* @govuk-one-login/auth-team @govuk-one-login/auth-leads @govuk-one-login/orchestration-leads @govuk-one-login/orchestration-team


### PR DESCRIPTION
This reverts commit 871be2690d6679904f2793d54462fd0174141d23.

## What?

Phase 1 deployment is complete; restore original codeowners