### PR TITLE
AUT-2409: Add Welsh text required for page title on 'Enter_a_security_code_from_your_authenticator_app' page

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2206,12 +2206,12 @@
         }
       },
       "2FaBeforeResetPassword": {
-        "title": "Enter a security code from your authenticator app",
-        "header": "Enter a security code from your authenticator app",
+        "title": "Rhowch god diogelwch o’ch ap dilysu",
+        "header": "Rhowch god diogelwch o’ch ap dilysu",
         "info": {
           "paragraph1": "I gael cod diogelwch, agorwch yr ",
           "authenticatorApp": "ap dilysydd ",
-          "paragraph1End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login"
+          "paragraph1End": "a ddefnyddiwyd gennych i greu eich GOV.UK One Login"
         },
         "code":{
           "label": "Rhowch y cod diogelwch 6 digid"


### PR DESCRIPTION
## What?

Add Welsh text required for page title on 'Enter_a_security_code_from_your_authenticator_app' page.

## Why?

This [AUT-2389](https://github.com/govuk-one-login/authentication-frontend/pull/1364) was merged without welsh translations for all sections, to speed up the testing process. This PR was made to include the translations, as they were recently provided. 

[AUT-2389]: https://govukverify.atlassian.net/browse/AUT-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