### PR TITLE
BAU: Switch of 2FA B4 password reset in build

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -29,4 +29,3 @@ orch_to_auth_audience           = "https://signin.build.account.gov.uk/"
 
 dynatrace_secret_arn                     = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 frame_ancestors_form_actions_csp_headers = "1"
-support_2fa_b4_password_reset            = "1"


### PR DESCRIPTION
## What?

Switch of 2FA B4 password reset in build.

## Why?

Further testing is required to make compatible with the acceptance tests.