### PR TITLE
AUT-2356: remove Back button from /reset-password-2fa-sms, add it to the /reset-password-check-email screen

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -529,7 +529,10 @@ const authStateMachine = createMachine(
           ],
         },
         meta: {
-          optionalPaths: [PATH_NAMES.RESET_PASSWORD_RESEND_CODE],
+          optionalPaths: [
+            PATH_NAMES.ENTER_PASSWORD,
+            PATH_NAMES.RESET_PASSWORD_RESEND_CODE,
+          ],
         },
       },
       [PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP]: {

--- a/src/components/reset-password-2fa-sms/index.njk
+++ b/src/components/reset-password-2fa-sms/index.njk
@@ -5,8 +5,6 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.checkYourPhone.title' | translate %}
-{% set showBack = true %}
-{% set hrefBack = 'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate %}
 
 {% block content %}
 

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.resetPasswordCheckEmail.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'enter-password' %}
 {% block content %}
     {% include "common/errors/errorSummary.njk" %}
 


### PR DESCRIPTION
## What?

 remove Back button from /reset-password-2fa-sms, add it to the /reset-password-check-email screen

## Why?

Changes required in new UI/UX design.

## Change have been demonstrated

- Back button removed from /reset-password-2fa-sms page
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/7d01b542-0c0f-43c7-ac06-bac51bd0b8b5)

-Back button added to reset-password-check-email page: 
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/f4508f05-ee06-418e-b4c9-5029342298b7)

-User can transition to /enter-password, from /reset-password-check email, via the new back button: 
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/6a641cde-55f9-452a-a8fb-56e0f84487c3)
