### PR TITLE
BAU: Add `dev:render-user-journey-documentation` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ If you're having problems running locally, try these steps first:
 
 Remember to run these commands in the docker container itself.
 
+### Documentation
+
+> Generate and view documentation of the user journey state machine 
+
+```shell script
+yarn dev:render-user-journey-documentation
+```
+
 ### Development
 
 > To run the app in development mode with nodemon watching the files

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:dev-evironment-variables": "mocha dev-check-environment.js",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
-    "watch-sass": "sass --load-path=node_modules/govuk-frontend/govuk --watch --quiet-deps src/assets/scss/application.scss dist/public/style.css"
+    "watch-sass": "sass --load-path=node_modules/govuk-frontend/govuk --watch --quiet-deps src/assets/scss/application.scss dist/public/style.css",
+    "dev:render-user-journey-documentation": "ts-node scripts/render-user-journey-documentation.ts"
   },
   "mocha": {
     "diff": true,

--- a/scripts/render-user-journey-documentation.ts
+++ b/scripts/render-user-journey-documentation.ts
@@ -1,0 +1,178 @@
+import { exec } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { authStateMachine } from "../src/components/common/state-machine/state-machine";
+import { PATH_NAMES } from "../src/app.constants";
+
+const allSupportedStates = Object.keys(authStateMachine.config.states);
+function renderCode(str: string) {
+  return `<code>${str}</code>`;
+}
+
+function renderRouterPageLink(path: string): string {
+  const entry = Object.entries(PATH_NAMES).find(([, val]) => val === path);
+  const pathName = entry ? entry[0] : null;
+  const link = pathName
+    ? `https://github.com/search?q=repo%3Agovuk-one-login%2Fauthentication-frontend+PATH_NAMES.${pathName}+routes&type=code`
+    : "";
+  return `<a title="PATH_NAMES.${pathName}" href="${link}">${renderCode(
+    path
+  )}</a> <sup class="external-link-icon">↪️</sup>`;
+}
+
+function renderCurrentPageLink(path: string): string {
+  const supported = allSupportedStates.includes(path);
+
+  if (supported) {
+    return `
+    <a href="#current-state-${path}">${renderCode(path)}</a>`;
+  } else {
+    return `<span title="Path does not exist in the state machine">${renderCode(
+      path
+    )} <sup class="unsupported-icon">🚫</sup></span>`;
+  }
+}
+
+const htmlContent = `
+<!DOCTYPE html>
+<html>
+<head>
+    <title>User Journey Paths</title>
+    <style>
+      table, th, td {
+        border: 1px solid black;
+        border-collapse: collapse;
+      }
+      dt {
+        font-weight: bold;
+      }        
+      ol.eventConsequences {
+        list-style-type: none;
+        counter-reset: item;
+      }     
+      ol.eventConsequences li::before {
+        content: "️️⬇️ ";
+        counter-increment: item;
+        opacity: 0.5;
+      }
+      ol.eventConsequences li:last-child::before {
+        content: "🏁 ";
+        opacity: 0.8;
+      }
+      ol.eventConsequences .condition {
+        opacity: 0.5;
+      }
+      sup.external-link-icon,
+      sup.unsupported-icon {
+        opacity: 0.8;
+        font-size: 0.6rem;
+      }
+      :target {
+        background-color: yellow;
+      }
+    </style>
+</head>
+<body>
+    <h1>User Journey</h1>
+    <h2>Path Transitions</h2>
+    <table>
+        <tr>
+          <th>Current Path</th>
+          <th>Input Event</th>
+          <th>Next Path</th>
+          <th>Optional Paths</th>
+        </tr>
+        ${allSupportedStates
+          .map((currentState) => {
+            const allEvents =
+              authStateMachine.config.states[currentState].on || {};
+            const eventNames = Object.keys(allEvents);
+            const optionalPaths =
+              authStateMachine.config.states[currentState]?.meta?.optionalPaths;
+
+            if (eventNames.length === 0) {
+              return `
+                  <tr>
+                    <td id="current-state-${currentState}" colspan="5">${renderRouterPageLink(
+                currentState
+              )} 🏁</td>
+                  </tr>
+              `;
+            }
+
+            return eventNames
+              .map((eventName, eventNameIndex) => {
+                const eventConsequences = (allEvents as any)[eventName];
+                return `
+                  <tr>
+                    ${
+                      eventNameIndex === 0
+                        ? `<td id="current-state-${currentState}" rowspan="${
+                            eventNames.length
+                          }">${renderRouterPageLink(currentState)}</td>`
+                        : ""
+                    }
+                    <td>${renderCode(eventName)}</td>
+                    <td><ol class="eventConsequences">${eventConsequences
+                      .map((consequence: any) => {
+                        if (typeof consequence === "string") {
+                          return `<li>${renderCurrentPageLink(
+                            consequence
+                          )}</li>`;
+                        }
+
+                        return `<li>${consequence.target
+                          .map((t: string) => renderCurrentPageLink(t))
+                          .join(",")}${
+                          consequence.cond
+                            ? ` <i class="condition" title="Definition: ${authStateMachine.options.guards[
+                                consequence.cond
+                              ].toString()}">when ${renderCode(
+                                consequence.cond
+                              )}</i>`
+                            : ""
+                        }</li>`;
+                      })
+                      .join("\n")}</ol></td>
+                    ${
+                      eventNameIndex === 0
+                        ? `<td rowspan="${eventNames.length}"><ul>${
+                            optionalPaths
+                              ? optionalPaths
+                                  .map(
+                                    (p: string) =>
+                                      `<li>${renderCurrentPageLink(p)}</li>`
+                                  )
+                                  .join("\n")
+                              : "N/A"
+                          }</ul></td>`
+                        : ""
+                    }
+                  </tr>
+              `;
+              })
+              .join("\n");
+          })
+          .join("\n")}
+    </table>
+</body>
+</html>
+`;
+
+const tempFilePath = path.join(os.tmpdir(), "temp.html");
+fs.writeFileSync(tempFilePath, htmlContent);
+
+exec(`open "${tempFilePath}"`, (error, stdout, stderr) => {
+  /* eslint-disable no-console */
+  if (error) {
+    console.error(`Error opening URL: ${error.message}`);
+    return;
+  }
+  if (stderr) {
+    console.error(`Error output: ${stderr}`);
+    return;
+  }
+  console.log(`Rendered page opened`);
+  /* eslint-enable no-console */
+});

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -831,4 +831,4 @@ function getNextState(
   };
 }
 
-export { getNextState, USER_JOURNEY_EVENTS };
+export { getNextState, USER_JOURNEY_EVENTS, authStateMachine };


### PR DESCRIPTION
## What?

Create a dev only command `yarn dev:render-user-journey-documentation` that generates temporary local documentation derived from the user journey state machine.

A HTML table is created that has had the headers "Current Path", "Input Event", "Next Path & "Optional Paths" and can be used to understand how a user can navigate through their journey.

Definitions of the conditions to get to the next paths are added inline with the `title` attribute and the fall through nature of next paths are visualised.

## Why?

Understanding how the user journey is implemented can take a while when looking at `src/components/common/state-machine/state-machine.ts`. This documentation should reduce the time to understand it.

## Change have been demonstrated

https://github.com/govuk-one-login/authentication-frontend/assets/723372/c7822553-54a4-4a06-940e-deb5c30e55a2


