### PR TITLE
AUT-2549: Bug fix for looping IPV page in AIS journey

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -589,6 +589,10 @@ const authStateMachine = createMachine(
               target: [PATH_NAMES.SHARE_INFO],
               cond: "isConsentRequired",
             },
+            {
+              target: [PATH_NAMES.PROVE_IDENTITY],
+              cond: "isIdentityRequired",
+            },
             { target: [PATH_NAMES.AUTH_CODE] },
           ],
         },


### PR DESCRIPTION
## What

Added the PROVE_IDENTITY path as an option from PASSWORD_CREATED given that isIdentityRequired is true. This is to resolve the IPV + AIS password reset required and suspended journey looping on the “You have already proved your identity” page.

This change needs to be merged and tested in staging as currently there is no way to test this locally.

## How to review

Changes need to be tested in the staging environment with prod promotion paused in the pipeline.

