### PR TITLE
AUT-2270 -Enabling Drop invalid  HTTP Header on Frontend ALB

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -10,7 +10,7 @@ resource "aws_lb" "frontend_alb" {
   ]
 
   enable_deletion_protection = true
-  drop_invalid_header_fields = (var.environment == "production" ? false : true)
+  drop_invalid_header_fields = true
 
   dynamic "access_logs" {
     for_each = var.environment == "production" ? [1] : []


### PR DESCRIPTION
## What?

AUT-2270 -Enabling Drop invalid  HTTP Header on Frontend ALB

## Why?

We need to enable HTTP drop Invalid Header as per CPC finding CPC-225 
Valid Header : Elastic Load Balancing requires that message header names conform to the regular expression [-A-Za-z0-9]+ 
Invalid Header  are which contains "-" (underscore) 

## Change have been demonstrated
NO change to Demonstrated , however this has be tested in Lower env Acceptance Test are passed  
