### PR TITLE
content updates for too many code request error screens

### DIFF
--- a/src/components/account-creation/resend-mfa-code/index.njk
+++ b/src/components/account-creation/resend-mfa-code/index.njk
@@ -25,6 +25,10 @@
             text: phoneNumberMessage | safe
         }) }}
 
+        {% if support2hrLockout %}
+        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}}</p>
+        {% endif %}
+
         <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>
         {{ govukButton({
         "text": "pages.resendMfaCode.continue" | translate,

--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
@@ -11,6 +11,7 @@ import { getErrorPathByCode, pathWithQueryParam } from "../../common/constants";
 import { SendNotificationServiceInterface } from "../../common/send-notification/types";
 import { sendNotificationService } from "../../common/send-notification/send-notification-service";
 import { BadRequestError } from "../../../utils/error";
+import { support2hrLockout } from "../../../config";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
   const newCodeLink = req.query?.isResendCodeRequest
@@ -41,6 +42,7 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
     res.render("account-creation/resend-mfa-code/index.njk", {
       phoneNumber: req.session.user.redactedPhoneNumber,
       isResendCodeRequest: req.query?.isResendCodeRequest,
+      support2hrLockout: support2hrLockout(),
     });
   }
 }

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -20,6 +20,10 @@
             html: emailMessage + '<span class="govuk-body govuk-!-font-weight-bold">' + emailAddress + '</span>'
         }) }}
 
+        {% if support2hrLockout %}
+        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}}</p>
+        {% endif %}
+
         <p class="govuk-body">{{'pages.resendMfaCode.email.paragraph' | translate}}</p>
         {{ govukButton({
         "text": 'pages.resendMfaCode.continue' | translate,

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -10,6 +10,7 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import xss from "xss";
+import { support2hrLockout } from "../../config";
 
 export function resendEmailCodeGet(req: Request, res: Response): void {
   if (
@@ -37,6 +38,7 @@ export function resendEmailCodeGet(req: Request, res: Response): void {
     emailAddress: req.session.user.email,
     requestNewCode:
       req.query.requestNewCode && req.query.requestNewCode === "true",
+    support2hrLockout: support2hrLockout(),
   });
 }
 

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -25,6 +25,10 @@
             text: phoneNumberMessage | safe
         }) }}
 
