### PR TITLE
AUT-2549: Added ipv callback journey from auth code

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -589,6 +589,10 @@ const authStateMachine = createMachine(
               target: [PATH_NAMES.SHARE_INFO],
               cond: "isConsentRequired",
             },
+            {
+              target: [PATH_NAMES.PROVE_IDENTITY],
+              cond: "isIdentityRequired",
+            },
             { target: [PATH_NAMES.AUTH_CODE] },
           ],
         },

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -143,6 +143,7 @@ export function resetPasswordPost(
         req.path,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
+          isIdentityRequired: req.session.user.isIdentityRequired,
           isConsentRequired: req.session.user.isConsentRequired,
           requiresTwoFactorAuth: !support2FABeforePasswordReset(),
           isLatestTermsAndConditionsAccepted:


### PR DESCRIPTION
## What

Added the PROVE_IDENTITY path as an option from PASSWORD_CREATED given that isIdentityRequired is true. This is to resolve the IPV + AIS password reset required and suspended journey looping on the “You have already proved your identity” page.

This change needs to be merged and tested in staging as currently there is no way to test this locally.

## How to review

Changes need to be tested in the staging environment with prod promotion paused in the pipeline.
