### PR TITLE
AUT-2389: New 2FA content missing from 'Enter security code from your auth app' page

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -29,3 +29,4 @@ orch_to_auth_audience           = "https://signin.build.account.gov.uk/"
 
 dynatrace_secret_arn                     = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 frame_ancestors_form_actions_csp_headers = "1"
+support_2fa_b4_password_reset            = "1"

--- a/src/components/reset-password-2fa-auth-app/index.njk
+++ b/src/components/reset-password-2fa-auth-app/index.njk
@@ -1,9 +1,10 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set pageTitleName = 'pages.enterAuthenticatorAppCode.title' | translate %}
+{% set pageTitleName = 'pages.enterAuthenticatorAppCode.2FaBeforeResetPassword.title' | translate %}
 
 {% block content %}
 
@@ -15,12 +16,20 @@
     <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
     <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
 
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3" id="updatedHeading">{{'pages.enterAuthenticatorAppCode.2FaBeforeResetPassword.header' | translate }}</h1>
+
+    <p class="govuk-body">
+            {{ govukInsetText({
+            html: 'pages.enterAuthenticatorAppCode.2FaBeforeResetPassword.info.paragraph1' | translate
+             + '<span class="govuk-body govuk-!-font-weight-bold">' +  'pages.enterAuthenticatorAppCode.2FaBeforeResetPassword.info.authenticatorApp' | translate + '</span>' +
+             'pages.enterAuthenticatorAppCode.2FaBeforeResetPassword.info.paragraph1End'| translate
+        }) }}
+        </p>
+
     {{ govukInput({
-      label: {
-        text: 'pages.enterAuthenticatorAppCode.header' | translate,
-        classes: "govuk-label--l",
-        isPageHeading: true
-      },
+    label: {
+                text: 'pages.enterAuthenticatorAppCode.2FaBeforeResetPassword.code.label' | translate
+            },
     classes: "govuk-input--width-10",
     id: "code",
     name: "code",
@@ -31,6 +40,7 @@
       text: errors['code'].text
     } if (errors['code'])})
   }}
+
 
     {{ govukButton({
     "text": "general.continue.label" | translate,

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon } from "../../../../test/utils/test-utils";
 import * as cheerio from "cheerio";
 import {
   API_ENDPOINTS,
@@ -61,9 +61,15 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
     app = undefined;
   });
 
-  it("should return check auth app page", (done) => {
+  it("should return updated check auth app page", (done) => {
     nock(baseApi).persist().post("/mfa").reply(204);
-    request(app).get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP).expect(200, done);
+    request(app)
+      .get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#updatedHeading").length).to.eq(1);
+      })
+      .expect(200, done);
   });
 
   it("should redirect to reset password step when valid sms code is entered", (done) => {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2197,6 +2197,18 @@
           "label": "Rhowch y cod diogelwch",
           "labelSummary": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd"
         }
+      },
+      "2FaBeforeResetPassword": {
+        "title": "Enter a security code from your authenticator app",
+        "header": "Enter a security code from your authenticator app",
+        "info": {
+          "paragraph1": "I gael cod diogelwch, agorwch yr ",
+          "authenticatorApp": "ap dilysydd ",
+          "paragraph1End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login"
+        },
+        "code":{
+          "label": "Rhowch y cod diogelwch 6 digid"
+        }
       }
     },
     "securityCodeEnteredExceeded": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2197,6 +2197,18 @@
           "label": "Enter the security code",
           "labelSummary": "This is the 6-digit number shown in your authenticator app"
         }
+      },
+      "2FaBeforeResetPassword": {
+        "title": "Enter a security code from your authenticator app",
+        "header": "Enter a security code from your authenticator app",
+        "info": {
+          "paragraph1": "To get a security code, open the ",
+          "authenticatorApp": "authenticator app ",
+          "paragraph1End": "you used to create your GOV.UK One Login"
+        },
+        "code":{
+          "label": "Enter the 6 digit security code"
+        }
       }
     },
     "securityCodeEnteredExceeded": {


### PR DESCRIPTION
## What?

Add New 2FA content missing from 'Enter security code from your auth app' page.

## Why?

New UI/UX design is required
