### PR TITLE
BAU: turn on support_2fa_b4_password_reset feature swtich in production

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -14,7 +14,9 @@ support_account_recovery         = "1"
 support_account_interventions    = "0"
 support_auth_orch_split          = "1"
 support_authorize_controller     = "1"
-url_for_support_links            = "https://home.account.gov.uk/contact-gov-uk-one-login"
+support_2fa_b4_password_reset    = "1"
+
+url_for_support_links = "https://home.account.gov.uk/contact-gov-uk-one-login"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

turn on support_2fa_b4_password_reset feature switch in production

## Why?

Please include reason for the change and any other relevant context.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Only to be merged with: https://github.com/govuk-one-login/authentication-api/pull/4033
