### PR TITLE
AUT-2358: Update GOV.UK Frontend to use Tudor Crown

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "express": "^4.17.2",
     "express-session": "^1.17.2",
     "express-validator": "^6.13.0",
-    "govuk-frontend": "^4.3.1",
+    "govuk-frontend": "^4.8.0",
     "helmet": "4.6.0",
     "i18next": "^21.6.5",
     "i18next-fs-backend": "^1.1.1",

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -5,22 +5,22 @@
 
 {% block head %}
 
-  <!--[if !IE 8]><!-->
+    <!--[if !IE 8]><!-->
     <link href="/public/style.css" rel="stylesheet">
-  <!--<![endif]-->
+    <!--<![endif]-->
 
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
-  <!--[if IE 8]>
+    {# For Internet Explorer 8, you need to compile specific stylesheet #}
+    {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
+    <!--[if IE 8]>
     <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
-  <![endif]-->
+    <![endif]-->
 
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
+    {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
+    <!--[if lt IE 9]>
     <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
+    <![endif]-->
 
-{% block headMetaData %}{% endblock %}
+    {% block headMetaData %}{% endblock %}
 
 {% endblock %}
 
@@ -41,80 +41,85 @@
 {% endblock %}
 
 {% block header %}
-  {{ govukHeader({
-  homepageUrl: 'general.header.homepageHref' | translate
-}) }}
+    {{ govukHeader({
+        homepageUrl: 'general.header.homepageHref' | translate,
+        useTudorCrown: false
+    }) }}
 {% endblock %}
 
 {% set phaseBannerText %}
-    {{ 'general.phaseBanner.message.start' | translate }} <a href="{{ contactUsLinkUrl }}" class="govuk-link" rel="noopener" target="_blank">{{ 'general.phaseBanner.message.linkText' | translate }}</a> {{ 'general.phaseBanner.message.end' | translate }}
+    {{ 'general.phaseBanner.message.start' | translate }} <a href="{{ contactUsLinkUrl }}" class="govuk-link"
+                                                             rel="noopener"
+                                                             target="_blank">{{ 'general.phaseBanner.message.linkText' | translate }}</a> {{ 'general.phaseBanner.message.end' | translate }}
 {% endset %}
 
 {% block main %}
-      <div class="govuk-width-container {{ containerClasses }}">
+    <div class="govuk-width-container {{ containerClasses }}">
         {{ govukPhaseBanner({
-          tag: {
-            text: 'general.phaseBanner.tag' | translate
-          },
-          html: phaseBannerText
+            tag: {
+                text: 'general.phaseBanner.tag' | translate
+            },
+            html: phaseBannerText
         }) }}
-	      {% block beforeContent %}{% endblock %}
-	      {% if showBack %}
-	        {{ govukBackLink({
+        {% block beforeContent %}{% endblock %}
+        {% if showBack %}
+            {{ govukBackLink({
                 text: "general.back" | translate,
                 href: hrefBack
             }) }}
-          {% endif %}
-	      <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
-              {% block content %}{% endblock %}
+        {% endif %}
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"
+              role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+                    {% block content %}{% endblock %}
+                </div>
             </div>
-          </div>
-	      </main>
-      </div>
+        </main>
+    </div>
 {% endblock %}
 
 {% block footer %}
     {{ govukFooter({
-      meta: {
-        items: [
-          {
-            href: "/accessibility-statement",
-            text: 'general.footer.accessibilityStatement.linkText' | translate
-          },
-          {
-            href: "/cookies",
-            text: 'general.footer.cookies.linkText' | translate
-          },
-          {
-            href: "/terms-and-conditions",
-            text: 'general.footer.terms.linkText' | translate
-          },
-          {
-              href: "/privacy-notice",
-              text: 'general.footer.privacy.linkText' | translate
-          },
-          {
-              href: contactUsLinkUrl,
-              attributes: {target: "_blank"},
-              text: 'general.footer.support.linkText' | translate
-          }
-        ]
-      },
-      contentLicence: {
-        text: 'general.footer.contentLicence.linkText' | translate | safe
-      },
-      copyright: {
-        text: 'general.footer.copyright.linkText' | translate
-      }
+        meta: {
+            items: [
+                {
+                    href: "/accessibility-statement",
+                    text: 'general.footer.accessibilityStatement.linkText' | translate
+                },
+                {
+                    href: "/cookies",
+                    text: 'general.footer.cookies.linkText' | translate
+                },
+                {
+                    href: "/terms-and-conditions",
+                    text: 'general.footer.terms.linkText' | translate
+                },
+                {
+                    href: "/privacy-notice",
+                    text: 'general.footer.privacy.linkText' | translate
+                },
+                {
+                    href: contactUsLinkUrl,
+                    attributes: {target: "_blank"},
+                    text: 'general.footer.support.linkText' | translate
+                }
+            ]
+        },
+        contentLicence: {
+            text: 'general.footer.contentLicence.linkText' | translate | safe
+        },
+        copyright: {
+            text: 'general.footer.copyright.linkText' | translate
+        }
     }) }}
-    {% endblock %}
+{% endblock %}
 
 {% block bodyEnd %}
     {% block scripts %}{% endblock %}
-  <script type="text/javascript" src="/public/scripts/cookies.js"></script>
-  <script type="text/javascript"  src="/public/scripts/application.js"></script>
-  <script type="text/javascript"  src="/public/scripts/all.js"></script>
-  <script type="text/javascript" nonce='{{scriptNonce}}'>window.GOVSignIn.appInit("{{gtmId}}", "{{ analyticsCookieDomain }}")</script>
+    <script type="text/javascript" src="/public/scripts/cookies.js"></script>
+    <script type="text/javascript" src="/public/scripts/application.js"></script>
+    <script type="text/javascript" src="/public/scripts/all.js"></script>
+    <script type="text/javascript"
+            nonce='{{ scriptNonce }}'>window.GOVSignIn.appInit("{{ gtmId }}", "{{ analyticsCookieDomain }}");</script>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,10 +3043,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^4.3.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.4.1.tgz#88857c4ad8508255a4e983030a3964d6e1674107"
-  integrity sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==
+govuk-frontend@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
+  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
 
 graceful-fs@^4.1.15:
   version "4.2.8"


### PR DESCRIPTION
## What?

Updates the govuk-frontend NPM package to version 4.8 so that we can use the Tudor Crown. Also introduces `useTudorCrown` to the `govukHeader` component so the swtich will simply be changing the value passed.

I've also applied IntelliJ auto-formatting to `base.njk` because the formatting was off. Most of these will changes can be hidden by choosing the 'hide whitespace'. 

## Why?

To prepare for the move to the Tudor Crown.

## Change have been demonstrated

This PR makes does not change the user interface.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1361
- https://github.com/alphagov/di-infrastructure/pull/574
