### PR TITLE
[AUT-2485] Improve Dev deployment scripts

### DIFF
--- a/deploy-authdevs.sh
+++ b/deploy-authdevs.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-
-set -eu
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_NAME="frontend-image-repository"
-REPO_URL="706615647326.dkr.ecr.eu-west-2.amazonaws.com/frontend-image-repository"
-IMAGE_TAG=latest
+set -euo pipefail
 
 envvalue=("authdev1" "authdev2")
 
@@ -20,101 +15,15 @@ done
 for ((i = 0; i < ${#envvalue[@]}; ++i)); do
   if ((i == user_in)); then
     printf 'You picked "%s"\n' "${envvalue[$i]}"
-    export env=${envvalue[$i]}
-    printf "deploying in enviorment %s\n" "$env"
-    read -r -p "Press enter to continue or ctr c to abort"
+    export DEPLOY_ENV=${envvalue[$i]}
+    printf "Deploying in environment %s\n" "${DEPLOY_ENV}"
+    read -r -p "Press enter to continue or Ctrl+C to abort"
   fi
 done
 
-function usage() {
-  cat <<USAGE
-  A script to deploy the GOV.UK Sign in APIs to the $env environment.
-  Requires a GDS CLI, AWS CLI and jq installed and configured.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-  Usage:
-    $0 [-b|--build] [-t|--terraform] [--destroy] [-p|--prompt]
+export AWS_PROFILE="di-auth-development-admin"
 
-  Options:
-    -b, --build               run docker build and push new version (default)
-    -t, --terraform           run terraform to deploy changes (default)
-    --destroy                 run terraform with the -destroy flag (destroys all managed resources)
-    -p, --prompt              will prompt for plan review before applying any terraform
-
-    If no options specified the default actions above will be carried out without prompting.
-USAGE
-}
-
-BUILD=0
-TERRAFORM=0
-TERRAFORM_OPTS="-auto-approve"
-
-if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
-  BUILD=1
-  TERRAFORM=1
-fi
-
-while [[ $# -gt 0 ]]; do
-  case $1 in
-  -b | --build)
-    BUILD=1
-    ;;
-  -t | --terraform)
-    # shellcheck disable=SC2034
-    TERRAFORM=1
-    ;;
-  --destroy)
-    TERRAFORM_OPTS="-destroy"
-    ;;
-  -p | --prompt)
-    TERRAFORM_OPTS=""
-    ;;
-  *)
-    usage
-    exit 1
-    ;;
-  esac
-  shift
-done
-
-echo "Generating temporary ECR credentials..."
-#Add you Tools DEV account Profile if diffrent name in below command
-aws ecr get-login-password --region eu-west-2 --profile di-tools-dev | docker login --username AWS --password-stdin "${REPO_URL}"
-
-if [[ $BUILD == "1" ]]; then
-  echo "Building image..."
-  docker buildx build --platform=linux/amd64 --file sandpit.Dockerfile -t "${REPO_NAME}" .
-  echo "Tagging image..."
-  docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
-
-  echo "Pushing image..."
-  docker push "${REPO_URL}:${IMAGE_TAG}"
-  IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
-  echo "Digest = ${IMAGE_DIGEST}"
-  echo "Complete"
-else
-  docker pull "${REPO_URL}:${IMAGE_TAG}"
-  IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
-fi
-
-if [[ $TERRAFORM == "1" ]]; then
-  echo -n "Getting AWS credentials ... "
-  ###Export The di-Auth-devlopment account profile below
-  export AWS_PROFILE=di-auth-dev
-  echo "done!"
-
-  echo "Running Terraform..."
-  pushd "${DIR}/ci/terraform" >/dev/null
-  rm -rf .terraform/
-  terraform init -backend-config="$env".hcl
-  terraform apply ${TERRAFORM_OPTS} -var-file "$env".tfvars -var "image_uri=${REPO_URL}" -var "image_digest=${IMAGE_DIGEST}"
-
-  if [[ $TERRAFORM_OPTS != "-destroy" ]]; then
-    echo -n "Waiting for ECS deployment to complete ... "
-    aws --region eu-west-2 ecs wait services-stable --services "$env-frontend-ecs-service" --cluster "$env-app-cluster"
-    echo "done!"
-  fi
-
-  popd >/dev/null
-fi
-
-echo "Deployment complete!"
+# shellcheck source=scripts/dev_deploy_common.sh
+source "${DIR}/scripts/dev_deploy_common.sh"

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -1,97 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -eu
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_NAME="frontend-image-repository"
-REPO_URL="706615647326.dkr.ecr.eu-west-2.amazonaws.com/frontend-image-repository"
-IMAGE_TAG=latest
 
