### PR TITLE
copy update for inline incorrect password error

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -258,7 +258,8 @@
         "label": "Cyfrinair",
         "validationError": {
           "required": "Rhowch eich cyfrinair",
-          "incorrectPassword": "Rhowch y cyfrinair cywir"
+          "incorrectPassword_old": "Rhowch y cyfrinair cywir",
+          "incorrectPassword": "Nid yw’r cyfrinair rydych wedi’i roi yn gywir. Os ydych wedi anghofio eich cyfrinair, gallwch ei ailosod"
         }
       },
       "forgottenPassword": {
@@ -274,7 +275,8 @@
         "label": "Cyfrinair",
         "validationError": {
           "required": "Rhowch eich cyfrinair",
-          "incorrectPassword": "Rhowch y cyfrinair cywir"
+          "incorrectPassword_old": "Rhowch y cyfrinair cywir",
+          "incorrectPassword": "Nid yw’r cyfrinair rydych wedii roi yn gywir. Os ydych wedi anghofio eich cyfrinair, gallwch ei ailosod"
         }
       },
       "forgottenPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -258,7 +258,9 @@
         "label": "Password",
         "validationError": {
           "required": "Enter your password",
-          "incorrectPassword": "Enter the correct password"
+          "incorrectPassword_old": "Enter the correct password",
+          "incorrectPassword": "The password you entered is not correct. If you have forgotten your password, you can reset it"
+
         }
       },
       "forgottenPassword": {
@@ -274,7 +276,8 @@
         "label": "Password",
         "validationError": {
           "required": "Enter your password",
-          "incorrectPassword": "Enter the correct password"
+          "incorrectPassword_old": "Enter the correct password",
+          "incorrectPassword": "The password you entered is not correct. If you have forgotten your password, you can reset it"
         }
       },
       "forgottenPassword": {


### PR DESCRIPTION
## What?

Copy update for enter password inline error message using feature flag.

## Why?

When feature flag is enabled we want to display the new content update.


## Evidence for feature flag turned off

<img width="1694" alt="Screenshot 2024-02-16 at 17 04 17" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/11fca431-73d0-4d23-b311-f0a30b5ebf9e">
<img width="1694" alt="Screenshot 2024-02-16 at 16 47 52" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/51f59bf9-b82a-43f7-812a-42f8f06c2600">


## Evidence for feature flag turned on

<img width="1694" alt="Screenshot 2024-02-16 at 16 34 33" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/d968d7bd-05a4-47b6-a7cf-52fff3eb14dd">
<img width="1694" alt="Screenshot 2024-02-16 at 16 34 00" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/c8a29630-5cdd-4c4a-ab40-1c6b4b543b8f">

