### PR TITLE
AUT-2462: modify content for the accessibility-statement page

### DIFF
--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -42,6 +42,16 @@
   <li>{{'pages.accessibilityStatement.section2.bulletPoint1' | translate}}</li>
   <li>{{'pages.accessibilityStatement.section2.bulletPoint2' | translate}}</li>
   <li>{{'pages.accessibilityStatement.section2.bulletPoint3' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint4' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint5' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint6' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint7' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint8' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint9' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint10' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint11' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint12' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint13' | translate}}</li>
 </ul>
 <p class="govuk-body">{{'pages.accessibilityStatement.section2.paragraph2' | translate}}</p>
 
@@ -89,7 +99,20 @@
 <h3 class="govuk-heading-s">
   {{'pages.accessibilityStatement.section7.subHeader' | translate}}
 </h3>
-<p class="govuk-body">{{'pages.accessibilityStatement.section7.paragraph2' | translate}}</p>
+<ol class="govuk-list govuk-list--number">
+    <li>{{'pages.accessibilityStatement.section7.listItem1' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem2' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem3' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem4' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem5' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem6' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem7' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem8' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem9' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem10' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem11' | translate}}</li>
+    <li>{{'pages.accessibilityStatement.section7.listItem12' | translate}}</li>
+</ol>
 
 <h2 class="govuk-heading-m">
   {{'pages.accessibilityStatement.section8.header' | translate}}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -849,6 +849,16 @@
         "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu GOV.UK One Login",
         "bulletPoint2": "nid yw’n bosib i ddarllenydd sgrin wybod pryd mae’r e-byst rydym yn eu hanfon mewn iaith ar wahân i’r Saesneg",
         "bulletPoint3": "mae un dudalen yn ail-lwytho yn awtomatig ar ôl terfyn amser penodol, ac nid yw’n bosibl i stopio neu oedi hyn",
