### PR TITLE
BAU: Update defaults in `startup.sh`

### DIFF
--- a/shutdown.sh
+++ b/shutdown.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 echo "Stopping frontend services..."
 

--- a/startup.sh
+++ b/startup.sh
@@ -3,10 +3,6 @@ set -eu
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-ACTION_CLEAN=0
-ACTION_LOCAL=0
-ACTION_DEPS_ONLY=0
-
 function usage() {
   local error_message="${1}"
   echo
@@ -37,7 +33,7 @@ while getopts ":clx" opt; do
   esac
 done
 
-if [ "${ACTION_CLEAN}" == "1" ]; then
+if [ "${ACTION_CLEAN:-0}" == "1" ]; then
   echo "Cleaning dist and node_modules..."
   rm -rf dist
   rm -rf node_modules
@@ -48,22 +44,23 @@ fi
 
 test -f .env || usage "Missing .env file"
 
-# shellcheck source=/dev/null
+# set shellcheck source to .env.build, as this is a 'complete' example
+# shellcheck source=.env.build
 set -o allexport && source .env && set +o allexport
 
 # shellcheck source=./scripts/export_aws_creds.sh
 source "${DIR}/scripts/export_aws_creds.sh"
 
-if [ "${ACTION_LOCAL}" == "1" ]; then
+if [ "${ACTION_LOCAL:-0}" == "1" ]; then
   echo "Starting frontend local service..."
   docker compose -f docker-compose.yml up --build -d --wait
-  echo "No-MFA stub listening on http://localhost:${DOCKER_STUB_NO_MFA_PORT}"
-  echo "Default stub listening on http://localhost:${DOCKER_STUB_DEFAULT_PORT}"
+  echo "No-MFA stub listening on http://localhost:${DOCKER_STUB_NO_MFA_PORT:-5000}"
+  echo "Default stub listening on http://localhost:${DOCKER_STUB_DEFAULT_PORT:-2000}"
   echo "Redis listening on redis://localhost:${DOCKER_REDIS_PORT:-6379}"
   export REDIS_PORT=${DOCKER_REDIS_PORT:-6379}
   export REDIS_HOST=localhost
-  if [ "${ACTION_DEPS_ONLY}" == "0" ]; then
-    export PORT="${DOCKER_FRONTEND_PORT}"
+  if [ "${ACTION_DEPS_ONLY:-0}" == "0" ]; then
+    export PORT="${DOCKER_FRONTEND_PORT:-3000}"
     yarn install && yarn test:dev-evironment-variables && yarn copy-assets && yarn dev
   else
     docker compose -f docker-compose.yml logs -f
@@ -71,9 +68,9 @@ if [ "${ACTION_LOCAL}" == "1" ]; then
 else
   echo "Starting frontend service..."
   docker compose -f docker-compose.yml -f docker-compose.frontend.yml up -d --wait --build
-  echo "No-MFA stub listening on http://localhost:${DOCKER_STUB_NO_MFA_PORT}"
-  echo "Default stub listening on http://localhost:${DOCKER_STUB_DEFAULT_PORT}"
-  echo "Redis listening on redis://localhost:${DOCKER_REDIS_PORT}"
-  echo "Frontend listening on http://localhost:${DOCKER_FRONTEND_PORT}"
-  echo "Frontend nodemon listening on localhost:${DOCKER_FRONTEND_NODEMON_PORT}"
+  echo "No-MFA stub listening on http://localhost:${DOCKER_STUB_NO_MFA_PORT:-5000}"
+  echo "Default stub listening on http://localhost:${DOCKER_STUB_DEFAULT_PORT:-2000}"
+  echo "Redis listening on redis://localhost:${DOCKER_REDIS_PORT:-6379}"
+  echo "Frontend listening on http://localhost:${DOCKER_FRONTEND_PORT:-3000}"
+  echo "Frontend nodemon listening on localhost:${DOCKER_FRONTEND_NODEMON_PORT:-9230}"
 fi


### PR DESCRIPTION
## What

It was pointed out that the `*_PORT` variables were missing defaults, meaning that the script blew up ungracefully if they were not set.
As they're not likely going to be deliberately changed by many users, we can set defaults within the script without it being '_unexpected behaviour_'.

Both `s{tartup,hutdown}.sh` scripts now have `set -euo pipefail` set, to better handle errors / missing values.

I've updated the `ACTION_*` variables to not have the default values pre-set at the top. Instead, they're set with defaults when the variable is accessed (`${VAR:-default}`). Happy to drop this if people think this'd be confusing. For me it's nice to have the defaults in the `if` statements, so 'default' behaviour can be more easily visualised (bash intellisense isn't a thing!)

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. with a valid `.env` file (with `*_PORT` values defined), run `./startup.sh -l`. Observe that no errors are thrown.
1. change one of the `*_PORT` values in `.env` to a different value (ie. frontend => `3001`), run `./startup.sh -l`. Observe that the service is deployed and listening on that new port.
1. remove the `*_PORT` values from `.env`, observe that no errors are thrown still, and the services are deployed to the default ports.
