### PR TITLE
BAU: Turn on support for account interventions in sandpit

### DIFF
--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -14,6 +14,7 @@ support_account_recovery      = "1"
 support_auth_orch_split       = "1"
 support_authorize_controller  = "1"
 support_international_numbers = "1"
+support_account_interventions = "1"
 
 frontend_task_definition_cpu     = 256
 frontend_task_definition_memory  = 512


### PR DESCRIPTION
We now have the correct variable set in secrets to point to the stub in sandpit, so we can turn this on.