+        "bulletPoint4": "mae’r ddolen allgofnodi pennawd yn achosi bar sgrolio llorweddol ar chwyddiadau mawr iawn ar ddyfeisiau symudol",
+        "bulletPoint5": "nid yw bob amser yn bosibl defnyddio opsiynau awtomatig eich porwr i roi gwybodaeth",
+        "bulletPoint6": "nid yw’r dolenni yn y troedyn yr un peth ar bob tudalen",
+        "bulletPoint7": "mae dolen wag yn y pennawd am ran fer o’r daith",
+        "bulletPoint8": "nid yw rhai tudalennau’n nodi’n gywir yr iaith y maent yn cael eu cyhoeddi ynddi",
+        "bulletPoint9": "nid yw teitlau rhai tudalennau yn dechrau gyda ’gwall’ os nad ydych wedi rhoi’r wybodaeth sydd ei hangen yn y ffurf cywir",
+        "bulletPoint10": "mae rhai dolenni yn y pennawd a’r troedyn y gallech ddisgwyl eu hagor mewn tab newydd yn agor yn yr un tab",
+        "bulletPoint11": "mae rhai meysydd ffurflen yn cyfyngu ar faint o nodau y gellir eu rhoi ynddynt, a all ei gwneud hi’n anodd rhoi gwybodaeth wrth ddefnyddio technolegau cynorthwyol",
+        "bulletPoint12": "nid yw botymau sy’n dangos animeiddiadau ’spinner’ yn cadw at eich gosodiadau cynnig llai",
+        "bulletPoint13": "nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni",
         "paragraph2": "Byddwn yn diweddaru’r dudalen hon pan fydd y materion wedi cael eu datrys neu gyda gwybodaeth ynghylch pryd rydym yn bwriadu eu datrys."
       },
       "section3": {
@@ -881,7 +891,18 @@
         "header": "Cynnwys anhygyrch",
         "paragraph1": "Nid yw’r cynnwys a restrir isod yn hygyrch am y rhesymau canlynol.",
         "subHeader": "Diffyg cydymffurfio â’r rheoliadau hygyrchedd",
-        "paragraph2": "Pan fyddwch yn creu GOV.UK One Login neu fewngofnodi, os nad ydych yn gwneud unrhyw beth am 1 awr, bydd y broses yn stopio (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn na diffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant WCAG 2.1  2.2.1 (Addasu Amseru)."
+        "listItem1": "Pan fyddwch yn creu GOV.UK One Login neu’n mewngofnodi, os nad ydych yn gwneud unrhyw beth am 60 munud, bydd y broses yn dod i ben (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn neu ddiffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant 2.2.1 (Amseru Addasadwy) WCAG 2.1.",
+        "listItem2": "Mae’r ddolen allgofnodi pennawd yn achosi bar sgrolio llorweddol ar chwyddiadau mawr iawn ar ddyfeisiau symudol. Os ydych chi’n defnyddio technolegau cynorthwyol efallai y byddwch yn cael hi’n anoddach i lywio tudalennau os ydych chi’n cynyddu’r lefel chwyddo. Mae hyn yn methu maen prawf llwyddiant 1.4.10 (Reflow) WCAG 2.2.",
+        "listItem3": "Nid yw bob amser yn bosibl defnyddio opsiynau awtomatig eich porwr i roi gwybodaeth.",
+        "listItem4": "Os ydych chi’n defnyddio technolegau cynorthwyol, efallai y bydd yn cymryd mwy o amser i chi rhoi gwybodaeth. Mae hyn yn methu maen prawf llwyddiant 1.3.5 (Pwrpas Mewnbwn Hunaniaeth) WCAG 2.2.",
+        "listItem5": "Nid yw’r dolenni yn y troedyn yr un peth ar bob tudalen. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2.",
+        "listItem6": "Mae dolen wag yn y pennawd ar gyfer rhan fer o’r daith. Os ydych chi’n defnyddio technolegau cynorthwyol efallai eich bod chi’n ymwybodol o’r ddolen ond ni fyddwch yn gallu ei dewis. Mae hyn yn methu maen prawf llwyddiant 3.2.3 (Llywio Cyson) WCAG 2.2.",
+        "listItem7": "Nid yw rhai tudalennau’n nodi’n gywir yr iaith y maent yn cael eu cyhoeddi ynddi. Mae hyn yn golygu na fydd darllenwyr sgrin yn darllen cynnwys yn gywir. Mae hyn yn methu maen prawf llwyddiant 3.1.1 (Iaith y Dudalen) WCAG 2.2.",
+        "listItem8": "Nid yw teitlau rhai tudalennau yn dechrau gyda ’gwall’ os nad yw’r defnyddiwr wedi rhoi’r wybodaeth sydd ei hangen yn y ffurf cywir. Mae hyn yn golygu nad yw defnyddwyr darllenwyr sgrin yn gwybod ar unwaith bod problem. Mae hyn yn methu maen prawf llwyddiant 2.4.2 (Teitl y dudalen) WCAG 2.2.",
+        "listItem9": "Mae dolenni yn y pennawd a’r troedyn y gallech ddisgwyl eu hagor mewn tab newydd weithiau’n agor mewn tab newydd. Mae hyn yn methu Canllaw 3.2 (Rhagweladwy) WCAG 2.2.",
+        "listItem10": "Mae rhai meysydd ffurflen yn cyfyngu ar faint o nodau y gellir eu rhoi, a all ei gwneud hi’n anodd rhoi gwybodaeth os ydych chi’n defnyddio technolegau cynorthwyol. Mae hyn yn methu maen prawf llwyddiant 3.3.1 (Adnabod Gwallau) WCAG 2.2.",
+        "listItem11": "Nid yw botymau sy’n dangos animeiddiadau ’spinner’ yn cadw at eich gosodiadau cynnig llai. Mae hyn yn methu maen prawf llwyddiant 2.2.2 (Saib, Stop, Cuddio) WCAG 2.2.",
+        "listItem12": "Nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2."
       },
       "section8": {
         "header": "Beth rydym yn ei wneud i wella hygyrchedd",
@@ -889,8 +910,8 @@
       },
       "section9": {
         "header": "Paratoi’r datganiad hygyrchedd hwn",
-        "paragraph1": "Paratowyd y datganiad hwn ar 4 Tachwedd 2020. Cafodd ei adolygu ddiwethaf ar 29 Mehefin 2022.",
-        "paragraph2": "Cafodd GOV.UK One Login ei brofi ddiwethaf ar 13 Mehefin 2022. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC), a gynhyrchodd adroddiad archwilio hygyrchedd ar 17 Mehefin 2022. Asesodd DAC GOV.UK One Login yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe WCAG 2.1."
+        "paragraph1": "Paratowyd y datganiad hwn ar 4 Tachwedd 2020. Cafodd ei adolygu ddiwethaf ar 28 Chwefror 2024.",
+        "paragraph2": "Cafodd GOV.UK One Login ei brofi ddiwethaf ym mis Hydref a Tachwedd 2023. Cynhaliwyd y prawf gan dîm hygyrchedd GOV.UK One Login, a gynhyrchodd archwiliad o’r daith yn Rhagfyr 2023. Asesodd dîm hygyrchedd GOV.UK One Login y gwasanaeth GOV.UK One Login yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe WCAG 2.2 wrth baratoi ar gyfer y canllawiau sy’n cael eu gorfodi yn Hydref 2024."
       }
     },
     "termsAndConditions": {
@@ -1603,7 +1624,7 @@
         "second_old": "ailosod eich cyfrinair",
         "second":"arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
       }
