### PR TITLE
AUT-2612: Reorder validation messages on create password screen

### DIFF
--- a/src/components/create-password/create-password-validation.ts
+++ b/src/components/create-password/create-password-validation.ts
@@ -5,24 +5,6 @@ import { ValidationChainFunc } from "../../types";
 
 export function validateCreatePasswordRequest(): ValidationChainFunc {
   return [
-    body("confirm-password")
-      .notEmpty()
-      .withMessage((value, { req }) => {
-        return req.t(
-          "pages.createPassword.confirmPassword.validationError.required",
-          { value }
-        );
-      })
-      .custom((value, { req }) => {
-        if (value !== req.body["password"]) {
-          throw new Error(
-            req.t(
-              "pages.createPassword.confirmPassword.validationError.matches"
-            )
-          );
-        }
-        return true;
-      }),
     body("password")
       .notEmpty()
       .withMessage((value, { req }) => {
@@ -53,6 +35,24 @@ export function validateCreatePasswordRequest(): ValidationChainFunc {
       })
       .custom((value, { req }) => {
         if (value !== req.body["confirm-password"]) {
+          throw new Error(
+            req.t(
+              "pages.createPassword.confirmPassword.validationError.matches"
+            )
+          );
+        }
+        return true;
+      }),
+    body("confirm-password")
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.createPassword.confirmPassword.validationError.required",
+          { value }
+        );
+      })
+      .custom((value, { req }) => {
+        if (value !== req.body["password"]) {
           throw new Error(
             req.t(
               "pages.createPassword.confirmPassword.validationError.matches"


### PR DESCRIPTION
## What

UCD identified a bug today relating to the order of validation messages when a user leaves both password fields blank during an account creation journey. The problem is that "Re-type your password" appears before "Enter your password" (whereas the fields are in the opposite order). This PR changes the order of these messages. 

I have also checked that the page retains existing validation behaviour, including:
- [x] failures relating to using a common password, like "password1"
- [x] leaving a single field blank
- [x] using a password that doesn't include numbers
- [x] allows submission when a good password is used to populate both fields

## How to review

1. Start frontend running locally against this branch
2. Begin an account creation journey
3. On the "Create your password", leave both fields blank and submit the form
4. Confirm that the error message order matches what's in the screenshots below
5. Try different validation error permutations to confirm all is working as expected
6. Code review

### Screenshots

<details>
<summary>English</summary>

![Error-Create-your-password-GOV-UK-One-Login](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/a246ec41-179d-41cf-a5d3-20e3656ca5bb)

</details>

<details>
<summary>Welsh</summary>

![Gwall-Creu-eich-cyfrinair-GOV-UK-One-Login](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/e10d17e8-87de-403d-87a1-fbef1f6cd544)

</details>


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

<!-- Delete this section if the PR does not change the UI. -->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
