### PR TITLE
AUT-2417: add lockout logic for reset passwd 2fa auth app controller

### DIFF
--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -8,17 +8,31 @@ import {
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types";
 import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
-import { JOURNEY_TYPE, MFA_METHOD_TYPE } from "../../app.constants";
+import { JOURNEY_TYPE, MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
 import {
   formatValidationError,
   renderBadRequest,
 } from "../../utils/validation";
 import { BadRequestError } from "../../utils/error";
+import { getCodeEnteredWrongBlockDurationInMinutes } from "../../config";
 
 const TEMPLATE_NAME = "reset-password-2fa-auth-app/index.njk";
 export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    res.render(TEMPLATE_NAME, {});
+    if (
+      req.session.user.wrongCodeEnteredLock &&
+      new Date().getTime() <
+        new Date(req.session.user.wrongCodeEnteredLock).getTime()
+    ) {
+      return res.render(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        {
+          newCodeLink: PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
+          isAuthApp: true,
+        }
+      );
+    }
+    return res.render(TEMPLATE_NAME, {});
   };
 }
 export function resetPassword2FAAuthAppPost(
@@ -46,6 +60,15 @@ export function resetPassword2FAAuthAppPost(
           )
         );
         return renderBadRequest(res, req, TEMPLATE_NAME, error);
+      }
+
+      if (
+        result.data.code ===
+        ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED
+      ) {
+        req.session.user.wrongCodeEnteredLock = new Date(
+          Date.now() + getCodeEnteredWrongBlockDurationInMinutes() * 60000
+        ).toUTCString();
       }
 
       const path = getErrorPathByCode(result.data.code);

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
@@ -100,5 +100,21 @@ describe("reset password 2fa auth app controller", () => {
         "reset-password-2fa-auth-app/index.njk"
       );
     });
+
+    it("should render security code entered too many times page view when user is account is locked from entering security codes", async () => {
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const date = new Date();
+      const futureDate = new Date(
+        date.setDate(date.getDate() + 6)
+      ).toUTCString();
+
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+        reauthenticate: "1234",
+        wrongCodeEnteredLock: futureDate,
+      };
+
+      await resetPassword2FAAuthAppGet()(req as Request, res as Response);
+    });
   });
 });


### PR DESCRIPTION
## What?

add lockout logic for reset-password-2fa-auth-app-controller.ts

## Why?

Enter a security code from your auth app - 6 incorrect codes - user can immediately navigate back to auth app screen without waiting for lockout period to expire