### PR TITLE
AUT-2552: ignore reset password intervention within middleware when password has been more recently reset than intervention applied

### DIFF
--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
@@ -14,7 +14,10 @@ import {
   RequestOutput,
   ResponseOutput,
 } from "mock-req-res";
-import { accountInterventionsFakeHelper } from "../../../../../test/helpers/account-interventions-helpers";
+import {
+  accountInterventionsFakeHelper,
+  noInterventions,
+} from "../../../../../test/helpers/account-interventions-helpers";
 import { fakeVerifyCodeServiceHelper } from "../../../../../test/helpers/verify-code-helpers";
 import { ERROR_CODES } from "../../../common/constants";
 
@@ -56,12 +59,8 @@ describe("check your email change security codes controller", () => {
 
     it("should redirect to /get-security-codes and not call AIS when valid code entered and account interventions is turned on", async () => {
       const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
-      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
-        "test@test.co.uk",
-        false,
-        false,
-        false
-      );
+      const fakeAccountInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
 
       await checkYourEmailSecurityCodesPost(
         fakeVerifyCodeService,
@@ -77,12 +76,8 @@ describe("check your email change security codes controller", () => {
     it("should redirect to /get-security-codes when valid code entered and there are no interventions in place and account interventions is turned on", async () => {
       process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
       const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
-      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
-        "test@test.co.uk",
-        false,
-        false,
-        false
-      );
+      const fakeAccountInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
 
       await checkYourEmailSecurityCodesPost(
         fakeVerifyCodeService,
@@ -98,12 +93,11 @@ describe("check your email change security codes controller", () => {
     it("should redirect to /password-reset-required when temporarilySuspended and resetPasswordRequired statuses applied to account.", async () => {
       process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
       const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
-      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
-        "test@test.co.uk",
-        true,
-        false,
-        true
-      );
+      const fakeAccountInterventionsService = accountInterventionsFakeHelper({
+        passwordResetRequired: true,
+        blocked: false,
+        temporarilySuspended: true,
+      });
 
       await checkYourEmailSecurityCodesPost(
         fakeVerifyCodeService,
@@ -121,12 +115,11 @@ describe("check your email change security codes controller", () => {
     it("should redirect to /unavailable-temporary when only temporarilySuspended AIS status applied to account", async () => {
       process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
       const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
-      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
-        "test@test.co.uk",
-        false,
-        false,
-        true
-      );
+      const fakeAccountInterventionsService = accountInterventionsFakeHelper({
+        temporarilySuspended: true,
+        blocked: false,
+        passwordResetRequired: false,
+      });
 
       await checkYourEmailSecurityCodesPost(
         fakeVerifyCodeService,
@@ -142,12 +135,11 @@ describe("check your email change security codes controller", () => {
     it("should redirect to /unavailable-permanent when only blocked AIS status applied to account", async () => {
       process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
       const fakeVerifyCodeService = fakeVerifyCodeServiceHelper(true);
-      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
-        "test@test.co.uk",
-        false,
-        true,
-        false
-      );
+      const fakeAccountInterventionsService = accountInterventionsFakeHelper({
+        blocked: true,
+        passwordResetRequired: false,
+        temporarilySuspended: false,
+      });
 
       await checkYourEmailSecurityCodesPost(
         fakeVerifyCodeService,
@@ -166,12 +158,8 @@ describe("check your email change security codes controller", () => {
         ERROR_CODES.INVALID_VERIFY_EMAIL_CODE
       );
 
-      const fakeAccountInterventionsService = accountInterventionsFakeHelper(
-        "test@test.co.uk",
-        false,
-        false,
-        false
-      );
+      const fakeAccountInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
 
       await checkYourEmailSecurityCodesPost(
         fakeService,

--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -11,7 +11,10 @@ import {
 } from "mock-req-res";
 import { fakeVerifyCodeServiceHelper } from "../../../../../test/helpers/verify-code-helpers";
 import { verifyCodePost } from "../verify-code-controller";
-import { accountInterventionsFakeHelper } from "../../../../../test/helpers/account-interventions-helpers";
+import {
+  accountInterventionsFakeHelper,
+  noInterventions,
+} from "../../../../../test/helpers/account-interventions-helpers";
 import {
   JOURNEY_TYPE,
   NOTIFICATION_TYPE,
@@ -35,12 +38,8 @@ describe("Verify code controller tests", () => {
 
   it("if code is valid and NOTIFICATION_TYPE.EMAIL_CODE redirects to /enter-password without calling account interventions", async () => {
     const verifyCodeService = fakeVerifyCodeServiceHelper(true);
-    const accountInterventionService = accountInterventionsFakeHelper(
-      "test@test.com",
-      false,
-      false,
-      false
-    );
+    const accountInterventionService =
+      accountInterventionsFakeHelper(noInterventions);
 
     req = mockRequest({
       path: PATH_NAMES.ENTER_PASSWORD,
@@ -72,12 +71,11 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account is blocked, redirects to /unavailable-permanent", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        true,
-        false
-      );
+      const accountInterventionService = accountInterventionsFakeHelper({
+        blocked: true,
+        passwordResetRequired: false,
+        temporarilySuspended: false,
+      });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
           NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
@@ -92,12 +90,11 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account is temporarily suspended only, redirects to /unavailable-temporary", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        true
-      );
+      const accountInterventionService = accountInterventionsFakeHelper({
+        temporarilySuspended: true,
+        blocked: false,
+        passwordResetRequired: false,
+      });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
           NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
@@ -112,12 +109,11 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has has password reset required status, redirects to /password-reset-required", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        true,
-        false,
-        true
-      );
+      const accountInterventionService = accountInterventionsFakeHelper({
+        passwordResetRequired: true,
+        temporarilySuspended: true,
+        blocked: false,
+      });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
           NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
@@ -132,12 +128,8 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has no AIS status, redirects to /get-security-codes", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const accountInterventionService =
+        accountInterventionsFakeHelper(noInterventions);
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
           NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
@@ -163,12 +155,8 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has no AIS status, redirects to reset password", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const accountInterventionService =
+        accountInterventionsFakeHelper(noInterventions);
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
         template: "check-your-email/index.njk",
@@ -183,12 +171,11 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has only temporary suspension status, redirects to /unavailable-temporary", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        true
-      );
+      const accountInterventionService = accountInterventionsFakeHelper({
+        temporarilySuspended: true,
+        blocked: false,
+        passwordResetRequired: false,
+      });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
         template: "check-your-email/index.njk",
@@ -203,12 +190,11 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has only permanent suspension status, redirects to /unavailable-permanent", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        true,
-        false
-      );
+      const accountInterventionService = accountInterventionsFakeHelper({
+        blocked: true,
+        passwordResetRequired: false,
+        temporarilySuspended: false,
+      });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
         template: "check-your-email/index.njk",
@@ -223,12 +209,11 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has reset password and suspended status, redirects to reset password", async () => {
-      const accountInterventionService = accountInterventionsFakeHelper(
-        "test@test.com",
-        true,
-        false,
-        true
-      );
+      const accountInterventionService = accountInterventionsFakeHelper({
+        passwordResetRequired: true,
+        temporarilySuspended: true,
+        blocked: false,
+      });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
         template: "check-your-email/index.njk",

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -421,12 +421,11 @@ describe("enter password controller", () => {
       ];
 
       for (const testCase of testCases) {
-        const fakeInterventionsService = accountInterventionsFakeHelper(
-          "joe.bloggs@test.com",
-          testCase.interventions.passwordResetRequired,
-          testCase.interventions.blocked,
-          testCase.interventions.temporarilySuspended
-        );
+        const fakeInterventionsService = accountInterventionsFakeHelper({
+          passwordResetRequired: testCase.interventions.passwordResetRequired,
+          blocked: testCase.interventions.blocked,
+          temporarilySuspended: testCase.interventions.temporarilySuspended,
+        });
         res.locals.sessionId = "123456-djjad";
         res.locals.clientSessionId = "00000-djjad";
         res.locals.persistentSessionId = "dips-123456-abc";

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
@@ -111,12 +111,11 @@ describe("reset password 2fa auth app controller", () => {
     it("should redirect to /unavailable-temporary when temporarilySuspended status applied to account and they try to reset their password", async () => {
       process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
       const fakeService = fakeVerifyCodeServiceHelper(true);
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        true
-      );
+      const fakeInterventionsService = accountInterventionsFakeHelper({
+        temporarilySuspended: true,
+        blocked: false,
+        passwordResetRequired: false,
+      });
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
@@ -128,15 +127,14 @@ describe("reset password 2fa auth app controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_NAMES.UNAVAILABLE_TEMPORARY);
     });
 
-    it("should redirect to /unavailable-temporary when temporarilySuspended status applied to account and they try to reset their password", async () => {
+    it("should redirect to /unavailable-permanent when bloced status applied to account and they try to reset their password", async () => {
       process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
       const fakeService = fakeVerifyCodeServiceHelper(true);
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        true,
-        false
-      );
+      const fakeInterventionsService = accountInterventionsFakeHelper({
+        blocked: true,
+        temporarilySuspended: false,
+        passwordResetRequired: false,
+      });
       req.session.user = {
         email: "joe.bloggs@test.com",
       };

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -17,7 +17,10 @@ import {
 } from "mock-req-res";
 import { PATH_NAMES } from "../../../app.constants";
 import { ERROR_CODES } from "../../common/constants";
-import { accountInterventionsFakeHelper } from "../../../../test/helpers/account-interventions-helpers";
+import {
+  accountInterventionsFakeHelper,
+  noInterventions,
+} from "../../../../test/helpers/account-interventions-helpers";
 import { fakeVerifyCodeServiceHelper } from "../../../../test/helpers/verify-code-helpers";
 
 describe("reset password check email controller", () => {
@@ -72,12 +75,8 @@ describe("reset password check email controller", () => {
     });
     it("should redirect to reset password if code entered is correct", async () => {
       const fakeService = fakeVerifyCodeServiceHelper(true);
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const fakeInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
         req as Request,
         res as Response
@@ -89,12 +88,8 @@ describe("reset password check email controller", () => {
     it("should redirect to check_phone if code entered is correct and feature flag is turned on", async () => {
       process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
       const fakeService = fakeVerifyCodeServiceHelper(true);
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const fakeInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
       req.session.user.enterEmailMfaType = "SMS";
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
         req as Request,
@@ -109,12 +104,8 @@ describe("reset password check email controller", () => {
     it("should redirect to check_auth_app if code entered is correct and feature flag is turned on", async () => {
       process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
       const fakeService = fakeVerifyCodeServiceHelper(true);
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const fakeInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
       req.session.user.enterEmailMfaType = "AUTH_APP";
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
         req as Request,
@@ -146,12 +137,8 @@ describe("reset password check email controller", () => {
       process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
       req.session.user.enterEmailMfaType = "SMS";
 
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const fakeInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
 
       const fakeService = fakeVerifyCodeServiceHelper(true);
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
@@ -167,12 +154,8 @@ describe("reset password check email controller", () => {
       process.env.SUPPORT_2FA_B4_PASSWORD_RESET = "1";
       req.session.user.enterEmailMfaType = "AUTH_APP";
 
-      const fakeInterventionsService = accountInterventionsFakeHelper(
-        "test@test.com",
-        false,
-        false,
-        false
-      );
+      const fakeInterventionsService =
+        accountInterventionsFakeHelper(noInterventions);
 
       const fakeService = fakeVerifyCodeServiceHelper(true);
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -81,6 +81,8 @@ export function resetPasswordPost(
       }
     }
 
+    req.session.user.passwordResetTime = Date.now();
+
     const loginResponse = await loginService.loginUser(
       sessionId,
       email,

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export interface UserSession {
   authCodeReturnToRP?: boolean;
   enterEmailMfaType?: string;
   withinForcedPasswordResetJourney?: boolean;
+  passwordResetTime?: number;
 }
 
 export interface UserSessionClient {

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -40,18 +40,19 @@ export const noInterventions: AccountInterventionsFlags = {
 };
 
 export function accountInterventionsFakeHelper(
-  email: string,
-  passwordResetRequired: boolean,
-  blocked: boolean,
-  temporarilySuspended: boolean
+  flags: AccountInterventionsFlags,
+  maybeDateTimeStamp?: string
 ) {
+  const dateTimeStamp =
+    maybeDateTimeStamp === undefined ? nowDateTime() : maybeDateTimeStamp;
   return {
     accountInterventionStatus: sinon.fake.returns({
       data: {
-        email: email,
-        passwordResetRequired: passwordResetRequired,
-        blocked: blocked,
-        temporarilySuspended: temporarilySuspended,
+        email: "joe.bloggs@test.com",
+        passwordResetRequired: flags.passwordResetRequired,
+        blocked: flags.blocked,
+        temporarilySuspended: flags.temporarilySuspended,
+        appliedAt: dateTimeStamp,
       },
     }),
   } as unknown as AccountInterventionsInterface;

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -6,7 +6,10 @@ import { sinon } from "../../utils/test-utils";
 import { expect } from "chai";
 import { accountInterventionsMiddleware } from "../../../src/middleware/account-interventions-middleware";
 import { AccountInterventionsInterface } from "../../../src/components/account-intervention/types";
-import { AccountInterventionsFlags } from "../../helpers/account-interventions-helpers";
+import {
+  accountInterventionsFakeHelper,
+  AccountInterventionsFlags,
+} from "../../helpers/account-interventions-helpers";
 
 describe("accountInterventionsMiddleware", () => {
   let req: Partial<Request>;
@@ -44,7 +47,7 @@ describe("accountInterventionsMiddleware", () => {
     });
 
     it("should call next()", async () => {
-      const fakeAccountInterventionService = fakeAccountInterventionsService({
+      const fakeAccountInterventionService = accountInterventionsFakeHelper({
         passwordResetRequired: false,
         blocked: false,
         temporarilySuspended: false,
@@ -64,7 +67,7 @@ describe("accountInterventionsMiddleware", () => {
       let noAccountInterventionsService: AccountInterventionsInterface;
 
       before(() => {
-        noAccountInterventionsService = fakeAccountInterventionsService({
+        noAccountInterventionsService = accountInterventionsFakeHelper({
           passwordResetRequired: false,
           blocked: false,
           temporarilySuspended: false,
@@ -81,7 +84,7 @@ describe("accountInterventionsMiddleware", () => {
       let accountInterventionsWithBlockedTrue: AccountInterventionsInterface;
 
       before(() => {
-        accountInterventionsWithBlockedTrue = fakeAccountInterventionsService({
+        accountInterventionsWithBlockedTrue = accountInterventionsFakeHelper({
           passwordResetRequired: true,
           blocked: true,
           temporarilySuspended: true,
@@ -101,7 +104,7 @@ describe("accountInterventionsMiddleware", () => {
 
       before(() => {
         accountInterventionsWithPasswordResetTrue =
-          fakeAccountInterventionsService({
+          accountInterventionsFakeHelper({
             passwordResetRequired: true,
             blocked: false,
             temporarilySuspended: true,
@@ -148,7 +151,7 @@ describe("accountInterventionsMiddleware", () => {
 
       before(() => {
         accountInterventionsWithTemporarilySuspendedTrue =
-          fakeAccountInterventionsService({
+          accountInterventionsFakeHelper({
             passwordResetRequired: false,
             blocked: false,
             temporarilySuspended: true,
@@ -192,20 +195,5 @@ describe("accountInterventionsMiddleware", () => {
       handlePasswordResetStatus,
       accountInterventionService
     )(req as Request, res as Response, next as NextFunction);
-  };
-
-  const fakeAccountInterventionsService = (
-    flags: AccountInterventionsFlags
-  ) => {
-    return {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: flags.passwordResetRequired,
-          blocked: flags.blocked,
-          temporarilySuspended: flags.temporarilySuspended,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
   };
 });

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -14,7 +14,6 @@ describe("accountInterventionsMiddleware", () => {
   let next: NextFunction;
 
   beforeEach(() => {
-    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
     req = mockRequest({
       session: {
         user: {
@@ -39,131 +38,148 @@ describe("accountInterventionsMiddleware", () => {
     delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
   });
 
-  it("should call next() when no account intervention API response options are true and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService = fakeAccountInterventionsService({
-      passwordResetRequired: false,
-      blocked: false,
-      temporarilySuspended: false,
+  describe("when supportAccountInterventions() returns false", function () {
+    beforeEach(() => {
+      process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "0";
     });
 
-    await callMiddleware(false, false, fakeAccountInterventionService);
-    expect(next).to.be.calledOnce;
+    it("should call next()", async () => {
+      const fakeAccountInterventionService = fakeAccountInterventionsService({
+        passwordResetRequired: false,
+        blocked: false,
+        temporarilySuspended: false,
+      });
+
+      await callMiddleware(false, false, fakeAccountInterventionService);
+      expect(next).to.be.calledOnce;
+    });
   });
 
-  it("should call next() when supportAccountInterventions() returns false", async () => {
-    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "0";
-    const fakeAccountInterventionService = fakeAccountInterventionsService({
-      passwordResetRequired: false,
-      blocked: false,
-      temporarilySuspended: false,
+  describe("when supportAccountInterventions() returns true", function () {
+    beforeEach(() => {
+      process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
     });
 
-    await callMiddleware(false, false, fakeAccountInterventionService);
-    expect(next).to.be.calledOnce;
-  });
+    describe("when there are no account interventions", function () {
+      let noAccountInterventionsService: AccountInterventionsInterface;
 
-  it("should redirect to getNextPathAndUpdateJourney with the journey being PASSWORD_RESET_INTERVENTION when passwordResetRequired === true in the response and supportAccountInterventions() returns true and handleResetPasswordStatus === true", async () => {
-    const fakeAccountInterventionService = fakeAccountInterventionsService({
-      passwordResetRequired: true,
-      blocked: false,
-      temporarilySuspended: false,
-    });
-
-    await callMiddleware(false, true, fakeAccountInterventionService);
-    expect(res.redirect).to.have.been.calledWith(
-      PATH_NAMES.PASSWORD_RESET_REQUIRED
-    );
-  });
-
-  it("should redirect to getNextPathAndUpdateJourney with the journey being PERMANENTLY_BLOCKED_INTERVENTION when blocked === true in the response and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService = fakeAccountInterventionsService({
-      passwordResetRequired: false,
-      blocked: true,
-      temporarilySuspended: false,
-    });
-
-    await callMiddleware(false, false, fakeAccountInterventionService);
-    expect(res.redirect).to.have.been.calledWith(
-      PATH_NAMES.UNAVAILABLE_PERMANENT
-    );
-  });
-
-  it("should redirect to getNextPathAndUpdateJourney with the journey being TEMPORARILY_BLOCKED_INTERVENTIONS when temporarilySuspended === true and handleSuspendedStatus === true", async () => {
-    const fakeAccountInterventionService = fakeAccountInterventionsService({
-      passwordResetRequired: false,
-      blocked: false,
-      temporarilySuspended: true,
-    });
-
-    await callMiddleware(true, false, fakeAccountInterventionService);
-    expect(res.redirect).to.have.been.calledWith(
-      PATH_NAMES.UNAVAILABLE_TEMPORARY
-    );
-  });
-
-  it("should not redirect to getNextPathAndUpdateJourney with the journey being RESET_PASSWORD_REQUIRED when resetPassword === true and handleResetPasswordStatus === false", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: true,
+      before(() => {
+        noAccountInterventionsService = fakeAccountInterventionsService({
+          passwordResetRequired: false,
           blocked: false,
           temporarilySuspended: false,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await callMiddleware(true, false, fakeAccountInterventionService);
+        });
 
-    expect(res.redirect).to.not.have.been.calledWith(
-      PATH_NAMES.PASSWORD_RESET_REQUIRED
-    );
-  });
-
-  it("should redirect to getNextPathAndUpdateJourney with the journey being RESET_PASSWORD_REQUIRED when passwordResetRequired === true, temporarilySuspended === true", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: true,
-          blocked: false,
-          temporarilySuspended: true,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await callMiddleware(true, true, fakeAccountInterventionService);
-    expect(res.redirect).to.have.been.calledWith(
-      PATH_NAMES.PASSWORD_RESET_REQUIRED
-    );
-  });
-
-  it("should not redirect to getNextPathAndUpdateJourney with the journey being UNAVAILABLE_TEMPORARY when passwordResetRequired === true and both password reset and suspension interventions are on", async () => {
-    const fakeAccountInterventionService: AccountInterventionsInterface = {
-      accountInterventionStatus: sinon.fake.returns({
-        data: {
-          email: "test@test.com",
-          passwordResetRequired: true,
-          blocked: false,
-          temporarilySuspended: true,
-        },
-      }),
-    } as unknown as AccountInterventionsInterface;
-    await callMiddleware(true, false, fakeAccountInterventionService);
-    expect(res.redirect).to.not.have.been.calledWith(
-      PATH_NAMES.UNAVAILABLE_TEMPORARY
-    );
-  });
-
-  it("should not redirect to UNAVAILABLE_TEMPORARY when temporarilySuspended === true in the response and supportAccountInterventions() returns true", async () => {
-    const fakeAccountInterventionService = fakeAccountInterventionsService({
-      passwordResetRequired: false,
-      blocked: false,
-      temporarilySuspended: true,
+        it("should call next() when no account intervention API response options are true", async () => {
+          await callMiddleware(false, false, noAccountInterventionsService);
+          expect(next).to.be.calledOnce;
+        });
+      });
     });
-    await callMiddleware(false, false, fakeAccountInterventionService);
 
-    expect(res.redirect).to.not.have.been.calledWith(
-      PATH_NAMES.UNAVAILABLE_TEMPORARY
-    );
+    describe("when blocked is true", function () {
+      let accountInterventionsWithBlockedTrue: AccountInterventionsInterface;
+
+      before(() => {
+        accountInterventionsWithBlockedTrue = fakeAccountInterventionsService({
+          passwordResetRequired: true,
+          blocked: true,
+          temporarilySuspended: true,
+        });
+      });
+
+      it("should redirect to UNAVAILABLE PERMANENT", async () => {
+        await callMiddleware(false, false, accountInterventionsWithBlockedTrue);
+        expect(res.redirect).to.have.been.calledWith(
+          PATH_NAMES.UNAVAILABLE_PERMANENT
+        );
+      });
+    });
+
+    describe("when passwordResetRequired and temporarilySuspended is true", function () {
+      let accountInterventionsWithPasswordResetTrue: AccountInterventionsInterface;
+
+      before(() => {
+        accountInterventionsWithPasswordResetTrue =
+          fakeAccountInterventionsService({
+            passwordResetRequired: true,
+            blocked: false,
+            temporarilySuspended: true,
+          });
+      });
+
+      it("should redirect to PASSWORD_RESET_REQUIRED when handlePasswordResetStatus is true", async () => {
+        await callMiddleware(
+          false,
+          true,
+          accountInterventionsWithPasswordResetTrue
+        );
+        expect(res.redirect).to.have.been.calledWith(
+          PATH_NAMES.PASSWORD_RESET_REQUIRED
+        );
+      });
+
+      it("should call next when handlePasswordResetStatus is false", async () => {
+        await callMiddleware(
+          false,
+          false,
+          accountInterventionsWithPasswordResetTrue
+        );
+        expect(res.redirect).to.not.have.been.calledWith(
+          PATH_NAMES.PASSWORD_RESET_REQUIRED
+        );
+        expect(next).to.be.calledOnce;
+      });
+
+      it("should redirect to PASSWORD_RESET_REQUIRED when handlePasswordResetStatus AND handleSuspendedStatus are both true", async () => {
+        await callMiddleware(
+          true,
+          true,
+          accountInterventionsWithPasswordResetTrue
+        );
+        expect(res.redirect).to.have.been.calledWith(
+          PATH_NAMES.PASSWORD_RESET_REQUIRED
+        );
+      });
+    });
+
+    describe("when temporarilySuspended is true", function () {
+      let accountInterventionsWithTemporarilySuspendedTrue: AccountInterventionsInterface;
+
+      before(() => {
+        accountInterventionsWithTemporarilySuspendedTrue =
+          fakeAccountInterventionsService({
+            passwordResetRequired: false,
+            blocked: false,
+            temporarilySuspended: true,
+          });
+      });
+
+      it("should redirect to UNAVAILABLE_TEMPORARY when handleSuspendedStatus is true", async () => {
+        await callMiddleware(
+          true,
+          false,
+          accountInterventionsWithTemporarilySuspendedTrue
+        );
+        expect(res.redirect).to.have.been.calledWith(
+          PATH_NAMES.UNAVAILABLE_TEMPORARY
+        );
+      });
+
+      it("should not redirect to UNAVAILABLE_TEMPORARY when handleSuspendedStatus is false", async () => {
+        await callMiddleware(
+          false,
+          false,
+          accountInterventionsWithTemporarilySuspendedTrue
+        );
+
+        expect(res.redirect).to.not.have.been.calledWith(
+          PATH_NAMES.UNAVAILABLE_TEMPORARY
+        );
+
+        expect(next).to.have.been.calledOnce;
+      });
+    });
   });
 
   const callMiddleware = (


### PR DESCRIPTION
This fixes a problem whereby when someone resets their password, we redirect them to /auth-code and immediately call the interventions middleware again, at which point we will prompt them to reset their password again, since this does not give enough time for the account interventions service to be updated.

Instead here, we:
* set the timestamp of the time when a user reset their password on the session
* read from this value in the middleware when we have the `resetPassword` intervention set. If a) there is a resetPasswordTime in the session, and b) it is later than the `appliedAt` time on the intervention, we ignore the intervention and continue the journey.

This also contains some refactoring commits to make tests easier to read.

Note that this alone will not be enough to ensure that a user who has reset their password can continue on with their journey outside of auth: we will also need to pass this information back to orchestration who will need to implement similar logic on their side. This will be handled in a [separate ticket](https://govukverify.atlassian.net/browse/AUT-2553).

## How to review

1. Code review
2. Set yourself up in build with a `resetPasswordRequired` and `suspended` intervention. Run this locally against build's backend, and perform a sign in journey. Once you've gone through password reset, you should not be prompted to password reset again, and should instead go through to the next stage of the journey (it is likely that you'll see a failure after the /auth-code stage because of how the local setup works). Compare this with the behaviour on `main`.
3. Note that when you reset your password in build, the timestamp at which you reset your password should always be later than the timestamp the intervention is applied at, since we [hardcode this in the stub](https://github.com/govuk-one-login/authentication-api/blob/main/interventions-api-stub/src/main/java/uk/gov/di/authentication/interventions/api/stub/entity/InterventionsApiStubResponse.java#L61) to a timestamp that equates to `Mon Oct 09 2023 16:30:05`. If we wanted at some point we could add these timestamps to the stub database to simulate alternative behaviour.


