### PR TITLE
feature flag for 2hr lockout duration increase

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -163,7 +163,11 @@ locals {
       {
         name  = "SUPPORT_REAUTHENTICATION"
         value = var.support_reauthentication
-      }
+      },
+      {
+        name  = "SUPPORT_2HR_LOCKOUT"
+        value = var.support_2hr_lockout
+      },
     ]
 
     secrets = [

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -247,6 +247,12 @@ variable "support_2fa_b4_password_reset" {
   default     = "0"
 }
 
+variable "support_2hr_lockout" {
+  description = "When true enables 2hr lockout"
+  type        = string
+  default     = "0"
+}
+
 variable "support_account_interventions" {
   description = "When true, turns on account interventions in environment"
   type        = string

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -7,7 +7,10 @@ import { SinonStub } from "sinon";
 import { API_ENDPOINTS } from "../../../app.constants";
 import { AuthCodeServiceInterface } from "../types";
 import { Http } from "../../../utils/http";
-import { support2FABeforePasswordReset } from "../../../config";
+import {
+  support2FABeforePasswordReset,
+  support2hrLockout,
+} from "../../../config";
 
 describe("authentication auth code service", () => {
   const redirectUriSentToAuth = "/redirect-uri";
@@ -163,6 +166,26 @@ describe("authentication auth code service", () => {
       process.env.SUPPORT_2FA_B4_PASSWORD_RESET = undefined;
 
       expect(support2FABeforePasswordReset()).to.be.false;
+    });
+  });
+
+  describe("support2hrLockout() with the support 2hr lockout for password and code lockouts", () => {
+    it("should return true when SUPPORT_2HR_LOCKOUT is set to '1'", async () => {
+      process.env.SUPPORT_2HR_LOCKOUT = "1";
+
+      expect(support2hrLockout()).to.be.true;
+    });
+
+    it("should return false  when SUPPORT_2HR_LOCKOUT is set to '0'", async () => {
+      process.env.SUPPORT_2HR_LOCKOUT = "0";
+
+      expect(support2hrLockout()).to.be.false;
+    });
+
+    it("should return false when SUPPORT_2HR_LOCKOUT is undefined", async () => {
+      process.env.SUPPORT_2HR_LOCKOUT = undefined;
+
+      expect(support2hrLockout()).to.be.false;
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,6 +173,10 @@ export function support2FABeforePasswordReset(): boolean {
   return process.env.SUPPORT_2FA_B4_PASSWORD_RESET === "1";
 }
 
+export function support2hrLockout(): boolean {
+  return process.env.SUPPORT_2HR_LOCKOUT === "1";
+}
+
 export function supportAccountInterventions(): boolean {
   return process.env.SUPPORT_ACCOUNT_INTERVENTIONS === "1";
 }


### PR DESCRIPTION
## What?

Added a feature flag for the lockout duration increase.

## Why?

Require a frontend flag for the new copy updates to mirror the existing flag in the backend PR as the new copy specifies the new 2hr lockout period

