### PR TITLE
AUT-2238: Indicate test files for sonarqube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src/
 sonar.tests=test/
+sonar.test.inclusions=src/**/*.test.ts,src/**/*-integration.test.ts
 sonar.exclusions=src/assets/javascript/all.js
 sonar.sourceEncoding=UTF-8
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION

## What?

Indicate test files for sonarqube.

## Why?

Sonarqube is including test code when calculating coverage which is reducing coverage.

## Related PRs

#1389 
#1388 
