### PR TITLE
AUT-2439: Add account interventions middleware to reset password required route

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -609,6 +609,12 @@ const authStateMachine = createMachine(
       },
       [PATH_NAMES.RESET_PASSWORD_REQUIRED]: {
         on: {
+          [USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_PERMANENT,
+          ],
+          [USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION]: [
+            PATH_NAMES.UNAVAILABLE_TEMPORARY,
+          ],
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
               target: [PATH_NAMES.GET_SECURITY_CODES],

--- a/src/components/reset-password/reset-password-routes.ts
+++ b/src/components/reset-password/reset-password-routes.ts
@@ -33,7 +33,11 @@ router.post(
   asyncHandler(resetPasswordPost())
 );
 
-router.get(PATH_NAMES.RESET_PASSWORD_REQUIRED, resetPasswordRequiredGet);
+router.get(
+  PATH_NAMES.RESET_PASSWORD_REQUIRED,
+  asyncHandler(accountInterventionsMiddleware(true, false)),
+  resetPasswordRequiredGet
+);
 
 router.post(
   PATH_NAMES.RESET_PASSWORD_REQUIRED,


### PR DESCRIPTION
This should ensure that when a user is forced to reset their password (for example, when their password is on the list of the most commonly used passwords), they cannot if they have a blocked or suspended account intervention set on them.

## Why?

Fixes a bug in account interventions

