### PR TITLE
Aut 2396/call account interventions on password reset

### DIFF
--- a/src/components/auth-code/auth-code-routes.ts
+++ b/src/components/auth-code/auth-code-routes.ts
@@ -13,7 +13,7 @@ router.get(
   PATH_NAMES.AUTH_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware()),
+  asyncHandler(accountInterventionsMiddleware(false)),
   asyncHandler(authCodeGet())
 );
 

--- a/src/components/auth-code/auth-code-routes.ts
+++ b/src/components/auth-code/auth-code-routes.ts
@@ -13,7 +13,7 @@ router.get(
   PATH_NAMES.AUTH_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware(false)),
+  asyncHandler(accountInterventionsMiddleware(false, true)),
   asyncHandler(authCodeGet())
 );
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -567,6 +567,9 @@ const authStateMachine = createMachine(
       },
       [PATH_NAMES.RESET_PASSWORD]: {
         on: {
+          [USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_PERMANENT,
+          ],
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
               target: [PATH_NAMES.GET_SECURITY_CODES],

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -570,6 +570,9 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION]: [
             PATH_NAMES.UNAVAILABLE_PERMANENT,
           ],
+          [USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_TEMPORARY,
+          ],
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
               target: [PATH_NAMES.GET_SECURITY_CODES],

--- a/src/components/prove-identity/prove-identity-routes.ts
+++ b/src/components/prove-identity/prove-identity-routes.ts
@@ -13,7 +13,7 @@ router.get(
   PATH_NAMES.PROVE_IDENTITY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware()),
+  asyncHandler(accountInterventionsMiddleware(false)),
   asyncHandler(proveIdentityGet())
 );
 

--- a/src/components/prove-identity/prove-identity-routes.ts
+++ b/src/components/prove-identity/prove-identity-routes.ts
@@ -13,7 +13,7 @@ router.get(
   PATH_NAMES.PROVE_IDENTITY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware(false)),
+  asyncHandler(accountInterventionsMiddleware(false, true)),
   asyncHandler(proveIdentityGet())
 );
 

--- a/src/components/reset-password/reset-password-routes.ts
+++ b/src/components/reset-password/reset-password-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "./reset-password-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { accountInterventionsMiddleware } from "../../middleware/account-interventions-middleware";
 
 const router = express.Router();
 
@@ -20,6 +21,7 @@ router.get(
   PATH_NAMES.RESET_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
+  asyncHandler(accountInterventionsMiddleware()),
   resetPasswordGet
 );
 

--- a/src/components/reset-password/reset-password-routes.ts
+++ b/src/components/reset-password/reset-password-routes.ts
@@ -21,7 +21,7 @@ router.get(
   PATH_NAMES.RESET_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware(true)),
+  asyncHandler(accountInterventionsMiddleware(true, false)),
   resetPasswordGet
 );
 

--- a/src/components/reset-password/reset-password-routes.ts
+++ b/src/components/reset-password/reset-password-routes.ts
@@ -21,7 +21,7 @@ router.get(
   PATH_NAMES.RESET_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware()),
+  asyncHandler(accountInterventionsMiddleware(true)),
   resetPasswordGet
 );
 

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -95,6 +95,16 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       .expect(302, done);
   });
 
+  it("should return reset password page when someone has a reset password intervention", (done) => {
+    setupAccountInterventionsResponse(baseApi, {
+      blocked: false,
+      passwordResetRequired: true,
+      temporarilySuspended: false,
+    });
+
+    request(app).get(ENDPOINT).expect(200, done);
+  });
+
   it("should return error when csrf not present", (done) => {
     request(app)
       .post(ENDPOINT)

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -80,6 +80,21 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       .expect(302, done);
   });
 
