### PR TITLE
AUT-2440: Showing password reset intervention screen when user tries to reset password with temporarilySuspended and passwordResetRequired AIS statuses

### DIFF
--- a/src/components/account-intervention/password-reset-required/password-reset-required-controller.ts
+++ b/src/components/account-intervention/password-reset-required/password-reset-required-controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { PATH_NAMES } from "../../../app.constants";
 
 export function passwordResetRequiredGet(req: Request, res: Response): void {
+  req.session.user.withinForcedPasswordResetJourney = true;
   res.render("account-intervention/password-reset-required/index.njk", {
     resetPasswordCheckEmailURL: PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL,
   });

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
@@ -3,14 +3,11 @@ import { describe } from "mocha";
 
 import { sinon } from "../../../../../test/utils/test-utils";
 import { Request, Response } from "express";
-
-import { VerifyCodeInterface } from "../../../common/verify-code/types";
 import {
   checkYourEmailSecurityCodesGet,
   checkYourEmailSecurityCodesPost,
 } from "../check-your-email-security-codes-controller";
 import { PATH_NAMES } from "../../../../app.constants";
-import { ERROR_CODES } from "../../../common/constants";
 import {
   mockRequest,
   mockResponse,
@@ -18,16 +15,8 @@ import {
   ResponseOutput,
 } from "mock-req-res";
 import { accountInterventionsFakeHelper } from "../../../../../test/helpers/account-interventions-helpers";
-
-function fakeVerifyCodeServiceHelper(success: boolean) {
-  const fakeService: VerifyCodeInterface = {
-    verifyCode: sinon.fake.returns({
-      success: success,
-      data: { code: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE },
-    }),
-  } as unknown as VerifyCodeInterface;
-  return fakeService;
-}
+import { fakeVerifyCodeServiceHelper } from "../../../../../test/helpers/verify-code-helpers";
+import { ERROR_CODES } from "../../../common/constants";
 
 describe("check your email change security codes controller", () => {
   let req: RequestOutput;
@@ -130,7 +119,10 @@ describe("check your email change security codes controller", () => {
     });
 
     it("should return error when invalid code", async () => {
-      const fakeService = fakeVerifyCodeServiceHelper(false);
+      const fakeService = fakeVerifyCodeServiceHelper(
+        false,
+        ERROR_CODES.INVALID_VERIFY_EMAIL_CODE
+      );
 
       const fakeAccountInterventionsService = accountInterventionsFakeHelper(
         "test@test.co.uk",

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -514,6 +514,9 @@ const authStateMachine = createMachine(
       },
       [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL]: {
         on: {
+          [USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION]: [
+            PATH_NAMES.PASSWORD_RESET_REQUIRED,
+          ],
           [USER_JOURNEY_EVENTS.RESET_PASSWORD_CODE_VERIFIED]: [
             {
               target: [PATH_NAMES.RESET_PASSWORD_2FA_SMS],

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -86,7 +86,10 @@ export function verifyCodePost(
       default:
         throw new Error("Unknown notification type");
     }
-    if (supportAccountInterventions()) {
+    if (
+      supportAccountInterventions() &&
+      !req.session.user.withinForcedPasswordResetJourney
+    ) {
       if (
         nextEvent === USER_JOURNEY_EVENTS.EMAIL_SECURITY_CODES_CODE_VERIFIED ||
         nextEvent === USER_JOURNEY_EVENTS.RESET_PASSWORD_CODE_VERIFIED

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -88,7 +88,8 @@ export function verifyCodePost(
     }
     if (supportAccountInterventions()) {
       if (
-        nextEvent === USER_JOURNEY_EVENTS.EMAIL_SECURITY_CODES_CODE_VERIFIED
+        nextEvent === USER_JOURNEY_EVENTS.EMAIL_SECURITY_CODES_CODE_VERIFIED ||
+        nextEvent === USER_JOURNEY_EVENTS.RESET_PASSWORD_CODE_VERIFIED
       ) {
         accountInterventionsResponse =
           await accountInterventionsService.accountInterventionStatus(

--- a/src/components/prove-identity/tests/prove-identity-integration.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-integration.test.ts
@@ -62,6 +62,7 @@ describe("Integration::prove identity", () => {
   after(() => {
     sinon.restore();
     app = undefined;
+    delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
   });
 
   it("should redirect to orchestration when the account interventions response shows no issues", async () => {

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -10,6 +10,10 @@ import {
   PATH_NAMES,
 } from "../../../app.constants";
 import nock = require("nock");
+import {
+  noInterventions,
+  setupAccountInterventionsResponse,
+} from "../../../../test/helpers/account-interventions-helpers";
 
 describe("Integration::reset password check email ", () => {
   let app: any;
@@ -23,6 +27,7 @@ describe("Integration::reset password check email ", () => {
     const sessionMiddleware = require("../../../middleware/session-middleware");
 
     process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
 
     sinon
       .stub(sessionMiddleware, "validateSessionMiddleware")
@@ -72,6 +77,8 @@ describe("Integration::reset password check email ", () => {
       .persist()
       .post(API_ENDPOINTS.VERIFY_CODE)
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
       .post("/reset-password-check-email")

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -159,5 +159,16 @@ describe("reset password check email controller", () => {
         PATH_NAMES.PASSWORD_RESET_REQUIRED
       );
     });
+
+    it("should redirect to /reset-password without calling the account interventions service when session.user.withinForcedPasswordResetJourney === true", async () => {
+      req.session.user.withinForcedPasswordResetJourney = true;
+      const fakeService = fakeVerifyCodeServiceHelper(true);
+      await resetPasswordCheckEmailPost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.RESET_PASSWORD);
+    });
   });
 });

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -10,6 +10,10 @@ import {
   PATH_NAMES,
 } from "../../../app.constants";
 import nock = require("nock");
+import {
+  noInterventions,
+  setupAccountInterventionsResponse,
+} from "../../../../test/helpers/account-interventions-helpers";
 
 describe("Integration::reset password check email ", () => {
   let app: any;
@@ -23,6 +27,7 @@ describe("Integration::reset password check email ", () => {
     const sessionMiddleware = require("../../../middleware/session-middleware");
 
     process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
 
     sinon
       .stub(sessionMiddleware, "validateSessionMiddleware")
@@ -131,6 +136,8 @@ describe("Integration::reset password check email ", () => {
       .persist()
       .post(API_ENDPOINTS.VERIFY_CODE)
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
       .post("/reset-password-check-email")

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -10,10 +10,6 @@ import {
   PATH_NAMES,
 } from "../../../app.constants";
 import nock = require("nock");
-import {
-  noInterventions,
-  setupAccountInterventionsResponse,
-} from "../../../../test/helpers/account-interventions-helpers";
 
 describe("Integration::reset password check email ", () => {
   let app: any;
@@ -27,7 +23,7 @@ describe("Integration::reset password check email ", () => {
     const sessionMiddleware = require("../../../middleware/session-middleware");
 
     process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "0";
-    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "0";
 
     sinon
       .stub(sessionMiddleware, "validateSessionMiddleware")
@@ -136,8 +132,6 @@ describe("Integration::reset password check email ", () => {
       .persist()
       .post(API_ENDPOINTS.VERIFY_CODE)
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
-
-    setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
       .post("/reset-password-check-email")

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -20,6 +20,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
 
   before(async () => {
     process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -40,6 +41,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       });
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
     request(app)
@@ -52,12 +54,14 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
   });
 
   beforeEach(() => {
+    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
     nock.cleanAll();
   });
 
   after(() => {
     sinon.restore();
     app = undefined;
+    delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
   });
 
   it("should return reset password page", (done) => {

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -60,6 +60,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
   after(() => {
     sinon.restore();
     app = undefined;
+    delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
   });
 
   it("should return reset password page when there are no interventions on a user", (done) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,7 @@ export interface UserSession {
   reauthenticate?: string;
   authCodeReturnToRP?: boolean;
   enterEmailMfaType?: string;
+  withinForcedPasswordResetJourney?: boolean;
 }
 
 export interface UserSessionClient {

--- a/test/helpers/verify-code-helpers.ts
+++ b/test/helpers/verify-code-helpers.ts
@@ -1,0 +1,11 @@
+import { VerifyCodeInterface } from "../../src/components/common/verify-code/types";
+import sinon from "sinon";
+
+export function fakeVerifyCodeServiceHelper(success: boolean, code?: any) {
+  return {
+    verifyCode: sinon.fake.returns({
+      success: success,
+      data: { code: code },
+    }),
+  } as unknown as VerifyCodeInterface;
+}


### PR DESCRIPTION
## What?

Showing forced password reset screen when a user goes through password reset journey with temporarilySuspended and passwordResetRequired AIS statuses applied to their account.

Also refactored some tests to read better/be shorter.

## Why?

Before, users were being redirected to the temporarily suspended screen. Changes were made in line with https://govukverify.atlassian.net/browse/AUT-2440

