### PR TITLE
BAU: Enable 2FA before password reset in staging

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -14,6 +14,7 @@ support_account_recovery         = "1"
 support_account_interventions    = "1"
 support_auth_orch_split          = "1"
 support_authorize_controller     = "1"
+support_2fa_b4_password_reset    = "1"
 url_for_support_links            = "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
 
 logging_endpoint_arns = [


### PR DESCRIPTION
## What?

Enable 2FA before password reset in staging.

## Why?

To enable testing in staging (with account interventions)

