### PR TITLE
Adding redis daily Automated backup

### DIFF
--- a/ci/terraform/redis.tf
+++ b/ci/terraform/redis.tf
@@ -33,7 +33,8 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
   port                        = local.redis_port_number
   maintenance_window          = "sun:22:00-sun:23:00"
   notification_topic_arn      = data.aws_sns_topic.slack_events.arn
-
+  snapshot_retention_limit    = 5
+  snapshot_window             = "00:00-04:00"
   multi_az_enabled = true
 
   at_rest_encryption_enabled = true

--- a/ci/terraform/redis.tf
+++ b/ci/terraform/redis.tf
@@ -35,7 +35,7 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
   notification_topic_arn      = data.aws_sns_topic.slack_events.arn
   snapshot_retention_limit    = 5
   snapshot_window             = "00:00-04:00"
-  multi_az_enabled = true
+  multi_az_enabled            = true
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true


### PR DESCRIPTION
## What

AUT-2551 -Enabling Auto backup of redis Cluster  

## How to review
This can  be review on this branch , try to deploy to Authdev1  ( frontend ), it must show below  high lighted changes 

  **# aws_elasticache_replication_group.frontend_sessions_store will be  `updated in-place`**
  ~ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
        id                          = "authdev1-frontend-cache"
```
     ~ snapshot_retention_limit    = 0 -> 5
      ~ snapshot_window             = "04:00-05:00" -> "00:00-04:00"
```



