### PR TITLE
bau: Amend check reauth user endpoint

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -114,7 +114,7 @@ export const API_ENDPOINTS = {
   IPV_PROCESSING_IDENTITY: "/processing-identity",
   VERIFY_MFA_CODE: "/verify-mfa-code",
   ACCOUNT_RECOVERY: "/account-recovery",
-  CHECK_REAUTH_USERS: "/check-reauth-users",
+  CHECK_REAUTH_USER: "/check-reauth-user",
 };
 
 export const ERROR_MESSAGES = {

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -231,7 +231,7 @@ describe("authorize controller", () => {
         fakeJwtService
       )(req as Request, res as Response);
 
-      expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
     });
 
     //note that this is currently the same behaviour with the feature flag on or off. This will change if we decide on a different initial page for the reauth journey

--- a/src/components/check-reauth-users/check-reauth-users-service.ts
+++ b/src/components/check-reauth-users/check-reauth-users-service.ts
@@ -27,7 +27,7 @@ export function checkReauthUsersService(
     });
 
     const response = await axios.client.post<DefaultApiResponse>(
-      API_ENDPOINTS.CHECK_REAUTH_USERS,
+      API_ENDPOINTS.CHECK_REAUTH_USER,
       { email: lowerCaseEmail },
       config
     );

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -136,7 +136,7 @@ const authStateMachine = createMachine(
           ],
           [USER_JOURNEY_EVENTS.NO_EXISTING_SESSION]: [
             {
-              target: [PATH_NAMES.SIGN_IN_OR_CREATE],
+              target: [PATH_NAMES.ENTER_EMAIL_SIGN_IN],
               cond: "isReauthenticationRequired",
             },
             {

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -152,7 +152,7 @@ describe("state-machine", () => {
         USER_JOURNEY_EVENTS.NO_EXISTING_SESSION,
         { isReauthenticationRequired: true }
       );
-      expect(nextState.value).to.equal(PATH_NAMES.SIGN_IN_OR_CREATE);
+      expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
     });
 
     it("should move from authorize to auth code create when the user is already logged in", () => {

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -224,7 +224,7 @@ describe("Integration::enter email", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
 
     nock(baseApi)
-      .post(API_ENDPOINTS.CHECK_REAUTH_USERS)
+      .post(API_ENDPOINTS.CHECK_REAUTH_USER)
       .once()
       .reply(HTTP_STATUS_CODES.OK);
 


### PR DESCRIPTION
## What?

Amend typo in the endpoint for checking validity of user when re-authentication is required.
- from `/check-reauth-users` to `/check-reauth-user`
- Refactor state machine to redirect to `/enter-email` re-auth screen when no session exists
