### PR TITLE
AUT-2297-Switching off V2 scaling in Prod

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -3,7 +3,7 @@ common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
 frontend_auto_scaling_enabled    = false
-frontend_auto_scaling_v2_enabled = true
+frontend_auto_scaling_v2_enabled = false
 frontend_task_definition_cpu     = 1024
 frontend_task_definition_memory  = 2048
 frontend_auto_scaling_min_count  = 60


### PR DESCRIPTION
## What?

Switch off autoscaling v2 in on prod.

## Why?
Precursor to switching on autoscaling v1 back  as a single deployment switching v2 off and v1 on does not work.



