### PR TITLE
AUT-2296: Change Temporary Suspension Behaviour

### DIFF
--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -22,15 +22,6 @@ export function accountInterventionsMiddleware(
           persistentSessionId
         );
 
-      if (accountInterventionsResponse.data.passwordResetRequired) {
-        res.redirect(
-          getNextPathAndUpdateJourney(
-            req,
-            req.path,
-            USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION
-          )
-        );
-      }
       if (accountInterventionsResponse.data.blocked) {
         res.redirect(
           getNextPathAndUpdateJourney(
@@ -40,12 +31,12 @@ export function accountInterventionsMiddleware(
           )
         );
       }
-      if (accountInterventionsResponse.data.temporarilySuspended) {
+      if (accountInterventionsResponse.data.passwordResetRequired) {
         res.redirect(
           getNextPathAndUpdateJourney(
             req,
             req.path,
-            USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
+            USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION
           )
         );
       }

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -135,7 +135,7 @@ describe("accountInterventionsMiddleware", () => {
       res as Response,
       next as NextFunction
     );
-    expect(res.redirect).to.have.been.calledWith(
+    expect(res.redirect).to.not.have.been.calledWith(
       PATH_NAMES.UNAVAILABLE_TEMPORARY
     );
   });


### PR DESCRIPTION
## What?

Removing temporary suspension handling from auth frontend

## Why?

Temporary suspension account interventions are handled by orchestration

## Change have been demonstrated

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change