-function usage() {
-  cat <<USAGE
-  A script to deploy the GOV.UK Sign in APIs to the sandpit environment.
-  Requires a GDS CLI, AWS CLI and jq installed and configured.
+export DEPLOY_ENV="sandpit"
+export AWS_PROFILE="gds-di-development-admin"
 
-  Usage:
-    $0 [-b|--build] [-t|--terraform] [--destroy] [-p|--prompt]
-
-  Options:
-    -b, --build               run docker build and push new version (default)
-    -t, --terraform           run terraform to deploy changes (default)
-    --destroy                 run terraform with the -destroy flag (destroys all managed resources)
-    -p, --prompt              will prompt for plan review before applying any terraform
-
-    If no options specified the default actions above will be carried out without prompting.
-USAGE
-}
-
-BUILD=0
-TERRAFORM=0
-TERRAFORM_OPTS="-auto-approve"
-
-if [[ $# == 0 ]] || [[ $* == "-p" ]]; then
-  BUILD=1
-  TERRAFORM=1
-fi
-while [[ $# -gt 0 ]]; do
-  case $1 in
-  -b | --build)
-    BUILD=1
-    ;;
-  -t | --terraform)
-    # shellcheck disable=SC2034
-    TERRAFORM=1
-    ;;
-  --destroy)
-    TERRAFORM_OPTS="-destroy"
-    ;;
-  -p | --prompt)
-    TERRAFORM_OPTS=""
-    ;;
-  *)
-    usage
-    exit 1
-    ;;
-  esac
-  shift
-done
-
-echo "Generating temporary ECR credentials..."
-eval "$(aws configure export-credentials --profile auth-dev-tools-admin --format env)"
-aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin "${REPO_URL}"
-
-if [[ $BUILD == "1" ]]; then
-  echo "Building image..."
-  docker buildx build --platform=linux/amd64 --file sandpit.Dockerfile -t "${REPO_NAME}" .
-  echo "Tagging image..."
-  docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
-
-  echo "Pushing image..."
-  docker push "${REPO_URL}:${IMAGE_TAG}"
-  IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
-  echo "Digest = ${IMAGE_DIGEST}"
-  echo "Complete"
-else
-  docker pull "${REPO_URL}:${IMAGE_TAG}"
-  IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
-fi
-
-if [[ $TERRAFORM == "1" ]]; then
-  echo -n "Getting AWS credentials ... "
-  eval "$(aws configure export-credentials --profile auth-dev-admin --format env)"
-  echo "done!"
-
-  echo "Running Terraform..."
-  pushd "${DIR}/ci/terraform" >/dev/null
-  rm -rf .terraform/
-  terraform init -backend-config=sandpit.hcl
-  terraform apply ${TERRAFORM_OPTS} -var-file sandpit.tfvars -var "image_uri=${REPO_URL}" -var "image_digest=${IMAGE_DIGEST}"
-
-  if [[ $TERRAFORM_OPTS != "-destroy" ]]; then
-    echo -n "Waiting for ECS deployment to complete ... "
-    aws --region eu-west-2 ecs wait services-stable --services "sandpit-frontend-ecs-service" --cluster "sandpit-app-cluster"
-    echo "done!"
-  fi
-  popd >/dev/null
-fi
-
-echo "Deployment complete!"
+# shellcheck source=scripts/dev_deploy_common.sh
+source "${DIR}/scripts/dev_deploy_common.sh"

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+    echo "Error: Script must be sourced, not executed"
+    exit 1
+}
+
+REPO_NAME="frontend-image-repository"
+REPO_URL="706615647326.dkr.ecr.eu-west-2.amazonaws.com/frontend-image-repository"
+IMAGE_TAG=latest
+
+function usage() {
+    cat <<USAGE
+  A script to deploy the GOV.UK Sign in APIs to the dev environment.
+  Requires a GDS CLI, AWS CLI and jq installed and configured.
+
+  Usage:
+    $0 [-b|--build] [-t|--terraform] [--destroy] [-p|--prompt]
+
+  Options:
+    -b, --build               run docker build and push new version (default)
+    -t, --terraform           run terraform to deploy changes (default)
+    --destroy                 run terraform with the -destroy flag (destroys all managed resources)
+    -p, --prompt              will prompt for plan review before applying any terraform
+
+    If no options specified the default actions above will be carried out without prompting.
+USAGE
+}
+
+BUILD=0
+TERRAFORM=0
+TERRAFORM_OPTS="-auto-approve"
+if [[ $# == 0 ]]; then
+    BUILD=1
+    TERRAFORM=1
+fi
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    -b | --build)
+        BUILD=1
+        ;;
+    -t | --terraform)
+        # shellcheck disable=SC2034
+        TERRAFORM=1
+        ;;
+    --destroy)
+        TERRAFORM_OPTS="-destroy"
+        ;;
+    -p | --prompt)
+        TERRAFORM_OPTS=""
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+DEPLOY_AWS_PROFILE="${AWS_PROFILE}"
+
+export AWS_PROFILE="digital-identity-tools-dev-admin"
+
+# shellcheck source=./scripts/export_aws_creds.sh
+source "${DIR}/scripts/export_aws_creds.sh"
+
+echo "Generating temporary ECR credentials..."
+aws ecr get-login-password --region eu-west-2 |
+    docker login --username AWS --password-stdin "${REPO_URL}"
+
+if [[ $BUILD == "1" ]]; then
+    echo "Building image..."
+    docker buildx build --platform=linux/amd64 --file sandpit.Dockerfile -t "${REPO_NAME}" .
+    echo "Tagging image..."
+    docker tag "${REPO_NAME}:latest" "${REPO_URL}:${IMAGE_TAG}"
+
+    echo "Pushing image..."
+    docker push "${REPO_URL}:${IMAGE_TAG}"
+    IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
+    echo "Digest = ${IMAGE_DIGEST}"
+    echo "Complete"
+else
+    docker pull "${REPO_URL}:${IMAGE_TAG}"
+    IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
+fi
+
+if [[ $TERRAFORM == "1" ]]; then
+    unset AWS_ACCESS_KEY_ID
+    unset AWS_SECRET_ACCESS_KEY
+
+    export AWS_PROFILE="${DEPLOY_AWS_PROFILE}"
+    # shellcheck source=./scripts/export_aws_creds.sh
+    source "${DIR}/scripts/export_aws_creds.sh"
+
+    echo "Running Terraform..."
+    pushd "${DIR}/ci/terraform" >/dev/null
+    rm -rf .terraform/
+    terraform init -backend-config="${DEPLOY_ENV}.hcl"
+    terraform apply ${TERRAFORM_OPTS} -var-file "${DEPLOY_ENV}.tfvars" -var "image_uri=${REPO_URL}" -var "image_digest=${IMAGE_DIGEST}"
+
+    if [[ $TERRAFORM_OPTS != "-destroy" ]]; then
+        echo -n "Waiting for ECS deployment to complete ... "
+        aws ecs wait services-stable --services "${DEPLOY_ENV}-frontend-ecs-service" --cluster "${DEPLOY_ENV}-app-cluster"
+        echo "done!"
+    fi
+    popd >/dev/null
+fi
+
+echo "Deployment complete!"