+  it("should return the suspended screen when someone has a suspended intervention", (done) => {
+    setupAccountInterventionsResponse(baseApi, {
+      blocked: false,
+      passwordResetRequired: false,
+      temporarilySuspended: true,
+    });
+
+    request(app)
+      .get(ENDPOINT)
+      .expect(function (res) {
+        expect(res.headers.location).to.eq("/unavailable-temporary");
+      })
+      .expect(302, done);
+  });
+
   it("should return error when csrf not present", (done) => {
     request(app)
       .post(ENDPOINT)

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -5,6 +5,10 @@ import nock = require("nock");
 import * as cheerio from "cheerio";
 import { PATH_NAMES } from "../../../app.constants";
 import decache from "decache";
+import {
+  noInterventions,
+  setupAccountInterventionsResponse,
+} from "../../../../test/helpers/account-interventions-helpers";
 
 describe("Integration::reset password (in 2FA Before Reset Password flow)", () => {
   let token: string | string[];
@@ -36,6 +40,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       });
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
+    setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
       .get(ENDPOINT)
@@ -56,7 +61,23 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
   });
 
   it("should return reset password page", (done) => {
+    setupAccountInterventionsResponse(baseApi, noInterventions);
     request(app).get(ENDPOINT).expect(200, done);
+  });
+
+  it("should return the blocked screen when someone has a blocked intervention", (done) => {
+    setupAccountInterventionsResponse(baseApi, {
+      blocked: true,
+      passwordResetRequired: false,
+      temporarilySuspended: false,
+    });
+
+    request(app)
+      .get(ENDPOINT)
+      .expect(function (res) {
+        expect(res.headers.location).to.eq("/unavailable-permanent");
+      })
+      .expect(302, done);
   });
 
   it("should return error when csrf not present", (done) => {

--- a/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
@@ -5,6 +5,10 @@ import nock = require("nock");
 import * as cheerio from "cheerio";
 import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../app.constants";
 import decache from "decache";
+import {
+  noInterventions,
+  setupAccountInterventionsResponse,
+} from "../../../../test/helpers/account-interventions-helpers";
 
 describe("Integration::reset password (in 2FA Before Reset Password flow)", () => {
   let token: string | string[];
@@ -39,6 +43,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       });
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
+    setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
       .get(ENDPOINT)
@@ -59,6 +64,8 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
   });
 
   it("should return reset password page", (done) => {
+    setupAccountInterventionsResponse(baseApi, noInterventions);
+
     request(app).get(ENDPOINT).expect(200, done);
   });
 

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -98,6 +98,16 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(302, done);
   });
 
