### PR TITLE
AUT-2623: Add reprove identity to account interventions response

### DIFF
--- a/src/components/account-intervention/types.ts
+++ b/src/components/account-intervention/types.ts
@@ -16,4 +16,5 @@ export interface AccountInterventionStatus extends DefaultApiResponse {
   blocked: boolean;
   temporarilySuspended: boolean;
   appliedAt: string;
+  reproveIdentity: boolean;
 }

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-controller.test.ts
@@ -97,6 +97,7 @@ describe("check your email change security codes controller", () => {
         passwordResetRequired: true,
         blocked: false,
         temporarilySuspended: true,
+        reproveIdentity: false
       });
 
       await checkYourEmailSecurityCodesPost(
@@ -119,6 +120,7 @@ describe("check your email change security codes controller", () => {
         temporarilySuspended: true,
         blocked: false,
         passwordResetRequired: false,
+        reproveIdentity: false
       });
 
       await checkYourEmailSecurityCodesPost(
@@ -139,6 +141,7 @@ describe("check your email change security codes controller", () => {
         blocked: true,
         passwordResetRequired: false,
         temporarilySuspended: false,
+        reproveIdentity: false
       });
 
       await checkYourEmailSecurityCodesPost(

--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -75,6 +75,7 @@ describe("Verify code controller tests", () => {
         blocked: true,
         passwordResetRequired: false,
         temporarilySuspended: false,
+        reproveIdentity: false,
       });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
@@ -94,6 +95,7 @@ describe("Verify code controller tests", () => {
         temporarilySuspended: true,
         blocked: false,
         passwordResetRequired: false,
+        reproveIdentity: false,
       });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
@@ -113,6 +115,7 @@ describe("Verify code controller tests", () => {
         passwordResetRequired: true,
         temporarilySuspended: true,
         blocked: false,
+        reproveIdentity: false,
       });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType:
@@ -175,6 +178,7 @@ describe("Verify code controller tests", () => {
         temporarilySuspended: true,
         blocked: false,
         passwordResetRequired: false,
+        reproveIdentity: false,
       });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
@@ -194,6 +198,7 @@ describe("Verify code controller tests", () => {
         blocked: true,
         passwordResetRequired: false,
         temporarilySuspended: false,
+        reproveIdentity: false,
       });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
@@ -213,6 +218,7 @@ describe("Verify code controller tests", () => {
         passwordResetRequired: true,
         temporarilySuspended: true,
         blocked: false,
+        reproveIdentity: false,
       });
       await verifyCodePost(verifyCodeService, accountInterventionService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -425,6 +425,7 @@ describe("enter password controller", () => {
           passwordResetRequired: testCase.interventions.passwordResetRequired,
           blocked: testCase.interventions.blocked,
           temporarilySuspended: testCase.interventions.temporarilySuspended,
+          reproveIdentity: false,
         });
         res.locals.sessionId = "123456-djjad";
         res.locals.clientSessionId = "00000-djjad";

--- a/src/components/prove-identity/tests/prove-identity-integration.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-integration.test.ts
@@ -70,6 +70,7 @@ describe("Integration::prove identity", () => {
       blocked: false,
       passwordResetRequired: false,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     const redirectUri = "https://some-redirect.com";
@@ -92,6 +93,7 @@ describe("Integration::prove identity", () => {
       blocked: false,
       passwordResetRequired: true,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     const response = await makeRequestToProveIdentityEndpoint();
@@ -105,6 +107,7 @@ describe("Integration::prove identity", () => {
       blocked: true,
       passwordResetRequired: false,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     const response = await makeRequestToProveIdentityEndpoint();

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
@@ -115,6 +115,7 @@ describe("reset password 2fa auth app controller", () => {
         temporarilySuspended: true,
         blocked: false,
         passwordResetRequired: false,
+        reproveIdentity: false,
       });
       req.session.user = {
         email: "joe.bloggs@test.com",
@@ -134,6 +135,7 @@ describe("reset password 2fa auth app controller", () => {
         blocked: true,
         temporarilySuspended: false,
         passwordResetRequired: false,
+        reproveIdentity: false,
       });
       req.session.user = {
         email: "joe.bloggs@test.com",

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -74,6 +74,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       blocked: true,
       passwordResetRequired: false,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     request(app)
@@ -89,6 +90,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       blocked: false,
       passwordResetRequired: false,
       temporarilySuspended: true,
+      reproveIdentity: false,
     });
 
     request(app)
@@ -104,6 +106,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       blocked: false,
       passwordResetRequired: true,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     request(app).get(ENDPOINT).expect(200, done);

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -74,6 +74,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       blocked: true,
       passwordResetRequired: false,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     request(app)
@@ -89,6 +90,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       blocked: false,
       passwordResetRequired: false,
       temporarilySuspended: true,
+      reproveIdentity: false,
     });
 
     request(app)
@@ -104,6 +106,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       blocked: false,
       passwordResetRequired: true,
       temporarilySuspended: false,
+      reproveIdentity: false,
     });
 
     request(app).get(ENDPOINT).expect(200, done);

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -7,6 +7,7 @@ export type AccountInterventionsFlags = {
   blocked: boolean;
   passwordResetRequired: boolean;
   temporarilySuspended: boolean;
+  reproveIdentity: boolean;
 };
 
 export const setupAccountInterventionsResponse = (
@@ -25,6 +26,7 @@ export const setupAccountInterventionsResponse = (
       blocked: flags.blocked,
       temporarilySuspended: flags.temporarilySuspended,
       appliedAt: dateTimeStamp,
+      reproveIdentity: flags.reproveIdentity
     });
 };
 
@@ -37,6 +39,7 @@ export const noInterventions: AccountInterventionsFlags = {
   blocked: false,
   passwordResetRequired: false,
   temporarilySuspended: false,
+  reproveIdentity: false
 };
 
 export function accountInterventionsFakeHelper(
@@ -53,6 +56,7 @@ export function accountInterventionsFakeHelper(
         blocked: flags.blocked,
         temporarilySuspended: flags.temporarilySuspended,
         appliedAt: dateTimeStamp,
+        reproveIdentity: flags.reproveIdentity
       },
     }),
   } as unknown as AccountInterventionsInterface;

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -48,6 +48,7 @@ describe("accountInterventionsMiddleware", () => {
         passwordResetRequired: false,
         blocked: false,
         temporarilySuspended: false,
+        reproveIdentity: false,
       });
 
       await callMiddleware(false, false, fakeAccountInterventionService);
@@ -68,6 +69,7 @@ describe("accountInterventionsMiddleware", () => {
           passwordResetRequired: false,
           blocked: false,
           temporarilySuspended: false,
+          reproveIdentity: false,
         });
 
         it("should call next() when no account intervention API response options are true", async () => {
@@ -85,6 +87,7 @@ describe("accountInterventionsMiddleware", () => {
           passwordResetRequired: true,
           blocked: true,
           temporarilySuspended: true,
+          reproveIdentity: false,
         });
       });
 
@@ -105,6 +108,7 @@ describe("accountInterventionsMiddleware", () => {
             passwordResetRequired: true,
             blocked: false,
             temporarilySuspended: true,
+            reproveIdentity: false,
           });
       });
 
@@ -154,6 +158,7 @@ describe("accountInterventionsMiddleware", () => {
               passwordResetRequired: true,
               blocked: false,
               temporarilySuspended: true,
+              reproveIdentity: false,
             },
             nowUnixTime.toString()
           );
@@ -180,6 +185,7 @@ describe("accountInterventionsMiddleware", () => {
               passwordResetRequired: true,
               blocked: false,
               temporarilySuspended: true,
+              reproveIdentity: false,
             },
             beforeNow.toString()
           );
@@ -205,6 +211,7 @@ describe("accountInterventionsMiddleware", () => {
             passwordResetRequired: false,
             blocked: false,
             temporarilySuspended: true,
+            reproveIdentity: false,
           });
       });
 


### PR DESCRIPTION
This is a preparatory commit to allow us to implement logic to allow users who are suspended with reprove identity to reset their passwords (and not hit a suspended page as they currently do). The field is unused for the moment.

## How to review

1. Code Review

## Related PRs

