### PR TITLE
AUT-2543: Created isForcedPasswordReset parameter in updatePassword method

### DIFF
--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -39,7 +39,7 @@ export function resetPasswordPost(
   mfaCodeService: MfaServiceInterface = mfaService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const { email } = req.session.user;
+    const { email, withinForcedPasswordResetJourney } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const newPassword = req.body.password;
 
@@ -48,7 +48,8 @@ export function resetPasswordPost(
       req.ip,
       sessionId,
       clientSessionId,
-      persistentSessionId
+      persistentSessionId,
+      withinForcedPasswordResetJourney
     );
 
     if (!updatePasswordResponse.success) {

--- a/src/components/reset-password/types.ts
+++ b/src/components/reset-password/types.ts
@@ -6,6 +6,7 @@ export interface ResetPasswordServiceInterface {
     sourceIp: string,
     sessionId: string,
     clientSessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    isForcedPasswordReset: boolean
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }


### PR DESCRIPTION
## What
Created isForcedPasswordReset parameter in updatePassword method to accept req.session.user.withinForcedPasswordResetJourney as an argument in the reset password controller. This is so that in the backend we can distinguish between password reset journey types for auditing.

Another PR is to follow for the backend.

## How to review

Code should be reviewed alongside backend PR (https://github.com/govuk-one-login/authentication-api/pull/4087) ensuring that the argument for isForcedPasswordReset is accessible in the ResetPasswordHandler

## Related PRs
https://github.com/govuk-one-login/authentication-api/pull/4087