+  it("should return reset password page when someone has a reset password intervention", (done) => {
+    setupAccountInterventionsResponse(baseApi, {
+      blocked: false,
+      passwordResetRequired: true,
+      temporarilySuspended: false,
+    });
+
+    request(app).get(ENDPOINT).expect(200, done);
+  });
+
   it("should return error when csrf not present", (done) => {
     request(app)
       .post(ENDPOINT)

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -5,6 +5,10 @@ import nock = require("nock");
 import * as cheerio from "cheerio";
 import { PATH_NAMES } from "../../../app.constants";
 import decache from "decache";
+import {
+  noInterventions,
+  setupAccountInterventionsResponse,
+} from "../../../../test/helpers/account-interventions-helpers";
 
 describe("Integration::reset password (in 6 digit code flow)", () => {
   let token: string | string[];
@@ -16,6 +20,8 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
 
   before(async () => {
     process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
+
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -36,6 +42,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       });
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
+    setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
       .get(ENDPOINT)
@@ -55,8 +62,25 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
     app = undefined;
   });
 
-  it("should return reset password page", (done) => {
+  it("should return reset password page when there are no interventions on a user", (done) => {
+    setupAccountInterventionsResponse(baseApi, noInterventions);
+
     request(app).get(ENDPOINT).expect(200, done);
+  });
+
+  it("should return the blocked screen when someone has a blocked intervention", (done) => {
+    setupAccountInterventionsResponse(baseApi, {
+      blocked: true,
+      passwordResetRequired: false,
+      temporarilySuspended: false,
+    });
+
+    request(app)
+      .get(ENDPOINT)
+      .expect(function (res) {
+        expect(res.headers.location).to.eq("/unavailable-permanent");
+      })
+      .expect(302, done);
   });
 
   it("should return error when csrf not present", (done) => {

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -83,6 +83,21 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(302, done);
   });
 
+  it("should return the suspended screen when someone has a suspended intervention", (done) => {
+    setupAccountInterventionsResponse(baseApi, {
+      blocked: false,
+      passwordResetRequired: false,
+      temporarilySuspended: true,
+    });
+
+    request(app)
+      .get(ENDPOINT)
+      .expect(function (res) {
+        expect(res.headers.location).to.eq("/unavailable-temporary");
+      })
+      .expect(302, done);
+  });
+
   it("should return error when csrf not present", (done) => {
     request(app)
       .post(ENDPOINT)

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -7,6 +7,7 @@ import { supportAccountInterventions } from "../config";
 
 export function accountInterventionsMiddleware(
   handleSuspendedStatus: boolean,
+  handlePasswordResetStatus: boolean,
   service = accountInterventionService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response, next: NextFunction) {
@@ -42,7 +43,10 @@ export function accountInterventionsMiddleware(
             USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
           )
         );
-      } else if (accountInterventionsResponse.data.passwordResetRequired) {
+      } else if (
+        accountInterventionsResponse.data.passwordResetRequired &&
+        handlePasswordResetStatus
+      ) {
         return res.redirect(
           getNextPathAndUpdateJourney(
             req,

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -33,17 +33,6 @@ export function accountInterventionsMiddleware(
           )
         );
       } else if (
-        accountInterventionsResponse.data.temporarilySuspended &&
-        handleSuspendedStatus
-      ) {
-        return res.redirect(
-          getNextPathAndUpdateJourney(
-            req,
-            req.path,
-            USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
-          )
-        );
-      } else if (
         accountInterventionsResponse.data.passwordResetRequired &&
         handlePasswordResetStatus
       ) {
@@ -52,6 +41,17 @@ export function accountInterventionsMiddleware(
             req,
             req.path,
             USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION
+          )
+        );
+      } else if (
+        accountInterventionsResponse.data.temporarilySuspended &&
+        handleSuspendedStatus
+      ) {
+        return res.redirect(
+          getNextPathAndUpdateJourney(
+            req,
+            req.path,
+            USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
           )
         );
       }

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -6,6 +6,7 @@ import { ExpressRouteFunc } from "../types";
 import { supportAccountInterventions } from "../config";
 
 export function accountInterventionsMiddleware(
+  handleSuspendedStatus: boolean,
   service = accountInterventionService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response, next: NextFunction) {
@@ -28,6 +29,17 @@ export function accountInterventionsMiddleware(
             req,
             req.path,
             USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION
+          )
+        );
+      } else if (
+        accountInterventionsResponse.data.temporarilySuspended &&
+        handleSuspendedStatus
+      ) {
+        return res.redirect(
+          getNextPathAndUpdateJourney(
+            req,
+            req.path,
+            USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
           )
         );
       } else if (accountInterventionsResponse.data.passwordResetRequired) {

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -1,7 +1,7 @@
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../src/app.constants";
 import nock = require("nock");
 
-type AccountInterventionsFlags = {
+export type AccountInterventionsFlags = {
   blocked: boolean;
   passwordResetRequired: boolean;
   temporarilySuspended: boolean;

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -1,0 +1,23 @@
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../src/app.constants";
+import nock = require("nock");
+
+type AccountInterventionsFlags = {
+  blocked: boolean;
+  passwordResetRequired: boolean;
+  temporarilySuspended: boolean;
+};
+
+export const setupAccountInterventionsResponse = (
+  baseApi: string,
+  flags: AccountInterventionsFlags
+) => {
+  nock(baseApi)
+    .post(API_ENDPOINTS.ACCOUNT_INTERVENTIONS)
+    .once()
+    .reply(HTTP_STATUS_CODES.OK, {
+      email: "joe.bloggs@test.com",
+      passwordResetRequired: flags.passwordResetRequired,
+      blocked: flags.blocked,
+      temporarilySuspended: flags.temporarilySuspended,
+    });
+};

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -21,3 +21,9 @@ export const setupAccountInterventionsResponse = (
       temporarilySuspended: flags.temporarilySuspended,
     });
 };
+
+export const noInterventions: AccountInterventionsFlags = {
+  blocked: false,
+  passwordResetRequired: false,
+  temporarilySuspended: false,
+};

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -46,7 +46,7 @@ describe("accountInterventionsMiddleware", () => {
       temporarilySuspended: false,
     });
 
-    await callMiddleware(fakeAccountInterventionService);
+    await callMiddleware(false, fakeAccountInterventionService);
     expect(next).to.be.calledOnce;
   });
 
@@ -58,7 +58,7 @@ describe("accountInterventionsMiddleware", () => {
       temporarilySuspended: false,
     });
 
-    await callMiddleware(fakeAccountInterventionService);
+    await callMiddleware(false, fakeAccountInterventionService);
     expect(next).to.be.calledOnce;
   });
 
@@ -69,7 +69,7 @@ describe("accountInterventionsMiddleware", () => {
       temporarilySuspended: false,
     });
 
-    await callMiddleware(fakeAccountInterventionService);
+    await callMiddleware(false, fakeAccountInterventionService);
     expect(res.redirect).to.have.been.calledWith(
       PATH_NAMES.PASSWORD_RESET_REQUIRED
     );
@@ -82,9 +82,22 @@ describe("accountInterventionsMiddleware", () => {
       temporarilySuspended: false,
     });
 
-    await callMiddleware(fakeAccountInterventionService);
+    await callMiddleware(false, fakeAccountInterventionService);
     expect(res.redirect).to.have.been.calledWith(
       PATH_NAMES.UNAVAILABLE_PERMANENT
+    );
+  });
+
+  it("should redirect to getNextPathAndUpdateJourney with the journey being TEMPORARILY_BLOCKED_INTERVENTIONS when temporarilySuspended === true and handleSuspendedStatus === true", async () => {
+    const fakeAccountInterventionService = fakeAccountInterventionsService({
+      passwordResetRequired: false,
+      blocked: false,
+      temporarilySuspended: true,
+    });
+
+    await callMiddleware(true, fakeAccountInterventionService);
+    expect(res.redirect).to.have.been.calledWith(
+      PATH_NAMES.UNAVAILABLE_TEMPORARY
     );
   });
 
