### PR TITLE
AUT-2446: Fixed AIS Password Reset Required Journey to Allow for Password Reset Instead of Showing Temporarily Suspended Screen

### DIFF
--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
@@ -129,6 +129,48 @@ describe("check your email change security codes controller", () => {
       );
     });
 
+    it("should redirect to /unavailable-temporary when only temporarilySuspended AIS status applied to account", async () => {
+      process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
+      const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
+      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
+        "test@test.co.uk",
+        false,
+        false,
+        true
+      );
+
+      await checkYourEmailSecurityCodesPost(
+        fakeVerifyCodeService,
+        fakeAccountInterventionsService
+      )(req as Request, res as Response);
+
+      expect(fakeAccountInterventionsService.accountInterventionStatus).to.have
+        .been.calledOnce;
+      expect(fakeVerifyCodeService.verifyCode).to.have.been.calledOnce;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.UNAVAILABLE_TEMPORARY);
+    });
+
+    it("should redirect to /unavailable-permanent when only blocked AIS status applied to account", async () => {
+      process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
+      const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
+      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
+        "test@test.co.uk",
+        false,
+        true,
+        false
+      );
+
+      await checkYourEmailSecurityCodesPost(
+        fakeVerifyCodeService,
+        fakeAccountInterventionsService
+      )(req as Request, res as Response);
+
+      expect(fakeAccountInterventionsService.accountInterventionStatus).to.have
+        .been.calledOnce;
+      expect(fakeVerifyCodeService.verifyCode).to.have.been.calledOnce;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.UNAVAILABLE_PERMANENT);
+    });
+
     it("should return error when invalid code", async () => {
       const fakeService = fakeVerifyCodeServiceHelper(false);
 

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -100,12 +100,10 @@ export function verifyCodePost(
           );
         if (accountInterventionsResponse.data.blocked) {
           nextEvent = USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION;
-        }
-        if (accountInterventionsResponse.data.temporarilySuspended) {
-          nextEvent = USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION;
-        }
-        if (accountInterventionsResponse.data.passwordResetRequired) {
+        } else if (accountInterventionsResponse.data.passwordResetRequired) {
           nextEvent = USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION;
+        } else if (accountInterventionsResponse.data.temporarilySuspended) {
+          nextEvent = USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION;
         }
       }
     }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1603,7 +1603,7 @@
         "second_old": "ailosod eich cyfrinair",
         "second":"arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
       }
-    }, 
+    },
     "browserBackButtonError": {
       "title": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",
       "header": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",


### PR DESCRIPTION
## What?

Fixed AIS password reset required journey to allow for password reset journey rather than redirecting to temporarily suspended screen.

## Why?

After password reset required screen, entering OTP and MFA a user with passwordResetRequired and temporarilySuspended statuses was incorrectly being shown the temporarily suspended screen instead of being taken through the password reset journey.
