### PR TITLE
AUT-2415: fix switching between screens when new code then requested

### DIFF
--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -33,6 +33,20 @@ export function resetPassword2FASmsGet(
   return async function (req: Request, res: Response) {
     const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    if (
+      req.session.user.wrongCodeEnteredLock &&
+      new Date().getTime() <
+        new Date(req.session.user.wrongCodeEnteredLock).getTime()
+    ) {
+      return res.render(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        {
+          newCodeLink: PATH_NAMES.RESET_PASSWORD_2FA_SMS,
+        }
+      );
+    }
+
     const mfaResponse = await mfaCodeService.sendMfaCode(
       sessionId,
       clientSessionId,

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
@@ -104,5 +104,30 @@ describe("reset password 2fa auth app controller", () => {
 
       expect(res.render).to.have.calledWith("reset-password-2fa-sms/index.njk");
     });
+
+    it("should render security code entered too many times page view when user is account is locked from entering security codes", async () => {
+      const fakeService: MfaServiceInterface = {
+        sendMfaCode: sinon.fake.returns({
+          success: false,
+        }),
+      } as unknown as MfaServiceInterface;
+
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      const date = new Date();
+      const futureDate = new Date(
+        date.setDate(date.getDate() + 6)
+      ).toUTCString();
+
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+        reauthenticate: "1234",
+        wrongCodeEnteredLock: futureDate,
+      };
+
+      await resetPassword2FASmsGet(fakeService)(
+        req as Request,
+        res as Response
+      );
+    });
   });
 });

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../app.constants";
 import decache from "decache";
 import nock = require("nock");
+import { ERROR_CODES, SecurityCodeErrorType } from "../../common/constants";
 
 describe("Integration::2fa sms (in reset password flow)", () => {
   let app: any;
@@ -81,6 +82,27 @@ describe("Integration::2fa sms (in reset password flow)", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.RESET_PASSWORD)
+      .expect(302, done);
+  });
+
+  it("should return error page when when user is locked out", (done) => {
+    nock(baseApi).persist().post(API_ENDPOINTS.VERIFY_CODE).reply(400, {
+      code: ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES,
+      success: false,
+    });
+
+    request(app)
+      .post(PATH_NAMES.RESET_PASSWORD_2FA_SMS)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect(
+        "Location",
+        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.MfaMaxRetries}`
+      )
       .expect(302, done);
   });
 });


### PR DESCRIPTION
## What?

Add lockout logic for reset-password-2fa-sms controller

## Why?

Reset password journey - 6 incorrect sms codes - switches between screens when new code then requested

## Change have been demonstrated