### PR TITLE
[AUT-2484] Add 'How to review' section in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,27 @@
-## What?
+## What
 
-Please include a summary of the change.
+<!-- Describe what you have changed and why -->
 
-## Why?
+## How to review
 
-Please include reason for the change and any other relevant context.
+<!-- Describe the steps required to review this PR.
+For example:
+
+1. Code Review
+1. Deploy to sandpit with `./deploy-sandpit.sh -a`
+1. Ensure that resources `x`, `y` and `z` were not changed
+1. Visit [some url](https://some.sandpit.url/to/visit)
+1. Log in
+1. Ensure `x` message appears in a modal
+-->
 
 ## Change have been demonstrated
 
 Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
+
 - [ ] Changes to the user interface have been demonstrated
 
-Delete this section if the PR does not change the UI.
+<!-- Delete this section if the PR does not change the UI. -->
 
 ## Performance Analysis have been informed of the change
 
@@ -19,5 +29,12 @@ Delete this section if the PR does not change the UI.
 
 ## Related PRs
 
-Please include links to PRs in other repositories relevant to this PR.
-Delete this section if not needed.
+<!-- Links to PRs in other repositories that are relevant to this PR.
+
+This could be:
+  - PRs that depend on this one
+  - PRs this one depends on
+  - If this work is being duplicated in other repos, other PRs
+  - PRs which just provide context to this one. -->
+
+<!-- Delete this section if not needed! -->


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

### Added How to review section

This is a space for developers to list specific steps needed for the PR to be
fully reviewed. 'Code review' is always implied, but can be stated here.

### Merge 'What' and 'Why' section

This seems completely unnecessary - it makes it really difficult to write
the PR in a logical way: 'what?' and 'why?' are intrinsicly linked, and the description
is easier to understand if these are together, rather than split apart.

### Convert instructions to comments

This emphasises their 'differentness', and means that they are not rendered if
left in after submitting the PR. Some people find it easier to write with the prompt
visible at the time, and this means they don't need to worry about removing the prompt
after finishing writing the description.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Ensure no important sections have been removed
2. Ensure no unnecessary sections have been added
3. Ensure the instructions are understandable and correct

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->

https://github.com/alphagov/di-infrastructure/pull/577
https://github.com/govuk-one-login/authentication-check-experian/pull/48
https://github.com/govuk-one-login/authentication-frontend/pull/1423
https://github.com/govuk-one-login/authentication-api/pull/4045