### PR TITLE
BAU: Sample .env config file to run di-authentication-frontend locally pointing to build

### DIFF
--- a/.env.build
+++ b/.env.build
@@ -1,0 +1,67 @@
+#
+# Environment variable configuration file for running di-authentication-frontend locally pointing to remote build
+#
+
+ENVIRONMENT=development
+
+# Orchestration OIDC API
+API_BASE_URL=https://oidc.build.account.gov.uk
+
+# Authentication Frontend API
+FRONTEND_API_BASE_URL=https://auth.build.account.gov.uk
+
+# Redirect host for the local stub client
+STUB_HOSTNAME=di-auth-stub-relying-party-build.london.cloudapps.digital
+
+# Test Client for local testing, must be configured in the client registry - Ask for value
+TEST_CLIENT_ID=
+
+# API Key for the Authentication Frontend API - Ask for value
+API_KEY=
+
+# Domain where app is running
+SERVICE_DOMAIN=localhost
+
+# Local Express session configuration
+SESSION_EXPIRY=60000
+SESSION_SECRET=123456
+
+#
+# Zendesk configuration for Support form submission - Ask for values
+#
+ZENDESK_USERNAME=
+ZENDESK_API_TOKEN=
+ZENDESK_GROUP_ID_PUBLIC=
+ZENDESK_API_URL=
+
+#
+# Orch to Auth configuration
+#
+ORCH_TO_AUTH_CLIENT_ID=orchestrationAuth
+ENCRYPTION_KEY_ID="alias/build-authentication-encryption-key-alias"
+ORCH_TO_AUTH_SIGNING_KEY="-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr\nCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==\n-----END PUBLIC KEY-----"
+ORCH_TO_AUTH_AUDIENCE="https://signin.build.account.gov.uk/"
+
+#
+# Local stub client options
+#
+
+# Set VTR for the stub client authorization request
+VTR=["Cl","Cl.Cm"]
+
+# Locales passed by the client - uncomment to use
+# UI_LOCALES=cy
+
+#
+# Feature switches
+#
+SUPPORT_MFA_OPTIONS=1
+SUPPORT_INTERNATIONAL_NUMBERS=1
+SUPPORT_LANGUAGE_CY=1
+SUPPORT_ACCOUNT_RECOVERY=1
+SUPPORT_AUTH_ORCH_SPLIT=1
+SUPPORT_AUTHORIZE_CONTROLLER=1
+FRAME_ANCESTORS_FORM_ACTIONS_CSP_HEADERS=1
+SUPPORT_ACCOUNT_INTERVENTIONS=1
+SUPPORT_2FA_B4_PASSWORD_RESET=1
+SUPPORT_REAUTHENTICATION=1


### PR DESCRIPTION
## What?

Sample .env config file to run di-authentication-frontend locally pointing to build.

## Why?
 
The local stub has recently been updated and additional environment variables are required to make it run against build

## Related

#1411 