@@ -94,21 +107,21 @@ describe("accountInterventionsMiddleware", () => {
       blocked: false,
       temporarilySuspended: true,
     });
-    await callMiddleware(fakeAccountInterventionService);
 
+    await callMiddleware(false, fakeAccountInterventionService);
     expect(res.redirect).to.not.have.been.calledWith(
       PATH_NAMES.UNAVAILABLE_TEMPORARY
     );
   });
 
   const callMiddleware = (
+    handleSuspendedStatus: boolean,
     accountInterventionService: AccountInterventionsInterface
   ) => {
-    accountInterventionsMiddleware(accountInterventionService)(
-      req as Request,
-      res as Response,
-      next as NextFunction
-    );
+    accountInterventionsMiddleware(
+      handleSuspendedStatus,
+      accountInterventionService
+    )(req as Request, res as Response, next as NextFunction);
   };
 
   const fakeAccountInterventionsService = (

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -6,6 +6,7 @@ import { sinon } from "../../utils/test-utils";
 import { expect } from "chai";
 import { accountInterventionsMiddleware } from "../../../src/middleware/account-interventions-middleware";
 import { AccountInterventionsInterface } from "../../../src/components/account-intervention/types";
+import { AccountInterventionsFlags } from "../../helpers/account-interventions-helpers";
 
 describe("accountInterventionsMiddleware", () => {
   let req: Partial<Request>;
@@ -39,104 +40,89 @@ describe("accountInterventionsMiddleware", () => {
   });
 
   it("should call next() when no account intervention API response options are true and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: false,
-          blocked: false,
-          temporarilySuspended: false,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await accountInterventionsMiddleware(fakeAccountInterventionService)(
-      req as Request,
-      res as Response,
-      next as NextFunction
-    );
+    const fakeAccountInterventionService = fakeAccountInterventionsService({
+      passwordResetRequired: false,
+      blocked: false,
+      temporarilySuspended: false,
+    });
+
+    await callMiddleware(fakeAccountInterventionService);
     expect(next).to.be.calledOnce;
   });
 
   it("should call next() when supportAccountInterventions() returns false", async () => {
     process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "0";
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: false,
-          blocked: false,
-          temporarilySuspended: false,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await accountInterventionsMiddleware(fakeAccountInterventionService)(
-      req as Request,
-      res as Response,
-      next as NextFunction
-    );
+    const fakeAccountInterventionService = fakeAccountInterventionsService({
+      passwordResetRequired: false,
+      blocked: false,
+      temporarilySuspended: false,
+    });
+
+    await callMiddleware(fakeAccountInterventionService);
     expect(next).to.be.calledOnce;
   });
 
   it("should redirect to getNextPathAndUpdateJourney with the journey being PASSWORD_RESET_INTERVENTION when passwordResetRequired === true in the response and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: true,
-          blocked: false,
-          temporarilySuspended: false,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await accountInterventionsMiddleware(fakeAccountInterventionService)(
-      req as Request,
-      res as Response,
-      next as NextFunction
-    );
+    const fakeAccountInterventionService = fakeAccountInterventionsService({
+      passwordResetRequired: true,
+      blocked: false,
+      temporarilySuspended: false,
+    });
+
+    await callMiddleware(fakeAccountInterventionService);
     expect(res.redirect).to.have.been.calledWith(
       PATH_NAMES.PASSWORD_RESET_REQUIRED
     );
   });
 
   it("should redirect to getNextPathAndUpdateJourney with the journey being PERMANENTLY_BLOCKED_INTERVENTION when blocked === true in the response and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: false,
-          blocked: true,
-          temporarilySuspended: false,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await accountInterventionsMiddleware(fakeAccountInterventionService)(
-      req as Request,
-      res as Response,
-      next as NextFunction
-    );
+    const fakeAccountInterventionService = fakeAccountInterventionsService({
+      passwordResetRequired: false,
+      blocked: true,
+      temporarilySuspended: false,
+    });
+
+    await callMiddleware(fakeAccountInterventionService);
     expect(res.redirect).to.have.been.calledWith(
       PATH_NAMES.UNAVAILABLE_PERMANENT
     );
   });
 
   it("should redirect to getNextPathAndUpdateJourney with the journey being TEMPORARILY_BLOCKED_INTERVENTION when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: false,
-          blocked: false,
-          temporarilySuspended: true,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await accountInterventionsMiddleware(fakeAccountInterventionService)(
-      req as Request,
-      res as Response,
-      next as NextFunction
-    );
+    const fakeAccountInterventionService = fakeAccountInterventionsService({
+      passwordResetRequired: false,
+      blocked: false,
+      temporarilySuspended: true,
+    });
+    await callMiddleware(fakeAccountInterventionService);
+
     expect(res.redirect).to.not.have.been.calledWith(
       PATH_NAMES.UNAVAILABLE_TEMPORARY
     );
   });
