### PR TITLE
AUT-2487-Removing old ecs scaling policy  post switched to step scaling

### DIFF
--- a/ci/terraform/auto-scaling.tf
+++ b/ci/terraform/auto-scaling.tf
@@ -1,49 +1,6 @@
 
-# TODO: fully replace frontend_auto_scaling_* with frontend_auto_scaling_*_v2 after performance testing
-resource "aws_appautoscaling_target" "frontend_auto_scaling_target" {
-  count              = var.frontend_auto_scaling_enabled ? 1 : 0
-  min_capacity       = var.frontend_auto_scaling_min_count
-  max_capacity       = var.frontend_auto_scaling_max_count
-  resource_id        = "service/${var.environment}-app-cluster/${aws_ecs_service.frontend_ecs_service.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-  service_namespace  = "ecs"
-}
+ # stepscaling frontend_auto_scaling_*_v2 after performance testing
 
-resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_memory" {
-  count              = var.frontend_auto_scaling_enabled ? 1 : 0
-  name               = "${var.environment}-frontend_auto_scaling_policy_memory"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.frontend_auto_scaling_target[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.frontend_auto_scaling_target[0].scalable_dimension
-  service_namespace  = aws_appautoscaling_target.frontend_auto_scaling_target[0].service_namespace
-
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
-    }
-    target_value       = var.frontend_auto_scaling_policy_memory_target
-    scale_out_cooldown = var.frontend_auto_scaling_policy_scale_out_cooldown
-    scale_in_cooldown  = var.frontend_auto_scaling_policy_scale_in_cooldown
-  }
-}
-
-resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_cpu" {
-  count              = var.frontend_auto_scaling_enabled ? 1 : 0
-  name               = "${var.environment}-frontend_auto_scaling_policy_cpu"
-  policy_type        = "TargetTrackingScaling"
-  resource_id        = aws_appautoscaling_target.frontend_auto_scaling_target[0].resource_id
-  scalable_dimension = aws_appautoscaling_target.frontend_auto_scaling_target[0].scalable_dimension
-  service_namespace  = aws_appautoscaling_target.frontend_auto_scaling_target[0].service_namespace
-
-  target_tracking_scaling_policy_configuration {
-    predefined_metric_specification {
-      predefined_metric_type = "ECSServiceAverageCPUUtilization"
-    }
-    target_value       = var.frontend_auto_scaling_policy_cpu_target
-    scale_out_cooldown = var.frontend_auto_scaling_policy_scale_out_cooldown
-    scale_in_cooldown  = var.frontend_auto_scaling_policy_scale_in_cooldown
-  }
-}
 
 resource "aws_cloudwatch_metric_alarm" "ecs_service_scale_out_alarm" {
   count               = var.frontend_auto_scaling_v2_enabled ? 1 : 0

--- a/ci/terraform/auto-scaling.tf
+++ b/ci/terraform/auto-scaling.tf
@@ -1,5 +1,5 @@
 
- # stepscaling frontend_auto_scaling_*_v2 after performance testing
+# stepscaling frontend_auto_scaling_*_v2 after performance testing
 
 
 resource "aws_cloudwatch_metric_alarm" "ecs_service_scale_out_alarm" {

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,7 +1,6 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled    = false
 frontend_auto_scaling_v2_enabled = true
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -2,7 +2,6 @@ environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled    = false
 frontend_auto_scaling_v2_enabled = true
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -71,10 +71,6 @@ variable "frontend_task_definition_memory" {
   default = 2048
 }
 
-variable "frontend_auto_scaling_enabled" {
-  default = false
-}
-
 variable "frontend_auto_scaling_v2_enabled" {
   default = false
 }


### PR DESCRIPTION
## What?

AUT-2487-Removing old ecs scaling policy  post switched to step scaling

## Why?

We have moved our ECS policy to step scaling after passing the Performance testing , so removing old scaling policy code for clean-up

