### PR TITLE
BAU/reauth-fix: Refactor axios handling of 404 http status code

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -17,6 +17,7 @@ support_2fa_b4_password_reset                       = "1"
 password_reset_code_entered_wrong_blocked_minutes   = "0.5"
 account_recovery_code_entered_wrong_blocked_minutes = "0.5"
 code_request_blocked_minutes                        = "0.5"
+email_entered_wrong_blocked_minutes                 = "0.5"
 code_entered_wrong_blocked_minutes                  = "0.5"
 url_for_support_links                               = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -165,6 +165,10 @@ locals {
         value = var.support_reauthentication
       },
       {
+        name  = "EMAIL_ENTERED_WRONG_BLOCKED_MINUTES"
+        value = var.email_entered_wrong_blocked_minutes
+      },
+      {
         name  = "SUPPORT_2HR_LOCKOUT"
         value = var.support_2hr_lockout
       },

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -264,3 +264,8 @@ variable "support_reauthentication" {
   type        = string
   default     = "0"
 }
+
+variable "email_entered_wrong_blocked_minutes" {
+  description = "The duration, in minutes, for which a user is blocked after entering the wrong email multiple times during reauthentication"
+  default     = "15"
+}

--- a/src/components/check-reauth-users/check-reauth-users-service.ts
+++ b/src/components/check-reauth-users/check-reauth-users-service.ts
@@ -4,7 +4,7 @@ import {
   Http,
   http,
 } from "../../utils/http";
-import { API_ENDPOINTS } from "../../app.constants";
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { CheckReauthServiceInterface } from "./types";
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
 
@@ -22,6 +22,11 @@ export function checkReauthUsersService(
     const config = getRequestConfig({
       sessionId,
       sourceIp,
+      validationStatues: [
+        HTTP_STATUS_CODES.OK,
+        HTTP_STATUS_CODES.BAD_REQUEST,
+        HTTP_STATUS_CODES.NOT_FOUND,
+      ],
       clientSessionId,
       persistentSessionId,
     });

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -3,8 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% set showBack = true %}
-{% set hrefBack = 'sign-in-or-create' %}
+{% set showBack = false %}
 {% set pageTitleName = 'pages.reEnterEmailAccount.title' | translate %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 

--- a/src/components/enter-email/index-sign-in-details-entered-too-many-times.njk
+++ b/src/components/enter-email/index-sign-in-details-entered-too-many-times.njk
@@ -3,8 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% set showBack = true %}
-{% set hrefBack = 'sign-in-or-create' %}
+{% set showBack = false %}
 {% set pageTitleName = 'pages.enteredWrongEmail.title' | translate %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 


### PR DESCRIPTION
## What?

- The reauth check lambda returns a 404 when no user matched or found
- The axios interceptor seems to validate only http status codes between 200 to 400
- For any other http status it rejects the promise and returns the screen "Sorry, there is a problem" which is not the requirement for reauth
- Refactor the axios create to validate status code up until 500 internal server error
- Reduce the email entered wrong blocked minutes to 30 secons in build
- Remove back button for reauth screens

## Why?

To return the appropriate screens for reauth journey when user enter's invalid email 