+
+  const callMiddleware = (
+    accountInterventionService: AccountInterventionsInterface
+  ) => {
+    accountInterventionsMiddleware(accountInterventionService)(
+      req as Request,
+      res as Response,
+      next as NextFunction
+    );
+  };
+
+  const fakeAccountInterventionsService = (
+    flags: AccountInterventionsFlags
+  ) => {
+    return {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: flags.passwordResetRequired,
+          blocked: flags.blocked,
+          temporarilySuspended: flags.temporarilySuspended,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+  };
 });

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -88,7 +88,7 @@ describe("accountInterventionsMiddleware", () => {
     );
   });
 
-  it("should redirect to getNextPathAndUpdateJourney with the journey being TEMPORARILY_BLOCKED_INTERVENTION when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
+  it("should not redirect to UNAVAILABLE_TEMPORARY when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
     const fakeAccountInterventionService = fakeAccountInterventionsService({
       passwordResetRequired: false,
       blocked: false,

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -119,6 +119,23 @@ describe("accountInterventionsMiddleware", () => {
     );
   });
 
+  it("should redirect to getNextPathAndUpdateJourney with the journey being RESET_PASSWORD_REQUIRED when passwordResetRequired === true, temporarilySuspended === true", async () => {
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: true,
+          blocked: false,
+          temporarilySuspended: true,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await callMiddleware(true, true, fakeAccountInterventionService);
+    expect(res.redirect).to.have.been.calledWith(
+      PATH_NAMES.PASSWORD_RESET_REQUIRED
+    );
+  });
+
   it("should not redirect to UNAVAILABLE_TEMPORARY when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
     const fakeAccountInterventionService = fakeAccountInterventionsService({
       passwordResetRequired: false,


### PR DESCRIPTION
## What?

This ensures that, when a user goes through the "forgotten password" flow, they are sent to the account suspended or blocked screen instead of being able to re-set their password.

## Why?

We should not allow users to re-set their passwords who have account interventions set on them.