### PR TITLE
AUT-2363: Enable Tudor Crown

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -43,7 +43,7 @@
 {% block header %}
     {{ govukHeader({
         homepageUrl: 'general.header.homepageHref' | translate,
-        useTudorCrown: false
+        useTudorCrown: true
     }) }}
 {% endblock %}
 


### PR DESCRIPTION
## What?

Enables Tudor Crown in header and favicons across pages.

## Why?

To reflect use of new crown across Digital Identity.

## Screenshots

### After change (graphics based on Tudor crown)

#### Site header logo
<img width="984" alt="New Crown" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/13f7c44f-7127-4f06-9243-4efbb7512d2f">

#### Favicon

<img width="255" alt="Tudor favicon" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/e420e156-6940-48e5-8a28-6018da28339f">


### Before change

#### Site header logo
<img width="989" alt="Previous crown" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/b86b148c-d303-4496-bf48-aa2973ccb242">

#### Favicon

<img width="249" alt="Previous favicon" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/8e2a5680-8a52-44ba-ac39-46c5f1a604be">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1360
- https://github.com/alphagov/di-infrastructure/pull/574
