### PR TITLE
AUT-2485: Fix loading the .env file

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -44,7 +44,8 @@ docker-compose --log-level ERROR down
 
 test -f .env || usage "Missing .env file"
 
-export "$(grep -v '^#' .env | xargs)"
+# shellcheck source=/dev/null
+set -o allexport && source .env && set +o allexport
 
 # shellcheck source=./scripts/export_aws_creds.sh
 source "${DIR}/scripts/export_aws_creds.sh"


### PR DESCRIPTION
## What?

The previous grep/xargs approach is a bit brittle and can break
on syntax errors in the .env file.

Instead, use `set -o allexport` to export all variables set in the file
and `source` it directly.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1424