+        {% if support2hrLockout %}
+        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}}</p>
+        {% endif %}
+
         <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>
         {{ govukButton({
         "text": "pages.resendMfaCode.continue" | translate,

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -5,6 +5,7 @@ import { MfaServiceInterface } from "../common/mfa/types";
 import { sendMfaGeneric } from "../common/mfa/send-mfa-controller";
 import { PATH_NAMES } from "../../app.constants";
 import { pathWithQueryParam } from "../common/constants";
+import { support2hrLockout } from "../../config";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
   if (
@@ -37,6 +38,7 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
     res.render("resend-mfa-code/index.njk", {
       phoneNumber: req.session.user.redactedPhoneNumber,
       isResendCodeRequest: req.query?.isResendCodeRequest,
+      support2hrLockout: support2hrLockout(),
     });
   }
 }

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -8,7 +8,7 @@ import { VerifyCodeInterface } from "../common/verify-code/types";
 import { codeService } from "../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
 import { NOTIFICATION_TYPE } from "../../app.constants";
-import { support2FABeforePasswordReset } from "../../config";
+import { support2FABeforePasswordReset, support2hrLockout } from "../../config";
 import { AccountInterventionsInterface } from "../account-intervention/types";
 import { accountInterventionService } from "../account-intervention/account-intervention-service";
 
@@ -82,7 +82,9 @@ export function resetPasswordCheckEmailGet(
         errorTemplate = "security-code-error/index-wait.njk";
       }
 
-      return res.render(errorTemplate);
+      return res.render(errorTemplate, {
+        support2hrLockout: support2hrLockout(),
+      });
     } else {
       throw new BadRequestError(result.data.message, result.data.code);
     }

--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -9,12 +9,20 @@
 
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityRequestsExceededExpired.header' | translate }}</h1>
-
+    
+    {% if support2hrLockout %}
     <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph1' | translate}}</p>
+    <h2 class="govuk-heading-s">{{'pages.securityRequestsExceededExpired.info.subHeading' | translate}}</h2>
+    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph3' | translate}}</p>
+
+    {% else %}
+    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info_old.paragraph1' | translate}}</p>
     <p class="govuk-body">
-        {{'pages.securityRequestsExceededExpired.info.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityRequestsExceededExpired.info.link' | translate}}</a>
-        {{'pages.securityRequestsExceededExpired.info.paragraph2End' | translate}}
+        {{'pages.securityRequestsExceededExpired.info_old.paragraph2Start' | translate}}
+        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityRequestsExceededExpired.info_old.link' | translate}}</a>
+        {{'pages.securityRequestsExceededExpired.info_old.paragraph2End' | translate}}
     </p>
 
+    {% endif %}
 {% endblock %}

--- a/src/components/security-code-error/index-wait.njk
+++ b/src/components/security-code-error/index-wait.njk
@@ -3,13 +3,34 @@
 {% set pageTitleName = 'pages.securityCodeWaitToRequest.title' | translate %}
 {% block content %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header' | translate }}</h1>
+    {% if support2hrLockout %}
 
+        {% if isAccountCreationJourney %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header_create' | translate }}</h1>
+    <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph1_create' | translate}}</p>
+        
+        {% else %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header' | translate }}</h1>
     <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph1' | translate}}</p>
+
+        {% endif %}
+
+    <h2 class="govuk-heading-s">{{'pages.securityCodeWaitToRequest.info.subHeading' | translate}}</h2>
+    <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph3' | translate}}</p>
+
+    {% else %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header' | translate }}</h1>
+    <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info_old.paragraph1' | translate}}</p>
     <p class="govuk-body">
-        {{'pages.securityCodeWaitToRequest.info.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeWaitToRequest.info.link' | translate}}</a>
-        {{'pages.securityCodeWaitToRequest.info.paragraph2End' | translate}}
+        {{'pages.securityCodeWaitToRequest.info_old.paragraph2Start' | translate}}
+        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeWaitToRequest.info_old.link' | translate}}</a>
+        {{'pages.securityCodeWaitToRequest.info_old.paragraph2End' | translate}}
     </p>
+
+    {% endif %}
 
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -10,6 +10,7 @@ import {
   getCodeEnteredWrongBlockDurationInMinutes,
   getCodeRequestBlockDurationInMinutes,
   getPasswordResetCodeEnteredWrongBlockDurationInMinutes,
+  support2hrLockout,
 } from "../../config";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
@@ -67,6 +68,8 @@ export function securityCodeTriesExceededGet(
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,
+    isAccountCreationJourney: req.session.user?.isAccountCreationJourney,
+    support2hrLockout: support2hrLockout(),
   });
 }
 
@@ -76,6 +79,7 @@ export function securityCodeCannotRequestCodeGet(
 ): void {
   res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    support2hrLockout: support2hrLockout(),
   });
 }
 

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -123,6 +123,8 @@ describe("security code  controller", () => {
         {
           newCodeLink: PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT,
           isResendCodeRequest: undefined,
+          isAccountCreationJourney: undefined,
+          support2hrLockout: false,
         }
       );
     });
@@ -141,6 +143,8 @@ describe("security code  controller", () => {
             SecurityCodeErrorType.MfaMaxRetries
           ),
           isResendCodeRequest: undefined,
+          isAccountCreationJourney: undefined,
+          support2hrLockout: false,
         }
       );
     });
@@ -155,6 +159,8 @@ describe("security code  controller", () => {
         {
           newCodeLink: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
           isResendCodeRequest: undefined,
+          isAccountCreationJourney: undefined,
+          support2hrLockout: false,
         }
       );
     });
@@ -170,6 +176,7 @@ describe("security code  controller", () => {
         "security-code-error/index-too-many-requests.njk",
         {
           newCodeLink: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+          support2hrLockout: false,
         }
       );
     });
