### PR TITLE
AUT-2356: Update error screens when a user has entered an incorrect SMS code more than 5 times

### DIFF
--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -8,6 +8,7 @@ import {
 } from "../common/constants";
 import {
   getCodeEnteredWrongBlockDurationInMinutes,
+  support2hrLockout,
   supportAccountRecovery,
 } from "../../config";
 import { VerifyMfaCodeInterface } from "./types";
@@ -48,6 +49,7 @@ export function enterAuthenticatorAppCodeGet(
         {
           newCodeLink: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
           isAuthApp: true,
+          show2HrScreen: support2hrLockout(),
         }
       );
     }

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -46,6 +46,7 @@ export function enterEmailGet(req: Request, res: Response): void {
 }
 
 export function enterEmailCreateGet(req: Request, res: Response): void {
+  req.session.user.isAccountCreationJourney = true;
   return res.render("enter-email/index-create-account.njk");
 }
 

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -187,6 +187,8 @@ export function enterPasswordPost(
       }
     }
 
+    req.session.user.isSignInJourney = true;
+
     if (
       userLogin.data.mfaRequired &&
       userLogin.data.mfaMethodVerified &&

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -26,10 +26,21 @@ export function resendEmailCodeGet(req: Request, res: Response): void {
     const newCodeLink = req.query?.isResendCodeRequest
       ? "/security-code-check-time-limit?isResendCodeRequest=true"
       : "/security-code-check-time-limit";
+
+    let show2HrScreen = false;
+    if (
+      support2hrLockout() &&
+      (req.session.user.isPasswordResetJourney ||
+        req.session.user.isAccountRecoveryJourney)
+    ) {
+      show2HrScreen = true;
+    }
+
     return res.render(
       "security-code-error/index-security-code-entered-exceeded.njk",
       {
         newCodeLink,
+        show2HrScreen: show2HrScreen,
       }
     );
   }

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -14,7 +14,10 @@ import {
   renderBadRequest,
 } from "../../utils/validation";
 import { BadRequestError } from "../../utils/error";
-import { getCodeEnteredWrongBlockDurationInMinutes } from "../../config";
+import {
+  getCodeEnteredWrongBlockDurationInMinutes,
+  support2hrLockout,
+} from "../../config";
 
 const TEMPLATE_NAME = "reset-password-2fa-auth-app/index.njk";
 export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
@@ -29,6 +32,7 @@ export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
         {
           newCodeLink: PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
           isAuthApp: true,
+          show2HrScreen: support2hrLockout(),
         }
       );
     }

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -19,6 +19,7 @@ import { VerifyCodeInterface } from "../common/verify-code/types";
 import { codeService } from "../common/verify-code/verify-code-service";
 import { AccountInterventionsInterface } from "../account-intervention/types";
 import { accountInterventionService } from "../account-intervention/account-intervention-service";
