### PR TITLE
AUT-2485: Use CLI profiles for local docker deployment

### DIFF
--- a/.env.build
+++ b/.env.build
@@ -4,6 +4,9 @@
 
 ENVIRONMENT=development
 
+# AWS Profile for the build account
+AWS_PROFILE=gds-di-development-admin
+
 # Orchestration OIDC API
 API_BASE_URL=https://oidc.build.account.gov.uk
 


### PR DESCRIPTION
## What?

Use `export_aws_creds.sh` to set AWS credential envars for local docker deploy.

This standardises credential access within this repo.

## Related

https://github.com/govuk-one-login/authentication-frontend/pull/1420
