### PR TITLE
AUT-2093-part-1: Remove previous implementation of reauth landing screen

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -129,7 +129,7 @@ const authStateMachine = createMachine(
               cond: "isConsentRequired",
             },
             {
-              target: [PATH_NAMES.ENTER_PASSWORD],
+              target: [PATH_NAMES.ENTER_EMAIL_SIGN_IN],
               cond: "isReauthenticationRequired",
             },
             { target: [PATH_NAMES.AUTH_CODE], cond: "isAuthenticated" },

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -143,7 +143,7 @@ describe("state-machine", () => {
         USER_JOURNEY_EVENTS.EXISTING_SESSION,
         { isAuthenticated: true, isReauthenticationRequired: true }
       );
-      expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
+      expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
     });
 
     it("should move from authorize to sign or create when reauthentication is requested and the user is not logged in", () => {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -19,12 +19,7 @@ import { MFA_METHOD_TYPE } from "../../app.constants";
 import xss from "xss";
 import { EnterEmailServiceInterface } from "../enter-email/types";
 import { enterEmailService } from "../enter-email/enter-email-service";
-import {
-  support2FABeforePasswordReset,
-  supportReauthentication,
-} from "../../config";
-import { CheckReauthServiceInterface } from "../check-reauth-users/types";
-import { checkReauthUsersService } from "../check-reauth-users/check-reauth-users-service";
+import { support2FABeforePasswordReset } from "../../config";
 import { getJourneyTypeFromUserSession } from "../common/journey/journey";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
@@ -36,33 +31,8 @@ const ENTER_PASSWORD_ACCOUNT_EXISTS_TEMPLATE =
 const ENTER_PASSWORD_ACCOUNT_EXISTS_VALIDATION_KEY =
   "pages.enterPasswordAccountExists.password.validationError.incorrectPassword";
 
-export function enterPasswordGet(
-  service: CheckReauthServiceInterface = checkReauthUsersService()
-): ExpressRouteFunc {
-  return async function (req: Request, res: Response) {
-    const isReauthenticationRequired = req.session.user.reauthenticate;
-
-    if (!supportReauthentication() || !isReauthenticationRequired) {
-      return res.render(ENTER_PASSWORD_TEMPLATE);
-    }
-
-    const email = req.session.user.email.toLowerCase();
-    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
-
-    const checkReauthUserResponse = await service.checkReauthUsers(
-      sessionId,
-      email,
-      req.ip,
-      clientSessionId,
-      persistentSessionId
-    );
-
-    if (!checkReauthUserResponse.success) {
-      return res.render("common/errors/500.njk");
-    }
-
-    return res.render(ENTER_PASSWORD_TEMPLATE);
-  };
+export function enterPasswordGet(req: Request, res: Response): void {
+  res.render(ENTER_PASSWORD_TEMPLATE);
 }
 
 export function enterSignInRetryBlockedGet(

--- a/src/components/enter-password/enter-password-routes.ts
+++ b/src/components/enter-password/enter-password-routes.ts
@@ -22,7 +22,7 @@ router.get(
   PATH_NAMES.ENTER_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(enterPasswordGet())
+  enterPasswordGet
 );
 
 router.get(

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -20,7 +20,6 @@ import {
 } from "mock-req-res";
 import { EnterEmailServiceInterface } from "../../enter-email/types";
 import { ERROR_CODES } from "../../common/constants";
-import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
 import * as journey from "../../common/journey/journey";
 
 describe("enter password controller", () => {
@@ -41,77 +40,10 @@ describe("enter password controller", () => {
   });
 
   describe("enterPasswordGet", () => {
-    const fakeService: CheckReauthServiceInterface = {
-      checkReauthUsers: sinon.fake.returns({
-        success: true,
-      }),
-    } as unknown as CheckReauthServiceInterface;
-
     it("should render enter password view", async () => {
-      await enterPasswordGet(fakeService)(req as Request, res as Response);
+      enterPasswordGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("enter-password/index.njk");
-    });
-
-    it("should render enter password view when supportReauthentication flag is switched off", async () => {
-      process.env.SUPPORT_REAUTHENTICATION = "0";
-
-      await enterPasswordGet(fakeService)(req as Request, res as Response);
-
-      expect(res.render).to.have.calledWith("enter-password/index.njk");
-    });
-
-    it("should render enter password view when isReautheticationRequired is false", async () => {
-      process.env.SUPPORT_REAUTHENTICATION = "1";
-      res.locals.sessionId = "123456-djjad";
-      res.locals.clientSessionId = "00000-djjad";
-      res.locals.persistentSessionId = "dips-123456-abc";
-      req.session.user = {
-        email: "joe.bloggs@test.com",
-      };
-
-      await enterPasswordGet(fakeService)(req as Request, res as Response);
-
-      expect(res.render).to.have.calledWith("enter-password/index.njk");
-    });
-
-    it("should render enter password view when isReautheticationRequired is true and check service returns successfully", async () => {
-      process.env.SUPPORT_REAUTHENTICATION = "1";
-      res.locals.sessionId = "123456-djjad";
-      res.locals.clientSessionId = "00000-djjad";
-      res.locals.persistentSessionId = "dips-123456-abc";
-      req.session.user = {
-        email: "joe.bloggs@test.com",
-        reauthenticate: "12345",
-      };
-
-      await enterPasswordGet(fakeService)(req as Request, res as Response);
-
-      expect(res.render).to.have.calledWith("enter-password/index.njk");
-    });
-
-    it("should render 500 error view when isReautheticationRequired is true and check service fails", async () => {
-      const unsuccessfulFakeService: CheckReauthServiceInterface = {
-        checkReauthUsers: sinon.fake.returns({
-          success: false,
-        }),
-      } as unknown as CheckReauthServiceInterface;
-
-      process.env.SUPPORT_REAUTHENTICATION = "1";
-      res.locals.sessionId = "123456-djjad";
-      res.locals.clientSessionId = "00000-djjad";
-      res.locals.persistentSessionId = "dips-123456-abc";
-      req.session.user = {
-        email: "joe.bloggs@test.com",
-        reauthenticate: "12345",
-      };
-
-      await enterPasswordGet(unsuccessfulFakeService)(
-        req as Request,
-        res as Response
-      );
-
-      expect(res.render).to.have.calledWith("common/errors/500.njk");
     });
   });
 

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -4,16 +4,8 @@ import { expect, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
-import {
-  API_ENDPOINTS,
-  HTTP_STATUS_CODES,
-  PATH_NAMES,
-} from "../../../app.constants";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
 import { ERROR_CODES } from "../../common/constants";
-import { AxiosResponse } from "axios";
-import { createApiResponse } from "../../../utils/http";
-import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
-import { DefaultApiResponse } from "../../../types";
 
 describe("Integration::enter password", () => {
   let token: string | string[];
@@ -27,7 +19,6 @@ describe("Integration::enter password", () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
-    const checkReauthUsersService = require("../../check-reauth-users/check-reauth-users-service");
 
     sinon
       .stub(sessionMiddleware, "validateSessionMiddleware")
@@ -45,20 +36,6 @@ describe("Integration::enter password", () => {
         };
 
         next();
-      });
-
-    sinon
-      .stub(checkReauthUsersService, "checkReauthUsersService")
-      .callsFake((): CheckReauthServiceInterface => {
-        async function checkReauthUsers() {
-          const fakeAxiosResponse: AxiosResponse = {
-            status: HTTP_STATUS_CODES.OK,
-          } as AxiosResponse;
-
-          return createApiResponse<DefaultApiResponse>(fakeAxiosResponse);
-        }
-
-        return { checkReauthUsers };
       });
 
     app = await require("../../../app").createApp();
@@ -83,11 +60,6 @@ describe("Integration::enter password", () => {
   });
 
   it("should return enter password page", (done) => {
-    request(app).get(ENDPOINT).expect(200, done);
-  });
-
-  it("should return enter password page when support reauthentication flag is on and check reauth users api call is successfull", (done) => {
-    process.env.SUPPORT_REAUTHENTICATION = "1";
     request(app).get(ENDPOINT).expect(200, done);
   });
 


### PR DESCRIPTION
## What?
- This PR is the first part of creating a new screen for the reauthentication journey
- Previously, it was decided for the user to be redirected to the /enter-password when reauthentication is required
- It has now been decided that the user to be redirected to a new re-auth screen

## Why?

New re-auth screen is now available, user will be redirected to this screen instead

## Related PRs

Revert some of the Initial PR to redirect user to /enter-password when re-authentication is required
(https://github.com/govuk-one-login/authentication-frontend/pull/1262)