--- a/scripts/export_aws_creds.sh
+++ b/scripts/export_aws_creds.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
+if [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "Using AWS credentials from existing environment variables"
+else
+  echo "Exporting credentials from AWS CLI profile ${AWS_PROFILE}"
+
+  # Test if the AWS CLI is configured with the correct profile
+  if ! sso_session="$(aws configure get sso_session --profile "${AWS_PROFILE}")"; then
+    echo "AWS CLI profile ${AWS_PROFILE} is not configured."
+    echo "Please visit https://govukverify.atlassian.net/wiki/x/IgFm5 for instructions."
+    exit 1
+  fi
+  if ! aws sts get-caller-identity --profile "${AWS_PROFILE}" >/dev/null; then
+    aws sso login --sso-session "${sso_session}"
+  fi
+  if ! aws_export="$(aws configure export-credentials --profile "${AWS_PROFILE}" --format env 2>/dev/null)"; then
+    echo "Failed to export AWS credentials from AWS CLI profile ${AWS_PROFILE}."
+    echo "Please visit https://govukverify.atlassian.net/wiki/x/IgFm5 for instructions."
+    exit 1
+  fi
+  eval "${aws_export}"
+fi
+
+configured_region="$(aws configure get region --profile "${AWS_PROFILE}" 2>/dev/null)"
+if [[ -n "${configured_region:-}" ]]; then
+  export AWS_REGION="${configured_region}"
+fi


### PR DESCRIPTION
## What?

- Use well-known AWS profile names
- Pull out common code from deploy-authdevs.sh and deploy-sandpit.sh
  into a common script
- Pull out AWS credential export into a separate script

## Why?

Local profile names were different for each person's laptop. This standardises them.

Also, it makes the deploy scripts easier to maintain.

## How to review

- use python script implemented in govuk-one-login/authentication-api#4042 to create the correct AWS accounts
- deploy something to sandpit - check there are no errors
- deploy something to an authdev - check there are no errors

## Related PRs

govuk-one-login/authentication-api#4042
alphagov/di-infrastructure#576