### PR TITLE
AUT-2553: Pass PW Reset Timestamp to Orch via Auth Code

### DIFF
--- a/src/components/auth-code/auth-code-service.ts
+++ b/src/components/auth-code/auth-code-service.ts
@@ -43,6 +43,7 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
         "redirect-uri": clientSession.redirectUri,
         "rp-sector-uri": clientSession.rpSectorHost,
         "is-new-account": userSession?.isAccountCreationJourney ?? false,
+        "password-reset-time": userSession?.passwordResetTime,
       };
       response = await axios.client.post(
         API_ENDPOINTS.ORCH_AUTH_CODE,

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -16,6 +16,7 @@ describe("authentication auth code service", () => {
   const redirectUriSentToAuth = "/redirect-uri";
   const rpSectorHostSentToAuth = "https://rp.redirect.uri";
   const isAccountCreationJourneyUserSession = true;
+  const passwordResetTime = 1710335967;
   const redirectUriReturnedFromResponse =
     "/redirect-here?with-some-params=added-by-the-endpoint";
   const apiBaseUrl = "/base-url";
@@ -66,6 +67,7 @@ describe("authentication auth code service", () => {
 
       const userSessionClient = {
         isAccountCreationJourney: isAccountCreationJourneyUserSession,
+        passwordResetTime: passwordResetTime,
       };
 
       const result = await service.getAuthCode(
@@ -83,6 +85,7 @@ describe("authentication auth code service", () => {
         "redirect-uri": redirectUriSentToAuth,
         "rp-sector-uri": rpSectorHostSentToAuth,
         "is-new-account": isAccountCreationJourneyUserSession,
+        "password-reset-time": passwordResetTime,
       };
 
       expect(

--- a/src/components/prove-identity/tests/prove-identity-controller.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-controller.test.ts
@@ -81,6 +81,7 @@ describe("prove identity controller", () => {
     const redirectUriSentToAuth = "/redirect-uri";
     const rpSectorHostSentToAuth = "https://rp.redirect.uri";
     const isAccountCreationJourneyUserSession = true;
+    const passwordResetTimeTestVar = 1710335967;
     const redirectUriReturnedFromResponse =
       "/redirect-here?with-some-params=added-by-the-endpoint";
     const frontendBaseUrl = "/frontend-base-url";
@@ -129,6 +130,7 @@ describe("prove identity controller", () => {
 
       req.session.user = {
         isAccountCreationJourney: isAccountCreationJourneyUserSession,
+        passwordResetTime: passwordResetTimeTestVar,
       };
 
       await controller(req as Request, res as Response);
@@ -139,6 +141,7 @@ describe("prove identity controller", () => {
         "redirect-uri": redirectUriSentToAuth,
         "rp-sector-uri": rpSectorHostSentToAuth,
         "is-new-account": isAccountCreationJourneyUserSession,
+        "password-reset-time": passwordResetTimeTestVar,
       };
 
       expect(


### PR DESCRIPTION
## What

Created the password reset time parameter in the auth code service in to be passed to the backend with the argument being stored in the access token store and then sent in the user info response to the backend. This argument is to be used by orchestration to compare the time a password has been successfully reset with the time a password reset account intervention status has been applied to an account.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review

-->

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

<!-- Delete this section if the PR does not change the UI. -->

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Change in backend to accept this as a parameter: https://github.com/govuk-one-login/authentication-api/pull/4104

This PR not to be merged until that one merged first.

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
