### PR TITLE
BAU: log landing referer

### DIFF
--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -18,6 +18,7 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { landingService } from "./landing-service";
 import { LandingServiceInterface } from "./types";
 import { appendQueryParamIfHasValue } from "../../utils/url";
+import { logger } from "../../utils/logger";
 
 function createConsentCookie(
   res: Response,
@@ -38,6 +39,7 @@ export function landingGet(
   return async function (req: Request, res: Response) {
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const loginPrompt = sanitize(req.query.prompt as string);
+    logger.info(`Landing referer: ${sanitize(req.headers.referer)}`);
 
     const startAuthResponse = await service.start(
       sessionId,


### PR DESCRIPTION


## What?

Log landing route referer.

## Why?

The landing route is no longer in use but is seeing some traffic.  When users land on '/' they are no longer able to log in, even though it looks like the journey is working correctly, and effectively their session is broken.

Would like to see where users are coming from before removing it completely.

The standard logger logs the referer pathname so logging the entire referer to see if it yields any more information.
