### PR TITLE
AUT-1540: Update content on uplift screens

### DIFF
--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -10,11 +10,12 @@
 
     {% include "common/errors/errorSummary.njk" %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.upliftRequired.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.enterMfa.upliftRequired.header' | translate }}</h1>
     <p class="govuk-body">{{ 'pages.enterMfa.upliftRequired.paragraph1' | translate }} </p>
 
     {% set insetTextHtml %}
-        <p class="govuk-body">{{ 'pages.enterMfa.upliftRequired.paragraph3' | translate }}</p>
+        <p class="govuk-body">{{ 'pages.enterMfa.upliftRequired.paragraph3' | translate }} <span
+                    class='govuk-!-font-weight-bold'>{{ phoneNumber | returnLastCharacters({limit: 3}) }}</span></p>
     {% endset %}
     {{ govukInsetText({
         html: insetTextHtml
@@ -25,8 +26,8 @@
     <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
         <input type="hidden" name="phoneNumber" value="{{ phoneNumber }}" />
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-        <input type="hidden" name="supportAccountRecovery" value="{{supportAccountRecovery}}"/>
-        <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
+        <input type="hidden" name="supportAccountRecovery" value="{{ supportAccountRecovery }}" />
+        <input type="hidden" name="checkEmailLink" value="{{ checkEmailLink }}" />
 
         {{ govukInput({
             label: {
@@ -44,12 +45,10 @@
 
         {% set detailsHTML %}
             <p class="govuk-body">
-                <a href="{{ 'pages.enterMfa.details.sendCodeLinkHref' | translate }}"
-                   class="govuk-link"
-                   rel="noreferrer noopener">
-                    {{'pages.enterMfa.upliftRequired.sendTheCodeAgain'| translate}}
-                </a>
-                {{'pages.enterMfa.details.text 2' | translate}}
+                {{ 'pages.enterMfa.details.text1' | translate }}
+                <a href="{{ 'pages.enterMfa.details.sendCodeLinkHref' | translate }}" class="govuk-link"
+                   rel="noreferrer noopener">{{ 'pages.enterMfa.details.sendCodeLinkText'| translate }}</a>
+                {{ 'pages.enterMfa.details.text 2' | translate }}
             </p>
             {% if supportAccountRecovery === true %}
                 <p class="govuk-body">

--- a/src/config/nunchucks.ts
+++ b/src/config/nunchucks.ts
@@ -1,7 +1,8 @@
 import express from "express";
 import * as nunjucks from "nunjucks";
-import i18next from "i18next";
 import { Environment } from "nunjucks";
+import i18next from "i18next";
+import { returnLastCharactersOnly } from "../utils/phone-number";
 
 export function configureNunjucks(
   app: express.Application,
@@ -17,6 +18,13 @@ export function configureNunjucks(
     const translate = i18next.getFixedT(this.ctx.i18n.language);
     return translate(key, options);
   });
+
+  nunjucksEnv.addFilter(
+    "returnLastCharacters",
+    function (key: string, options?: any) {
+      return returnLastCharactersOnly(key, options);
+    }
+  );
 
   return nunjucksEnv;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -522,12 +522,11 @@
         "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch"
       },
       "upliftRequired": {
-        "title": "Mae angen i chi roi cod diogelwch",
-        "header": "Mae angen i chi roi cod diogelwch",
-        "paragraph1": "Mae hwn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
+        "title": "Rhowch god diogelwch i barhau",
+        "header": "Rhowch god diogelwch i barhau",
+        "paragraph1": "Mae hyn ar gyfer diogelwch ychwanegol.",
         "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
-        "paragraph3": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login.",
-        "sendTheCodeAgain": "Anfon y cod eto"
+        "paragraph3": "Rydym wedi anfon cod i’ch rhif ffôn sy’n gorffen gyda "
       }
     },
     "passwordResetMfaSms": {
@@ -561,12 +560,11 @@
         "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch"
       },
       "upliftRequired": {
-        "title": "Mae angen i chi roi cod diogelwch",
-        "header": "Mae angen i chi roi cod diogelwch",
-        "paragraph1": "Mae hwn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
+        "title": "Rhowch god diogelwch i barhau",
+        "header": "Rhowch god diogelwch i barhau",
+        "paragraph1": "Mae hyn ar gyfer diogelwch ychwanegol.",
         "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
-        "paragraph3": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login.",
-        "sendTheCodeAgain": "Anfon y cod eto"
+        "paragraph3": "Rydym wedi anfon cod i’ch rhif ffôn sy’n gorffen gyda "
       }
     },
     "resendMfaCode": {
@@ -2278,10 +2276,10 @@
         "text3": "."
       },
       "upliftRequired": {
-        "title": "Mae angen i chi roi cod diogelwch",
-        "header": "Mae angen i chi roi cod diogelwch",
+        "title": "Rhowch god diogelwch i barhau",
+        "header": "Rhowch god diogelwch i barhau",
         "info": {
-          "paragraph1": "Mae hwn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
+          "paragraph1": "Mae hyn ar gyfer diogelwch ychwanegol.",
           "paragraph2": "I gael cod diogelwch, agorwch yr ",
           "authenticatorApp": "ap dilysydd ",
           "paragraph2End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -267,7 +267,6 @@
           "required": "Enter your password",
           "incorrectPassword_old": "Enter the correct password",
           "incorrectPassword": "The password you entered is not correct. If you have forgotten your password, you can reset it"
-
         }
       },
       "forgottenPassword": {
@@ -523,12 +522,11 @@
         "changeGetSecurityCodesLinkText": "change how you get security codes"
       },
       "upliftRequired": {
-        "title": "You need to enter a security code",
-        "header": "You need to enter a security code",
-        "paragraph1": "This helps keep your GOV.UK One Login secure.",
+        "title": "Enter a security code to continue",
+        "header": "Enter a security code to continue",
+        "paragraph1": "This is for extra security.",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes.",
-        "paragraph3": "We sent a code to the phone number linked to your GOV.UK One Login.",
-        "sendTheCodeAgain": "Send the code again"
+        "paragraph3": "We have sent a code to your phone number ending with "
       }
     },
     "passwordResetMfaSms": {
@@ -562,12 +560,11 @@
         "changeGetSecurityCodesLinkText": "change how you get security codes"
       },
       "upliftRequired": {
-        "title": "You need to enter a security code",
-        "header": "You need to enter a security code",
-        "paragraph1": "This helps keep your GOV.UK One Login secure.",
+        "title": "Enter a security code to continue",
+        "header": "Enter a security code to continue",
+        "paragraph1": "This is for extra security.",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes.",
-        "paragraph3": "We sent a code to the phone number linked to your GOV.UK One Login.",
-        "sendTheCodeAgain": "Send the code again"
+        "paragraph3": "We have sent a code to your phone number ending with "
       }
     },
     "resendMfaCode": {
@@ -2279,10 +2276,10 @@
         "text3": "."
       },
       "upliftRequired": {
-        "title": "You need to enter a security code",
-        "header": "You need to enter a security code",
+        "title": "Enter a security code to continue",
+        "header": "Enter a security code to continue",
         "info": {
-          "paragraph1": "This helps keep your GOV.UK One Login secure.",
+          "paragraph1": "This is for extra security.",
           "paragraph2": "To get a security code, open the ",
           "authenticatorApp": "authenticator app ",
           "paragraph2End": "you used to create your GOV.UK One Login"

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -55,3 +55,10 @@ export function convertInternationalPhoneNumberToE164Format(
 
   return "+".concat(value);
 }
+
+export function returnLastCharactersOnly(
+  value: string,
+  options: { limit: number } = { limit: 4 }
+): string {
+  return value.slice(-options.limit);
+}

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -5,6 +5,7 @@ import {
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
   convertInternationalPhoneNumberToE164Format,
+  returnLastCharactersOnly,
 } from "../../../src/utils/phone-number";
 
 describe("phone-number", () => {
@@ -237,6 +238,19 @@ describe("phone-number", () => {
       expect(
         convertInternationalPhoneNumberToE164Format("0034608453322")
       ).to.equal("+34608453322");
+    });
+  });
+
+  describe("returnLastCharacters", () => {
+    it("should return the last four characters where no limit is set in the options", () => {
+      expect(returnLastCharactersOnly("1234567890")).to.equal("7890");
+    });
+    it("should return a string of length equal to the limit set", () => {
+      [1, 2, 3, 4, 5, 6, 7, 8, 9].forEach((i) => {
+        expect(
+          returnLastCharactersOnly("1234567890", { limit: i }).length
+        ).to.equal(i);
+      });
     });
   });
 });


### PR DESCRIPTION
## What

Updates the content on SMS and Authenticator App uplift screens, including introducing the last three characters of the user's telephone number (for which I've introduced a Nunjucks filter, utility function and associated tests). 

### Screenshots

<details>
<summary>Enter a security code to continue (SMS version in English)</summary>

<img width="993" alt="Phone security code - English" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/881506c2-e1bf-4ca7-a3ad-748e292b0ca1">

</details>

<details>
<summary>Enter a security code to continue (SMS version in Welsh)</summary>

<img width="994" alt="Phone security code - Welsh" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/9cc7506b-887f-4331-ac40-699246992f6c">

</details>

<details>
<summary>Enter a security code to continue (Authenticator App version in English</summary>

<img width="984" alt="App security code - English" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/c6fe1c2c-a4df-4be7-a2cf-41042ae08812">

</details>

<details>
<summary>Enter a security code to continue (Authenticator App version in Welsh)</summary>

<img width="985" alt="App security code - Welsh" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1961aafe-8793-405f-b518-2fb256875760">

</details>

## How to review

1. Look at the [SonarCloud report](https://sonarcloud.io/summary/new_code?id=govuk-one-login_authentication-frontend&pullRequest=1438) to see if there's anything which concerns you
1. Review the code changes
1. Confirm the updated templates render as expected (reflecting the screenshots above) during user journeys from your local development machine. This is not straighforward to simulate because a user will only be presented with these screens during an uplift journey. During development I got round this by temporarily hard-coding the changed template names as the value for `templateName` in the relevant controllers and then going through account creation journeys using both SMS and Authenticator Apps as the second factor, i.e.
     - replacing lines 37-39 of `enter-authenticator-app-code-controller.ts` with `const templateName = UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME` and then creating an account with an Authenticator App as the second factor
     - replacing lines 28-32 of `enter-mfa-controller.ts` with `const templateName = UPLIFT_REQUIRED_SMS_TEMPLATE_NAME`
1. If you used my approach to simulate an uplift journey, revert the changes to `enter-authenticator-app-code-controller.ts` and `enter-mfa-controller.ts`

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

<!-- Delete this section if the PR does not change the UI. -->

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
