### PR TITLE
Bugfix: removed the 2FA step from the password reset intervention flow

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -78,6 +78,7 @@ const authStateMachine = createMachine(
       isReauthenticationRequired: false,
       requiresResetPasswordMFASmsCode: false,
       requiresResetPasswordMFAAuthAppCode: false,
+      isOnForcedPasswordResetJourney: false,
     },
     states: {
       [PATH_NAMES.ROOT]: {
@@ -789,9 +790,11 @@ const authStateMachine = createMachine(
         context.requiresTwoFactorAuth === true,
       requiresResetPasswordMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
+        context.isOnForcedPasswordResetJourney !== true &&
         context.support2FABeforePasswordReset === true,
       requiresResetPasswordMFASmsCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.SMS &&
+        context.isOnForcedPasswordResetJourney !== true &&
         context.support2FABeforePasswordReset === true,
       isPasswordChangeRequired: (context) => context.isPasswordChangeRequired,
       is2FASMSPasswordChangeRequired: (context) =>

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -8,7 +8,11 @@ import { BadRequestError } from "../../../utils/error";
 import { VerifyCodeInterface } from "./types";
 import { ExpressRouteFunc } from "../../../types";
 import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine";
-import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../../app.constants";
+import {
+  JOURNEY_TYPE,
+  NOTIFICATION_TYPE,
+  PATH_NAMES,
+} from "../../../app.constants";
 import {
   support2FABeforePasswordReset,
   supportAccountInterventions,
@@ -20,6 +24,7 @@ interface Config {
   template: string;
   validationKey: string;
   validationErrorCode: number;
+  isOnForcedPasswordResetJourney?: boolean;
   callback?: (req: Request, res: Response) => void;
   journeyType?: JOURNEY_TYPE;
 }
@@ -128,6 +133,9 @@ export function verifyCodePost(
           support2FABeforePasswordReset: support2FABeforePasswordReset(),
           mfaMethodType: req.session.user.enterEmailMfaType,
           isPasswordChangeRequired: req.session.user.isPasswordChangeRequired,
+          isOnForcedPasswordResetJourney:
+            req.path === PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL &&
+            req.session.user.withinForcedPasswordResetJourney,
         },
         res.locals.sessionId
       )

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -141,10 +141,41 @@ describe("reset password check email controller", () => {
       );
     });
 
-    it("should redirect to /reset-password without calling the account interventions service when session.user.withinForcedPasswordResetJourney === true", async () => {
+    it("should redirect to /reset-password without calling the account interventions service when session.user.withinForcedPasswordResetJourney === true and enterEmailMfaType == SMS", async () => {
       req.session.user.withinForcedPasswordResetJourney = true;
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      req.session.user.enterEmailMfaType = "SMS";
+
+      const fakeInterventionsService = accountInterventionsFakeHelper(
+        "test@test.com",
+        false,
+        false,
+        false
+      );
+
       const fakeService = fakeVerifyCodeServiceHelper(true);
-      await resetPasswordCheckEmailPost(fakeService)(
+      await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.RESET_PASSWORD);
+    });
+
+    it("should redirect to /reset-password without calling the account interventions service when session.user.withinForcedPasswordResetJourney === true and enterEmailMfaType == AUTH_APP", async () => {
+      req.session.user.withinForcedPasswordResetJourney = true;
+      process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
+      req.session.user.enterEmailMfaType = "AUTH_APP";
+
+      const fakeInterventionsService = accountInterventionsFakeHelper(
+        "test@test.com",
+        false,
+        false,
+        false
+      );
+
+      const fakeService = fakeVerifyCodeServiceHelper(true);
+      await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
         req as Request,
         res as Response
       );


### PR DESCRIPTION
## What

A user going through the forced password reset flow has already entered a 2FA code when going through the regular login journey. A user should not have to enter their MFA twice.