### PR TITLE
AUT-2362/enter password error update

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -17,6 +17,7 @@ import { CheckReauthServiceInterface } from "../check-reauth-users/types";
 import { checkReauthUsersService } from "../check-reauth-users/check-reauth-users-service";
 import {
   getEmailEnteredWrongBlockDurationInMinutes,
+  support2hrLockout,
   supportReauthentication,
 } from "../../config";
 import {
@@ -98,7 +99,9 @@ export function enterEmailPost(
 
     if (!result.success) {
       if (result.data.code === ERROR_CODES.ACCOUNT_LOCKED) {
-        return res.render("enter-password/index-sign-in-retry-blocked.njk");
+        return res.render("enter-password/index-sign-in-retry-blocked.njk", {
+          support2hrLockout: support2hrLockout(),
+        });
       }
       throw new BadRequestError(result.data.message, result.data.code);
     }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -19,7 +19,7 @@ import { MFA_METHOD_TYPE } from "../../app.constants";
 import xss from "xss";
 import { EnterEmailServiceInterface } from "../enter-email/types";
 import { enterEmailService } from "../enter-email/enter-email-service";
-import { support2FABeforePasswordReset } from "../../config";
+import { support2FABeforePasswordReset, support2hrLockout } from "../../config";
 import { getJourneyTypeFromUserSession } from "../common/journey/journey";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
@@ -56,6 +56,7 @@ export function enterSignInRetryBlockedGet(
     ) {
       return res.render("enter-password/index-sign-in-retry-blocked.njk", {
         newLink: "/sign-in-retry-blocked",
+        support2hrLockout: support2hrLockout(),
       });
     }
 
@@ -69,6 +70,7 @@ export function enterPasswordAccountLockedGet(
 ): void {
   res.render("enter-password/index-account-locked.njk", {
     newLink: "/sign-in-retry-blocked",
+    support2hrLockout: support2hrLockout(),
   });
 }
 

--- a/src/components/enter-password/index-account-locked.njk
+++ b/src/components/enter-password/index-account-locked.njk
@@ -11,17 +11,26 @@
 
 {% include "common/errors/errorSummary.njk" %}
 
+{% if support2hrLockout %}
+
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountLocked.header' | translate}}</h1>
-
 <p class="govuk-body">{{'pages.accountLocked.paragraph' | translate}}</p>
-
 <h2 class="govuk-heading-m">{{'pages.accountLocked.subHeader' | translate}}</h2>
-
 <p class="govuk-body">{{'pages.accountLocked.bulletPointSection.title' | translate}}</p>
-
 <ul class="govuk-list govuk-list--bullet">
-    <li>{{'pages.accountLocked.bulletPointSection.first' | translate}}<a href={{ newLink }} class="govuk-link">{{'pages.accountLocked.bulletPointSection.firstLink' | translate}}</a></li>
-    <li><a href="/reset-password-request" class="govuk-link">{{'pages.accountLocked.bulletPointSection.second' | translate}}</a></li>
+    <li><a href="/reset-password-request" class="govuk-link">{{'pages.accountLocked.bulletPointSection.first' | translate}}</a></li>
+    <li>{{'pages.accountLocked.bulletPointSection.second' | translate}}</li>
 </ul>
+{% else %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountLocked.header' | translate}}</h1>
+<p class="govuk-body">{{'pages.accountLocked.paragraph_old' | translate}}</p>
+<h2 class="govuk-heading-m">{{'pages.accountLocked.subHeader_old' | translate}}</h2>
+<p class="govuk-body">{{'pages.accountLocked.bulletPointSection.title' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+    <li>{{'pages.accountLocked.bulletPointSection.first_old' | translate}}<a href={{ newLink }} class="govuk-link">{{'pages.accountLocked.bulletPointSection.firstLink_old' | translate}}</a></li>
+    <li><a href="/reset-password-request" class="govuk-link">{{'pages.accountLocked.bulletPointSection.second_old' | translate}}</a></li>
+</ul>
+{% endif %}
 
 {% endblock %}

--- a/src/components/enter-password/index-sign-in-retry-blocked.njk
+++ b/src/components/enter-password/index-sign-in-retry-blocked.njk
@@ -15,16 +15,27 @@
 
 <p class="govuk-body">{{'pages.signInRetryBlocked.paragraph' | translate}}</p>
 
+{% if support2hrLockout %}
+
+<h2 class="govuk-heading-m">{{'pages.signInRetryBlocked.subHeader' | translate}}</h2>
+<p class="govuk-body">{{'pages.signInRetryBlocked.bulletPointSection.title' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+    <li><a href="/reset-password-request" class="govuk-link">{{'pages.signInRetryBlocked.bulletPointSection.first' | translate}}</a></li>
+    <li>{{'pages.signInRetryBlocked.bulletPointSection.second' | translate}}</li>
+</ul>
+{% else %}
+
 <p class="govuk-body">
-    {{'pages.signInRetryBlocked.info.paragraph1Start' | translate}}
-    <a class="govuk-link" rel="noreferrer" href={{ newLink }}>{{'pages.signInRetryBlocked.info.firstLink' | translate}}</a>
-    {{'pages.signInRetryBlocked.info.paragraph1End' | translate}}
+    {{'pages.signInRetryBlocked.info_old.paragraph1Start' | translate}}
+    <a class="govuk-link" rel="noreferrer" href={{ newLink }}>{{'pages.signInRetryBlocked.info_old.firstLink' | translate}}</a>
+    {{'pages.signInRetryBlocked.info_old.paragraph1End' | translate}}
 </p>
 
 <p class="govuk-body">
-    {{'pages.signInRetryBlocked.info.paragraph2Start' | translate}}
-    <a class="govuk-link" rel="noreferrer" href="/reset-password">{{'pages.signInRetryBlocked.info.secondLink' | translate}}</a>
-    {{'pages.signInRetryBlocked.info.paragraph2End' | translate}}
+    {{'pages.signInRetryBlocked.info_old.paragraph2Start' | translate}}
+    <a class="govuk-link" rel="noreferrer" href="/reset-password">{{'pages.signInRetryBlocked.info_old.secondLink' | translate}}</a>
+    {{'pages.signInRetryBlocked.info_old.paragraph2End' | translate}}
 </p>
+{% endif %}
 
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1589,15 +1589,19 @@
     "accountLocked": {
       "title": "Rydych wedi rhoi’r cyfrinair anghywir i mewn ormod o weithiau",
       "header": "Rydych wedi rhoi’r cyfrinair anghywir i mewn ormod o weithiau",
-      "paragraph": "Rydych chi wedi cael eich cloi allan o’ch GOV.UK One Login oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
-      "subHeader": "Beth nesaf",
+      "paragraph_old": "Rydych chi wedi cael eich cloi allan o’ch GOV.UK One Login oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
+      "paragraph":"Ni fyddwch yn gallu mewngofnodi am 2 awr, oherwydd eich bod wedi rhoi’r cyfrinair anghywir fwy na 5 gwaith.",
+      "subHeader_old": "Beth nesaf",
+      "subHeader":"Beth allwch chi ei wneud",
       "bulletPointSection": {
         "title": "Gallwch:",
-        "first": "aros am 15 munud a ",
-        "firstLink": "cheisio mewngofnodi eto",
-        "second": "ailosod eich cyfrinair"
+        "first_old": "aros am 15 munud a ",
+        "first":"ailosod eich cyfrinair",
+        "firstLink_old": "cheisio mewngofnodi eto",
+        "second_old": "ailosod eich cyfrinair",
+        "second":"arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
       }
-    },
+    }, 
     "browserBackButtonError": {
       "title": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",
       "header": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",
@@ -2249,13 +2253,22 @@
       "title": "Ni allwch fewngofnodi ar hyn o bryd",
       "header": "Ni allwch fewngofnodi ar hyn o bryd",
       "paragraph": "Mae hyn oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith y tro diwethaf i chi geisio mewngofnodi. Mae hyn er mwyn cadw eich GOV.UK One Login yn ddiogel.",
-      "info": {
+      "info_old": {
         "paragraph1Start": "Gallwch ",
         "firstLink": "geisio mewngofnodi eto",
         "paragraph1End": " ar ôl i 15 munud fynd heibio.",
         "paragraph2Start": "Gallwch hefyd ",
         "secondLink": "ailosod eich cyfrinair",
         "paragraph2End": "."
+      },
+      "subHeader":"Beth allwch chi ei wneud",
+      "bulletPointSection": {
+        "title": "Gallwch:",
+        "first_old": "aros am 15 munud a ",
+        "first":"ailosod eich cyfrinair",
+        "firstLink_old": "cheisio mewngofnodi eto",
+        "second_old": "ailosod eich cyfrinair",
+        "second":"arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
       }
     },
     "needToResetPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1589,13 +1589,17 @@
     "accountLocked": {
       "title": "You entered the wrong password too many times",
       "header": "You entered the wrong password too many times",
-      "paragraph": "You’ve been locked out of your GOV.UK One Login because you entered the wrong password more than 5 times. This is to keep your GOV.UK One Login secure.",
-      "subHeader": "What next",
+      "paragraph_old": "You’ve been locked out of your GOV.UK One Login because you entered the wrong password more than 5 times. This is to keep your GOV.UK One Login secure.",
+      "paragraph": "You will not be able to sign in for 2 hours, because you entered the wrong password more than 5 times. This is to keep your GOV.UK One Login secure.",
+      "subHeader_old": "What next",
+      "subHeader": "What you can do",
       "bulletPointSection": {
         "title": "You can:",
-        "first": "wait 15 minutes and ",
-        "firstLink": "try to sign in again",
-        "second": "reset your password"
+        "first_old": "wait 15 minutes and ",
+        "first": "reset your password",
+        "firstLink_old": "try to sign in again",
+        "second_old": "reset your password",
+        "second": "wait 2 hours, then go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage"
       }
     },
     "browserBackButtonError": {
@@ -2249,13 +2253,22 @@
       "title": "You cannot sign in at the moment",
       "header": "You cannot sign in at the moment",
       "paragraph": "This is because you entered the wrong password more than 5 times the last time you tried to sign in. This is to keep your GOV.UK One Login secure.",
-      "info": {
+      "info_old": {
         "paragraph1Start": "You can ",
         "firstLink": "try to sign in again",
         "paragraph1End": " after 15 minutes have passed.",
         "paragraph2Start": "You can also ",
         "secondLink": "reset your password",
         "paragraph2End": "."
+      },
+      "subHeader": "What you can do",
+      "bulletPointSection": {
+        "title": "You can:",
+        "first_old": "wait 15 minutes and ",
+        "first": "reset your password",
+        "firstLink_old": "try to sign in again",
+        "second_old": "reset your password",
+        "second": "wait 2 hours, then go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage"
       }
     },
     "needToResetPassword": {


### PR DESCRIPTION
## What?

Copy update for enter password lockout error screens using feature flag.

## Why?

When feature flag is enabled lockout is increased to 2 hours so we need to display updated error messages.


## Evidence for feature flag turned off

Lockout
<img width="1694" alt="Screenshot 2024-02-16 at 13 48 08" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/9aa4ed6d-edf3-4569-87a6-b5596ee270a3">
<img width="1694" alt="Screenshot 2024-02-16 at 13 23 07" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/7733c6ff-8953-4584-84ba-c78d37c813c1">

Later Attempt
<img width="1694" alt="Screenshot 2024-02-16 at 13 52 56" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/aed97b4d-e749-40a8-9f3e-7c05d90a3071">
<img width="1694" alt="Screenshot 2024-02-16 at 13 52 35" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/dac5fd20-fe56-477a-a396-a757a8b2a873">

## Evidence for feature flag turned on

Lockout
<img width="1694" alt="Screenshot 2024-02-16 at 14 31 35" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/49573f49-0936-4a7d-a6fa-72dc95a355d4">
<img width="1694" alt="Screenshot 2024-02-16 at 14 31 19" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/667a1ba0-6562-448c-a4c5-02014c728ad6">

Later attempt
<img width="1694" alt="Screenshot 2024-02-16 at 15 18 24" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/31e44efe-542a-4a7f-aa7f-577ada303638">
<img width="1694" alt="Screenshot 2024-02-16 at 15 18 02" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/c222c043-70a1-49b9-80fa-db07be0e9bb6">
