### PR TITLE
ATO-364: Pass through intervention from processing identity API call

### DIFF
--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -27,6 +27,10 @@ export function proveIdentityCallbackGet(
       persistentSessionId
     );
 
+    if (response.data.status === IdentityProcessingStatus.INTERVENTION) {
+      return res.redirect(response.data.redirectUrl);
+    }
+
     if (response.data.status === IdentityProcessingStatus.PROCESSING) {
       return res.render("prove-identity-callback/index.njk", {
         serviceName: clientName,

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -135,5 +135,25 @@ describe("prove identity callback controller", () => {
       );
       process.env.SUPPORT_AUTH_ORCH_SPLIT = "0";
     });
+
+    it("should redirect to the provided url when the response is an intervention", async () => {
+      const redirectUrl = "https://www.example.com";
+      const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
+        processIdentity: sinon.fake.returns({
+          success: true,
+          data: {
+            status: IdentityProcessingStatus.INTERVENTION,
+            redirectUrl: redirectUrl,
+          },
+        }),
+      } as unknown as ProveIdentityCallbackServiceInterface;
+
+      await proveIdentityCallbackGet(fakeProveIdentityService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(redirectUrl);
+    });
   });
 });

--- a/src/components/prove-identity-callback/types.ts
+++ b/src/components/prove-identity-callback/types.ts
@@ -10,12 +10,25 @@ export interface ProveIdentityCallbackServiceInterface {
   ) => Promise<ApiResponseResult<ProcessIdentityResponse>>;
 }
 
-export interface ProcessIdentityResponse extends DefaultApiResponse {
-  status: IdentityProcessingStatus;
+export type ProcessIdentityResponse =
+  | ProcessIdentitySPOTResponse
+  | ProcessIdentityInterventionResponse;
+
+interface ProcessIdentitySPOTResponse extends DefaultApiResponse {
+  status:
+    | IdentityProcessingStatus.COMPLETED
+    | IdentityProcessingStatus.PROCESSING
+    | IdentityProcessingStatus.ERROR;
+}
+
+interface ProcessIdentityInterventionResponse extends DefaultApiResponse {
+  status: IdentityProcessingStatus.INTERVENTION;
+  redirectUrl: string;
 }
 
 export enum IdentityProcessingStatus {
   COMPLETED = "COMPLETED",
   ERROR = "ERROR",
   PROCESSING = "PROCESSING",
+  INTERVENTION = "INTERVENTION",
 }


### PR DESCRIPTION
## What?

Some account interventions need to be applied post SPoT. To do this, the backend will return an intervention response with a redirect URL. This change actions that.

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/3928