### PR TITLE
bau: Refactor CheckReauthUser service to include the user sub in request

### DIFF
--- a/src/components/check-reauth-users/check-reauth-users-service.ts
+++ b/src/components/check-reauth-users/check-reauth-users-service.ts
@@ -14,6 +14,7 @@ export function checkReauthUsersService(
   const checkReauthUsers = async function (
     sessionId: string,
     emailAddress: string,
+    sub: string,
     sourceIp: string,
     clientSessionId: string,
     persistentSessionId: string
@@ -33,7 +34,7 @@ export function checkReauthUsersService(
 
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.CHECK_REAUTH_USER,
-      { email: lowerCaseEmail },
+      { email: lowerCaseEmail, rpPairwiseId: sub },
       config
     );
 

--- a/src/components/check-reauth-users/types.ts
+++ b/src/components/check-reauth-users/types.ts
@@ -4,6 +4,7 @@ export interface CheckReauthServiceInterface {
   checkReauthUsers: (
     sessionId: string,
     email: string,
+    sub: string,
     sourceIp: string,
     clientSessionId: string,
     persistentSessionId: string

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -57,12 +57,13 @@ export function enterEmailPost(
     const email = req.body.email;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     req.session.user.email = email.toLowerCase();
-    const isReAuthenticationRequired = req.session.user.reauthenticate;
+    const sub = req.session.user.reauthenticate;
 
-    if (supportReauthentication() && isReAuthenticationRequired) {
+    if (supportReauthentication() && sub) {
       const checkReauth = await checkReauthService.checkReauthUsers(
         sessionId,
         email,
+        sub,
         req.ip,
         clientSessionId,
         persistentSessionId


### PR DESCRIPTION
## What?

- Include reauthenticate claim in the request of the CheckReauthUser lambda

## Why?

The value would be used to compared against a calculated rpPairwiseID