### PR TITLE
AUT-2487-Switch off current scaling policy on Prod

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -2,7 +2,7 @@ environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled    = true
+frontend_auto_scaling_enabled    = false
 frontend_auto_scaling_v2_enabled = false
 frontend_task_definition_cpu     = 1024
 frontend_task_definition_memory  = 2048


### PR DESCRIPTION
## What?

AUT-2487 switching off the current scaling policy on prod to enable new scaling policy in next PR 

## Why?

The new scaling policy for NFR has been tested and passed in Staging environment so push the new scaling policy on prod  


## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
