### PR TITLE
BAU: Replace Zendesk with new Contact Centre env vars

### DIFF
--- a/.env.authdev1
+++ b/.env.authdev1
@@ -30,12 +30,16 @@ SESSION_EXPIRY=60000
 SESSION_SECRET=123456
 
 #
-# Zendesk configuration for Support form submission - Ask for values
+# SmartAgent configuration for Support form submission - Ask for values
 #
-ZENDESK_USERNAME=
-ZENDESK_API_TOKEN=
-ZENDESK_GROUP_ID_PUBLIC=
-ZENDESK_API_URL=
+SMARTAGENT_API_KEY=
+SMARTAGENT_API_URL=
+SMARTAGENT_WEBFORM_ID=
+
+#
+# Triage page URL
+#
+URL_FOR_SUPPORT_LINKS="/contact-us"
 
 #
 # Orch to Auth configuration

--- a/.env.build
+++ b/.env.build
@@ -30,12 +30,17 @@ SESSION_EXPIRY=60000
 SESSION_SECRET=123456
 
 #
-# Zendesk configuration for Support form submission - Ask for values
+# SmartAgent configuration for Support form submission - Ask for values
 #
-ZENDESK_USERNAME=
-ZENDESK_API_TOKEN=
-ZENDESK_GROUP_ID_PUBLIC=
-ZENDESK_API_URL=
+SMARTAGENT_API_KEY=
+SMARTAGENT_API_URL=
+SMARTAGENT_WEBFORM_ID=
+
+#
+# Triage page URL
+#
+URL_FOR_SUPPORT_LINKS="/contact-us"
+
 
 #
 # Orch to Auth configuration

--- a/dev-check-environment.js
+++ b/dev-check-environment.js
@@ -11,10 +11,10 @@ describe("environment", function () {
   const requiredEnvVars = [
     "TEST_CLIENT_ID",
     "API_KEY",
-    "ZENDESK_USERNAME",
-    "ZENDESK_API_TOKEN",
-    "ZENDESK_GROUP_ID_PUBLIC",
-    "ZENDESK_API_URL",
+    "SMARTAGENT_API_KEY",
+    "SMARTAGENT_API_URL",
+    "SMARTAGENT_WEBFORM_ID",
+    "URL_FOR_SUPPORT_LINKS",
   ];
 
   requiredEnvVars.forEach((envVar) => {


### PR DESCRIPTION
## What

Having pulled the latest `main` I've found that frontend isn't running locally. In trying to understand what's happened, I've found that one issue is tests that require environment variables relating to Zendesk. Because all code relating to Zendesk was [removed in January](https://github.com/govuk-one-login/authentication-frontend/pull/1316), I've replaced these with to those that relate to SmartAgent and included these in `.env.authdev1`. Doing so has fixed the ability to run frontend locally. 

## How to review

1. Code Review
1. Follow the setup instructions in `README.md` (ensuring you have the all the `requiredEnvVars` stipulated in `dev-check-environment.js`)
1. Run the frontend with `./startup.sh -l`

## Related PRs

The PR that removed Zendesk was https://github.com/govuk-one-login/authentication-frontend/pull/1316
