### PR TITLE
AUT-2270 conditionally enabling http drop invalid  header  on lower env

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -10,6 +10,7 @@ resource "aws_lb" "frontend_alb" {
   ]
 
   enable_deletion_protection = true
+  drop_invalid_header_fields = (var.environment == "production" ? false : true)
 
   dynamic "access_logs" {
     for_each = var.environment == "production" ? [1] : []


### PR DESCRIPTION
What?
AUT-2270 --Ensure that Drop Invalid Header Fields feature is enabled for your Amazon Application Load Balancers (ALBs)

Why?
If Drop Invalid Header Fields security feature is enabled, HTTP headers with header fields that are not valid are removed by the Application Load Balancer instead of being routed to the associated targets