-    }, 
+    },
     "browserBackButtonError": {
       "title": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",
       "header": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -850,6 +850,16 @@
         "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create a GOV.UK One Login",
         "bulletPoint2": "it’s not possible for a screen reader to know when the emails we send are in a language other than English",
         "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
+        "bulletPoint4": "the header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices",
+        "bulletPoint5": "it’s not always possible to use your browser’s autocomplete options to enter information",
+        "bulletPoint6": "the links in the footer are not the same on every page",
+        "bulletPoint7": "there is an empty link in the header for a short section of the journey",
+        "bulletPoint8": "some pages do not correctly identify the language they are published in",
+        "bulletPoint9": "some page titles do not start with ‘error’ if you have not entered the information that’s needed in the correct format",
+        "bulletPoint10": "some links in the header and footer that you may expect to open in a new tab open in the same tab",
+        "bulletPoint11": "some form fields limit how many characters can be entered in them, which can make it difficult to enter information when using assistive technologies",
+        "bulletPoint12": "buttons that show ‘spinner’ animations do not adhere to your reduced motion settings",
+        "bulletPoint13": "the information in the cookie banner content is not the same on all pages it appears on",
         "paragraph2": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
       },
       "section3": {
@@ -882,7 +892,18 @@
         "header": "Non-accessible content",
         "paragraph1": "The content listed below is non-accessible for the following reasons.",
         "subHeader": "Non compliance with the accessibility regulations",
-        "paragraph2": "When you create a GOV.UK One Login or sign in, if you do not do anything for 1 hour, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable)."
+        "listItem1": "When you create a GOV.UK One Login or sign in, if you do not do anything for 1 hour, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable).",
+        "listItem2": "The header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices. If you use assistive technologies you may find it harder to navigate pages if you increase the zoom level. This fails WCAG 2.2 success criterion 1.4.10 (Reflow).",
+        "listItem3": "It’s not always possible to use your browser’s autocomplete options to enter information.",
+        "listItem4": "If you use assistive technologies, it may take you longer to enter information. This fails WCAG 2.2 success criterion 1.3.5 (Identity Input Purpose).",
+        "listItem5": "The links in the footer are not the same on every page. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help).",
+        "listItem6": "There is an empty link in the header for a short section of the journey. If you use assistive technologies you may be aware of the link but will not be able to select it. This fails WCAG 2.2 success criterion 3.2.3 (Consistent Navigation).",
+        "listItem7": "Some pages do not correctly identify the language they are published in. This means screen readers will not read content correctly. This fails WCAG 2.2 success criterion 3.1.1 (Language of Page).",
+        "listItem8": "Some page titles do not start with ‘error’ if the user hasn’t entered the information that’s needed in the correct format. This means screen reader users do not immediately know there is a problem. This fails WCAG 2.2 success criterion 2.4.2 (Page Titled).",
+        "listItem9": "Links in the header and footer that you may expect to open in a new tab sometimes open in a new tab. This fails WCAG 2.2 Guideline 3.2 (Predictable).",
+        "listItem10": "Some form fields limit how many characters can be entered, which can make it difficult to enter information if you are using assistive technologies. This fails WCAG 2.2 success criterion 3.3.1 (Error Identification).",
+        "listItem11": "Buttons that show ‘spinner’ animations do not adhere to your reduced motion settings. This fails WCAG 2.2 success criterion 2.2.2 (Pause, Stop, Hide).",
+        "listItem12": "The information in the cookie banner content is not the same on all pages it appears on. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help)."
       },
       "section8": {
         "header": "What we’re doing to improve accessibility",
@@ -890,8 +911,8 @@
       },
       "section9": {
         "header": "Preparation of this accessibility statement",
-        "paragraph1": "This statement was prepared on 4 November 2020. It was last reviewed on 29 June 2022.",
-        "paragraph2": "GOV.UK One Login was last tested on 13 June 2022. The test was carried out by the Digital Accessibility Centre (DAC), who produced an accessibility audit report on 17 June 2022. DAC assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.1."
+        "paragraph1": "This statement was prepared on 4 November 2020. It was last reviewed on 28 February 2024.",
+        "paragraph2": "GOV.UK One Login was last tested in October and November 2023. The test was carried out by the GOV.UK One Login accessibility team who produced an audit of the journey in December 2023. The GOV.UK One Login accessibility team assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.2 in preparation for the guidelines being enforced in October 2024."
       }
     },
     "termsAndConditions": {


### PR DESCRIPTION
## What?

Several changes for the accessibility-statement page.

**Update 1**
ADD
  
    - the header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices
    - it’s not always possible to use your browser's autocomplete options to enter information
    - the links in the footer are not the same on every page
    - there is an empty link in the header for a short section of the journey
    - some pages do not correctly identify the language they are published in
    - some page titles do not start with ‘error’ if you have not entered the information that’s needed in the correct format`
    - some links in the header and footer that you may expect to open in a new tab open in the same tab
    - some form fields limit how many characters can be entered in them, which can make it difficult to enter information when using assistive technologies
    - buttons that show ‘spinner’ animations do not adhere to your reduced motion settings
    - the information in the cookie banner content is not the same on all pages it appears on
  
AFTER
  
    - one page reloads automatically after a set time limit, and it’s not possible to stop or delay this

![accessibility statement 2](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/f8286ca3-45df-4521-a2fa-9c0338fc2bd3)
![accessibility statement welsh 2](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/08867946-e76c-4793-84a7-3c91139c90b5)

**Update 2**

In the ‘Non-accessible content’ section

- [x] REPLACE ~~"When you create a GOV.UK One Login or sign in, if you do not do anything for 60 minutes, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable)."~~ 


WITH

1. When you create a GOV.UK One Login or sign in, if you do not do anything for 60 minutes, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable). 
2. The header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices. If you use assistive technologies you may find it harder to navigate pages if you increase the zoom level. This fails WCAG 2.2 success criterion 1.4.10 (Reflow).
3. It’s not always possible to use your browser's autocomplete options to enter information
4. . If you use assistive technologies, it may take you longer to enter information. This fails WCAG 2.2 success criterion 1.3.5 (Identity Input Purpose).
5. The links in the footer are not the same on every page. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help).
6. There is an empty link in the header for a short section of the journey. If you use assistive technologies you may be aware of the link but will not be able to select it. This fails WCAG 2.2 success criterion 3.2.3 (Consistent Navigation).
7. Some pages do not correctly identify the language they are published in. This means screen readers will not read content correctly. This fails WCAG 2.2 success criterion 3.1.1 (Language of Page).
8. Some page titles do not start with ‘error’ if the user hasn’t entered the information that’s needed in the correct format. This means screen reader users do not immediately know there is a problem. This fails WCAG 2.2 success criterion 2.4.2 (Page Titled).
9. Links in the header and footer that you may expect to open in a new tab sometimes open in a new tab. This fails WCAG 2.2 Guideline 3.2 (Predictable).
10. Some form fields limit how many characters can be entered, which can make it difficult to enter information if you are using assistive technologies. This fails WCAG 2.2 success criterion 3.3.1 (Error Identification).
11. Buttons that show ‘spinner’ animations do not adhere to your reduced motion settings. This fails WCAG 2.2 success criterion 2.2.2 (Pause, Stop, Hide).
12. The information in the cookie banner content is not the same on all pages it appears on. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help)

![accessibility statement 3](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/2d611208-7261-443b-874d-169e23e358b6)
![accessibility statement welsh 3](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/5e6fd674-9199-47ec-a23e-d3154c4dc7d5)

**Update 3**
- [x] ~~"GOV.UK One Login was last tested on 13 June 2022. The test was carried out by the Digital Accessibility Centre (DAC), who produced an accessibility audit report on 17 June 2022. DAC assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.1."~~ WITH "GOV.UK One Login was last tested in October and November 2023. The test was carried out by the GOV.UK One Login accessibility team who produced an audit of the journey in December 2023. The GOV.UK One Login accessibility team assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.2 in preparation for the guidelines being enforced in October 2024."

![accessibility statement 4](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/fd77af7d-99fc-4985-bf4f-f57528418240)
![accessibility statement welsh 4](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/5eda3216-8f3e-4c92-a855-1739a33f8b63)

**Update 4** 

Replace 
- [x] ~~"It was last reviewed on 29 June 2022."~~ WITH "It was last reviewed on 28 February 2024. "
![accessibility statement 5](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/16341b5d-1df6-4191-8d89-511200b24965)
![accessibility statement welsh 5](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/4ceaa755-a3c9-4d46-b36d-a20c3d41e0a1)


## Why?

We need to update our accessibility statement prior to HMRC go live.

## Changes have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated