### PR TITLE
Bugfix: Do not direct to suspensions screen when password reset intervention also applies

### DIFF
--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -45,6 +45,7 @@ export function accountInterventionsMiddleware(
         );
       } else if (
         accountInterventionsResponse.data.temporarilySuspended &&
+        !accountInterventionsResponse.data.passwordResetRequired &&
         handleSuspendedStatus
       ) {
         return res.redirect(

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -136,6 +136,23 @@ describe("accountInterventionsMiddleware", () => {
     );
   });
 
+  it("should not redirect to getNextPathAndUpdateJourney with the journey being UNAVAILABLE_TEMPORARY when passwordResetRequired === true and both password reset and suspension interventions are on", async () => {
+    const fakeAccountInterventionService: AccountInterventionsInterface = {
+      accountInterventionStatus: sinon.fake.returns({
+        data: {
+          email: "test@test.com",
+          passwordResetRequired: true,
+          blocked: false,
+          temporarilySuspended: true,
+        },
+      }),
+    } as unknown as AccountInterventionsInterface;
+    await callMiddleware(true, false, fakeAccountInterventionService);
+    expect(res.redirect).to.not.have.been.calledWith(
+      PATH_NAMES.UNAVAILABLE_TEMPORARY
+    );
+  });
+
   it("should not redirect to UNAVAILABLE_TEMPORARY when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
     const fakeAccountInterventionService = fakeAccountInterventionsService({
       passwordResetRequired: false,


### PR DESCRIPTION
This fixes the case where, when resetting a password due to an account intervention of password reset required, we are taken to the temporarily blocked screen, since in the reset password routes we still care about the suspension status as we don't want to allow password resets on suspended users. However, when someone has an account intervention of 'password_reset_required', they will always have a suspension also until they have reset their password. Therefore, in the password reset routes and in the middleware, we want to differentiate between the case where a user only has a suspension status (in which case they should not be allowed to reset their password) from the case where they have a suspension status because they need to reset their password.