+import { support2hrLockout } from "../../config";
 
 const TEMPLATE_NAME = "reset-password-2fa-sms/index.njk";
 const RESEND_CODE_LINK = pathWithQueryParam(
@@ -43,6 +44,7 @@ export function resetPassword2FASmsGet(
         "security-code-error/index-security-code-entered-exceeded.njk",
         {
           newCodeLink: PATH_NAMES.RESET_PASSWORD_2FA_SMS,
+          show2HrScreen: support2hrLockout(),
         }
       );
     }

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -23,6 +23,7 @@ export function resetPasswordCheckEmailGet(
     const requestCode = !(
       req.query.requestCode && req.query.requestCode === "false"
     );
+    req.session.user.isPasswordResetJourney = true;
     let result;
 
     if (requestCode) {
@@ -47,6 +48,7 @@ export function resetPasswordCheckEmailGet(
         "security-code-error/index-security-code-entered-exceeded.njk",
         {
           newCodeLink,
+          show2HrScreen: support2hrLockout(),
         }
       );
     }

--- a/src/components/security-code-error/index-security-code-entered-exceeded.njk
+++ b/src/components/security-code-error/index-security-code-entered-exceeded.njk
@@ -1,29 +1,48 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-
-{% if isAuthApp %}
-    {% set pageTitleName = 'pages.securityCodeAuthAppEnteredExceeded.title' | translate %}
+{% if show2HrScreen %}
+    {% set pageTitleName = 'pages.signInRetryBlocked.title' | translate %}
 {% else %}
-    {% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+    {% if isAuthApp %}
+        {% set pageTitleName = 'pages.securityCodeAuthAppEnteredExceeded.title' | translate %}
+    {% else %}
+        {% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+    {% endif %}
 {% endif %}
 
 {% block content %}
-    {% if isAuthApp %}
-        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeAuthAppEnteredExceeded.header' | translate }}</h1>
-        <p class="govuk-body">{{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph1' | translate}}</p>
+    {% if show2HrScreen %}
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInRetryBlocked.header' | translate }}</h1>
+        <p class="govuk-body">{{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph5' | translate}}</p>
         <p class="govuk-body">
-            {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2Start' | translate}}
-            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeAuthAppEnteredExceeded.info.link' | translate}}</a>
-            {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2End' | translate}}
+            <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
+                {{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph2' | translate}}
+            </h1>
+            <p class="govuk-body">{{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph3' | translate}}</p>
+            <p class="govuk-body">{{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph4' | translate}}</p>
         </p>
     {% else %}
-        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeEnteredExceeded.header' | translate }}</h1>
-        <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
-        <p class="govuk-body">
-            {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
-            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
-            {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
-        </p>
+        {% if isAuthApp %}
+            {% set pageTitleName = 'pages.securityCodeAuthAppEnteredExceeded.title' | translate %}
+        {% else %}
+            {% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+        {% endif %}
+        {% if isAuthApp %}
+            <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeAuthAppEnteredExceeded.header' | translate }}</h1>
+            <p class="govuk-body">{{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph1' | translate}}</p>
+            <p class="govuk-body">
+                {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2Start' | translate}}
+                <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeAuthAppEnteredExceeded.info.link' | translate}}</a>
+                {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2End' | translate}}
+            </p>
+        {% else %}
+            <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeEnteredExceeded.header' | translate }}</h1>
+            <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
+            <p class="govuk-body">
+                {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
+                <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
+                {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
+            </p>
+        {% endif %}
     {% endif %}
-
 {% endblock %}

--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -9,7 +9,7 @@
 
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityRequestsExceededExpired.header' | translate }}</h1>
-    
+
     {% if support2hrLockout %}
     <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph1' | translate}}</p>
     <h2 class="govuk-heading-s">{{'pages.securityRequestsExceededExpired.info.subHeading' | translate}}</h2>

--- a/src/components/security-code-error/index-wait.njk
+++ b/src/components/security-code-error/index-wait.njk
@@ -9,7 +9,7 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header_create' | translate }}</h1>
     <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph1_create' | translate}}</p>
-        
+
         {% else %}
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header' | translate }}</h1>

--- a/src/components/security-code-error/index.njk
+++ b/src/components/security-code-error/index.njk
@@ -1,27 +1,37 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.securityCodeInvalid.title' | translate %}
-
 {% block content %}
-
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeInvalid.header' | translate }}</h1>
-{% if isBlocked %}
-    <p class="govuk-body">{{'pages.securityCodeInvalid.info.paragraph1' | translate}}</p>
-{% endif %}
-<p class="govuk-body">
-    {% if isAuthApp == true %}
-        {{'pages.securityCodeInvalid.authAppInfo.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.authAppInfo.link' | translate}}</a>
-        {{'pages.securityCodeInvalid.authAppInfo.paragraph2End' | translate}}
-    {% else %}
-        {% if isBlocked %}
-            {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
-        {% else %}
-            {{'pages.securityCodeInvalid.info.paragraph2Unblocked' | translate}}
-        {% endif %}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
-        {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+{% if show2HrScreen %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeInvalid.header' | translate }}</h1>
+    <p class="govuk-body">{{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph1' | translate}}</p>
+    <p class="govuk-body">
+        <h1 class="govuk-heading-m govuk-!-margin-bottom-3">
+            {{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph2' | translate}}
+        </h1>
+        <p class="govuk-body">{{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph3' | translate}}</p>
+        <p class="govuk-body">{{'pages.securityCodeInvalid.2hLockout.signInJourney.info.paragraph4' | translate}}</p>
+    </p>
+{% else %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeInvalid.header' | translate }}</h1>
+    {% if isBlocked %}
+            <p class="govuk-body">{{'pages.securityCodeInvalid.info.paragraph1' | translate}}</p>
     {% endif %}
-</p>
-
+    <p class="govuk-body">
+       {% if isAuthApp == true %}
+            {{'pages.securityCodeInvalid.authAppInfo.paragraph2Start' | translate}}
+            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.authAppInfo.link' | translate}}</a>
+            {{'pages.securityCodeInvalid.authAppInfo.paragraph2End' | translate}}
+       {% else %}
+            {% if isBlocked %}
+                {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
+            {% else %}
+                {{'pages.securityCodeInvalid.info.paragraph2Unblocked' | translate}}
+            {% endif %}
+            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
+            {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+       {% endif %}
+    </p>
+{% endif %}
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -51,10 +51,25 @@ export function securityCodeInvalidGet(req: Request, res: Response): void {
     ).toUTCString();
   }
 
+  let show2HrScreen = false;
+  if (support2hrLockout()) {
+    if (
+      (req.session.user.isSignInJourney &&
+        !req.session.user.isAccountPartCreated &&
+        !req.session.user.isAccountRecoveryJourney) ||
+      req.session.user.isPasswordResetJourney ||
+      (!isNotEmailCode && !req.session.user.isAccountCreationJourney) ||
+      (!isNotEmailCode && req.session.user.isAccountRecoveryJourney)
+    ) {
+      show2HrScreen = true;
+    }
+  }
+
   return res.render("security-code-error/index.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
     isBlocked: isNotEmailCode || showFifteenMinutesParagraph,
+    show2HrScreen: show2HrScreen,
   });
 }
 
@@ -65,9 +80,28 @@ export function securityCodeTriesExceededGet(
   req.session.user.codeRequestLock = new Date(
     Date.now() + getCodeRequestBlockDurationInMinutes() * 60000
   ).toUTCString();
+  const isNotEmailCode =
+    req.query.actionType !== SecurityCodeErrorType.EmailMaxRetries &&
+    req.query.actionType !==
+      SecurityCodeErrorType.ChangeSecurityCodesEmailMaxRetries &&
+    req.query.actionType !==
+      SecurityCodeErrorType.InvalidPasswordResetCodeMaxRetries;
+
+  let show2HrScreen = false;
+  if (support2hrLockout()) {
+    show2HrScreen =
+      (req.session.user.isSignInJourney &&
+        !req.session.user.isAccountPartCreated &&
+        !req.session.user.isAccountRecoveryJourney) ||
+      req.session.user.isPasswordResetJourney ||
+      (!isNotEmailCode && !req.session.user.isAccountCreationJourney) ||
+      (!isNotEmailCode && req.session.user.isAccountRecoveryJourney);
+  }
+
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,
+    show2HrScreen: show2HrScreen,
     isAccountCreationJourney: req.session.user?.isAccountCreationJourney,
     support2hrLockout: support2hrLockout(),
   });

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -6,7 +6,8 @@ import { MFA_METHOD_TYPE } from "../../app.constants";
 
 export function getSecurityCodesGet(req: Request, res: Response): void {
   req.session.user.isAccountCreationJourney =
-    !req.session.user.isAccountRecoveryJourney;
+    !req.session.user.isAccountRecoveryJourney ||
+    req.session.user.isAccountPartCreated;
 
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -4,10 +4,12 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { supportInternationalNumbers, supportLanguageCY } from "../../config";
 
 export function signInOrCreateGet(req: Request, res: Response): void {
+  req.session.user.isAccountCreationJourney = false;
+  req.session.user.isPasswordResetJourney = false;
+  req.session.user.isSignInJourney = false;
   if (req.query.redirectPost) {
     return signInOrCreatePost(req, res);
   }
-
   res.render("sign-in-or-create/index.njk", {
     serviceType: req.session.client.serviceType,
     supportInternationalNumbers: supportInternationalNumbers() ? true : null,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -469,6 +469,17 @@
         "paragraph2Start": "Yna gallwch ",
         "link": "roi cynnig arall",
         "paragraph2End": " gyda chod newydd."
+      },
+      "2hLockout":{
+        "signInJourney":{
+          "info":{
+            "paragraph1": "Ni fyddwch yn gallu mewngofnodi am 2 awr.",
+            "paragraph2": "Beth allwch chi ei wneud",
+            "paragraph3": "Arhoswch am 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto.",
+            "paragraph4": "Os ydych angen ei ddefnyddio yn gynt, gallwch fynd yn ôl i’r gwasanaeth a chwilio am ffyrdd eraill i barhau.",
+            "paragraph5": "This is because you entered the wrong security code too many times the last time you tried to sign in."
+          }
+        }
       }
     },
     "securityRequestsExceededExpired": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -469,6 +469,17 @@
         "paragraph2Start": "You can then ",
         "link": "try again",
         "paragraph2End": " with a new code."
+      },
+      "2hLockout":{
+        "signInJourney":{
+          "info":{
+            "paragraph1": "You will not be able to sign in for 2 hours.",
+            "paragraph2": "What can you do",
+            "paragraph3": "Wait for 2 hours, then go back to the service you were trying to use and start again.",
+            "paragraph4": "If you need to use it sooner, you can go back to the service and look for other ways to continue.",
+            "paragraph5": "This is because you entered the wrong security code too many times the last time you tried to sign in."
+          }
+        }
       }
     },
     "securityRequestsExceededExpired": {
@@ -496,7 +507,7 @@
         "paragraph2Start": "You can ",
         "link": "get a new code",
         "paragraph2End": " after 15 minutes."
-      }, 
+      },
       "info":{
         "paragraph1":"This is because you asked to resend the security code too many times the last time you tried to sign in.",
         "paragraph1_create": "This is because you asked to resend the security code too many times.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,8 @@ export interface UserSession {
   enterEmailMfaType?: string;
   withinForcedPasswordResetJourney?: boolean;
   passwordResetTime?: number;
+  isPasswordResetJourney?: boolean;
+  isSignInJourney?: boolean;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Update the content of the error screens that appear when a user is locked out due to entering and incorrect SMS OTP too many times

## Why?

We are increasing the lockout time to 2 hours, so the lockout time needs to be accurately reflected.

This is longer than the idle session time out, so the user journey changes.

Journeys this needs to be done in:
 * Create a  One Login account- will need different content to the rest of the journeys

 * Sign in to One Login

 * Reset password

 * 2fa account recovery - when user is setting up their new 2fa method

## Change have been demonstrated

The changes for this were demonstrated to Kim and to Craig, Kim and other colleagues in a demo.