@@ -183,6 +190,7 @@ describe("security code  controller", () => {
         "security-code-error/index-too-many-requests.njk",
         {
           newCodeLink: PATH_NAMES.RESEND_MFA_CODE,
+          support2hrLockout: false,
         }
       );
     });
@@ -196,6 +204,7 @@ describe("security code  controller", () => {
         "security-code-error/index-too-many-requests.njk",
         {
           newCodeLink: PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT,
+          support2hrLockout: false,
         }
       );
     });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -472,22 +472,36 @@
     "securityRequestsExceededExpired": {
       "title": "Rydych wedi gofyn i ailanfon y cod diogelwch gormod o weithiau",
       "header": "Rydych wedi gofyn i ailanfon y cod diogelwch gormod o weithiau",
-      "info": {
+      "info_old": {
         "paragraph1": "Mae angen i chi aros am 15 munud.",
         "paragraph2Start": "Yna gallwch ",
         "link": "gael cod newydd",
         "paragraph2End": " a rhoi cynnig arall."
+      },
+      "info": {
+        "paragraph1": "Ni fyddwch yn gallu parhau am 2 awr.",
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Arhoswch am 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto.",
+        "paragraph3": "Os ydych angen ei ddefnyddio yn gynt, gallwch fynd yn ôl i’r gwasanaeth a chwilio am ffyrdd eraill i barhau"
       }
     },
     "securityCodeWaitToRequest": {
       "title": "Ni allwch gael cod diogelwch newydd ar hyn o bryd ",
       "header": "Ni allwch gael cod diogelwch newydd ar hyn o bryd ",
-      "info": {
+      "header_create": "Ni allwch greu GOV.UK One Login ar hyn o bryd ",
+      "info_old": {
         "paragraph1": "Mae hyn oherwydd eich bod wedi gofyn i ailanfon cod diogelwch ormod o weithiau.",
         "paragraph2Start": "Gallwch ",
         "link": "gael cod newydd",
         "paragraph2End": " ar ôl 15 munud."
-      }
+      },
+      "info":{
+        "paragraph1":"Mae hyn oherwydd eich bod wedi gofyn i ail-anfon y cod diogelwch gormod o weithiau y tro diwethaf i chi geisio mewngofnodi.",
+        "paragraph1_create": "Mae hyn oherwydd eich bod wedi gofyn i ail-anfon y cod diogelwch gormod o weithiau.",
+        "subHeading":"Beth allwch chi ei wneud",
+        "paragraph2":"Arhoswch am 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto.",
+        "paragraph3":"Os ydych angen ei ddefnyddio yn gynt, gallwch fynd yn ôl i’r gwasanaeth a chwilio am ffyrdd eraill i barhau"
+     }
     },
     "enterMfa": {
       "title": "Gwiriwch eich ffôn",
@@ -572,6 +586,7 @@
       "header": "Cael cod diogelwch",
       "continue": "Cael cod diogelwch",
       "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
+      "paragraph1":"Gallwch ofyn am 5 cod diogelwch. Os byddwch yn gofyn am fwy na 5, byddwch yn cael eich cloi allan am 2 awr.",
       "phoneNumber": {
         "default": "Byddwn yn anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login",
         "isResendCodeRequest": "Byddwn yn anfon cod i’ch rhif ffôn sy’n gorffen gyda "

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -472,22 +472,36 @@
     "securityRequestsExceededExpired": {
       "title": "You asked to resend the security code too many times",
       "header": "You asked to resend the security code too many times",
-      "info": {
+      "info_old": {
         "paragraph1": "You need to wait 15 minutes.",
         "paragraph2Start": "You can then ",
         "link": "get a new code",
         "paragraph2End": " and try again."
+      },
+      "info": {
+        "paragraph1": "You will not be able to continue for 2 hours.",
+        "subHeading": "What you can do",
+        "paragraph2": "Wait 2 hours, then go back to the service you were trying to use and start again.",
+        "paragraph3": "If you need to use it sooner, you can go back to the service and look for other ways to continue."
       }
     },
     "securityCodeWaitToRequest": {
       "title": "You cannot get a new security code at the moment ",
       "header": "You cannot get a new security code at the moment ",
-      "info": {
+      "header_create": "You cannot create a GOV.UK One Login at the moment ",
+      "info_old": {
         "paragraph1": "This is because you asked to resend the security code too many times.",
         "paragraph2Start": "You can ",
         "link": "get a new code",
         "paragraph2End": " after 15 minutes."
-      }
+      }, 
+      "info":{
+        "paragraph1":"This is because you asked to resend the security code too many times the last time you tried to sign in.",
+        "paragraph1_create": "This is because you asked to resend the security code too many times.",
+        "subHeading":"What you can do",
+        "paragraph2":"Wait 2 hours, then go back to the service you were trying to use and start again.",
+        "paragraph3":"If you need to use it sooner, you can go back to the service and look for other ways to continue."
+     }
     },
     "enterMfa": {
       "title": "Check your phone",
@@ -572,6 +586,7 @@
       "header": "Get security code",
       "continue": "Get security code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
+      "paragraph1": "You can request 5 security codes. If you request more than 5, you will be locked out for 2 hours.",
       "phoneNumber": {
         "default": "We will send the code to the phone number linked to your GOV.UK One Login.",
         "isResendCodeRequest": "We will send a code to your phone number ending with "


### PR DESCRIPTION
## What?

Update the content of the error screens that appear when a user is locked out due to requesting an SMS + email OTP too many times.

## Why?

We are increasing the lockout time to 2 hours, so the lockout time needs to be accurately reflected.
This is longer than the idle session time out, so the user journey changes.
[email ticket](https://govukverify.atlassian.net/browse/AUT-2367)
[SMS ticket](https://govukverify.atlassian.net/browse/AUT-2366)

## Evidence

###  Feature flag Off

**_You asked to resend the security code too many times_**

<img width="631" alt="Screenshot 2024-02-27 at 11 34 00" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/5fd278a4-c6b6-4e45-b769-4de358c65e80">
<img width="631" alt="Screenshot 2024-02-27 at 11 34 12" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/24e1684e-908c-45cb-b430-223a55ec769b">

-----
**_You cannot get a new security code at the moment_**

<img width="631" alt="Screenshot 2024-02-23 at 13 48 41" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/7e5e8dbc-4e55-40ed-8a12-c2d9a828067f">
<img width="631" alt="Screenshot 2024-02-23 at 13 48 58" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/e8b1daa0-33d5-47c7-8858-61a0d3944a5f">

-----
**_Get security code_**

<img width="631" alt="Screenshot 2024-02-23 at 13 55 25" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/9acc7374-42fe-4733-a70f-a2f902d6ad6a">
<img width="631" alt="Screenshot 2024-02-23 at 13 55 57" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/f67c9118-0ae3-4f47-b066-e5f0c63b7583">

-----
-----
### Feature flag on

**_You asked to resend the security code too many times_**

<img width="631" alt="Screenshot 2024-02-27 at 11 24 19" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/dde83de9-7c60-4966-87a9-3b9bb59bbe2b">
<img width="631" alt="Screenshot 2024-02-27 at 11 24 39" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/2a6e3dda-d6a3-4b59-9c72-3fc6f57a11d5">

-----
**_You cannot get a new security code at the moment_**

<img width="631" alt="Screenshot 2024-02-27 at 11 29 36" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/297aab6b-76cc-4a72-9524-673fa4d4da8d">
<img width="631" alt="Screenshot 2024-02-27 at 11 30 53" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/e82843bd-9c35-4651-bbe9-08379a5f6f62">

-----
**_Get security code_**

<img width="631" alt="Screenshot 2024-02-23 at 14 53 09" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/a8a190ea-44ea-4625-980e-350923cf5521">
<img width="631" alt="Screenshot 2024-02-23 at 14 53 21" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/8c85d285-2b33-46fd-9c23-ea4357c16773">