### PR TITLE
Aut 2623/allow actions for reprove identity

### DIFF
--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -130,6 +130,26 @@ describe("Verify code controller tests", () => {
       expect(res.redirect).to.have.calledWith("/password-reset-required");
     });
 
+    it("if account has reprove identity and suspended status, redirects to /get-security-codes", async () => {
+      const accountInterventionService = accountInterventionsFakeHelper({
+        passwordResetRequired: false,
+        temporarilySuspended: true,
+        blocked: false,
+        reproveIdentity: true,
+      });
+      await verifyCodePost(verifyCodeService, accountInterventionService, {
+        notificationType:
+          NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+        template: "check-your-email/index.njk",
+        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
+        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
+      })(req as Request, res as Response);
+
+      expect(accountInterventionService.accountInterventionStatus).to.have.been
+        .called;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.GET_SECURITY_CODES);
+    });
+
     it("if account has no AIS status, redirects to /get-security-codes", async () => {
       const accountInterventionService =
         accountInterventionsFakeHelper(noInterventions);

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -17,10 +17,8 @@ import {
   support2FABeforePasswordReset,
   supportAccountInterventions,
 } from "../../../config";
-import {
-  AccountInterventionsInterface,
-  AccountInterventionStatus,
-} from "../../account-intervention/types";
+import { AccountInterventionsInterface } from "../../account-intervention/types";
+import { isSuspendedWithoutUserActions } from "../../../utils/interventions";
 
 interface Config {
   notificationType: NOTIFICATION_TYPE;
@@ -146,14 +144,4 @@ export function verifyCodePost(
       )
     );
   };
-}
-
-function isSuspendedWithoutUserActions(
-  status: AccountInterventionStatus
-): boolean {
-  return (
-    status.temporarilySuspended &&
-    !status.reproveIdentity &&
-    !status.passwordResetRequired
-  );
 }

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -17,7 +17,10 @@ import {
   support2FABeforePasswordReset,
   supportAccountInterventions,
 } from "../../../config";
-import { AccountInterventionsInterface } from "../../account-intervention/types";
+import {
+  AccountInterventionsInterface,
+  AccountInterventionStatus,
+} from "../../account-intervention/types";
 
 interface Config {
   notificationType: NOTIFICATION_TYPE;
@@ -114,7 +117,9 @@ export function verifyCodePost(
           if (options.journeyType !== JOURNEY_TYPE.PASSWORD_RESET_MFA) {
             nextEvent = USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION;
           }
-        } else if (accountInterventionsResponse.data.temporarilySuspended) {
+        } else if (
+          isSuspendedWithoutUserActions(accountInterventionsResponse.data)
+        ) {
           nextEvent = USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION;
         }
       }
@@ -141,4 +146,14 @@ export function verifyCodePost(
       )
     );
   };
+}
+
+function isSuspendedWithoutUserActions(
+  status: AccountInterventionStatus
+): boolean {
+  return (
+    status.temporarilySuspended &&
+    !status.reproveIdentity &&
+    !status.passwordResetRequired
+  );
 }

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -4,8 +4,11 @@ import { USER_JOURNEY_EVENTS } from "../components/common/state-machine/state-ma
 import { accountInterventionService } from "../components/account-intervention/account-intervention-service";
 import { ExpressRouteFunc } from "../types";
 import { supportAccountInterventions } from "../config";
-import { AccountInterventionStatus } from "../components/account-intervention/types";
 import { logger } from "../utils/logger";
+import {
+  isSuspendedWithoutUserActions,
+  passwordHasBeenResetMoreRecentlyThanInterventionApplied,
+} from "../utils/interventions";
 
 export function accountInterventionsMiddleware(
   handleSuspendedStatus: boolean,
@@ -72,24 +75,4 @@ export function accountInterventionsMiddleware(
 
     return next();
   };
-}
-
-function isSuspendedWithoutUserActions(
-  status: AccountInterventionStatus
-): boolean {
-  return (
-    status.temporarilySuspended &&
-    !status.reproveIdentity &&
-    !status.passwordResetRequired
-  );
-}
-
-function passwordHasBeenResetMoreRecentlyThanInterventionApplied(
-  req: Request,
-  status: AccountInterventionStatus
-) {
-  return (
-    req.session.user.passwordResetTime !== undefined &&
-    req.session.user.passwordResetTime > parseInt(status.appliedAt)
-  );
 }

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -57,8 +57,7 @@ export function accountInterventionsMiddleware(
           );
         }
       } else if (
-        accountInterventionsResponse.data.temporarilySuspended &&
-        !accountInterventionsResponse.data.passwordResetRequired &&
+        isSuspendedWithoutUserActions(accountInterventionsResponse.data) &&
         handleSuspendedStatus
       ) {
         return res.redirect(
@@ -73,6 +72,16 @@ export function accountInterventionsMiddleware(
 
     return next();
   };
+}
+
+function isSuspendedWithoutUserActions(
+  status: AccountInterventionStatus
+): boolean {
+  return (
+    status.temporarilySuspended &&
+    !status.reproveIdentity &&
+    !status.passwordResetRequired
+  );
 }
 
 function passwordHasBeenResetMoreRecentlyThanInterventionApplied(

--- a/src/utils/interventions.ts
+++ b/src/utils/interventions.ts
@@ -1,0 +1,22 @@
+import { Request } from "express";
+import { AccountInterventionStatus } from "../components/account-intervention/types";
+
+export function isSuspendedWithoutUserActions(
+  status: AccountInterventionStatus
+): boolean {
+  return (
+    status.temporarilySuspended &&
+    !status.reproveIdentity &&
+    !status.passwordResetRequired
+  );
+}
+
+export function passwordHasBeenResetMoreRecentlyThanInterventionApplied(
+  req: Request,
+  status: AccountInterventionStatus
+) {
+  return (
+    req.session.user.passwordResetTime !== undefined &&
+    req.session.user.passwordResetTime > parseInt(status.appliedAt)
+  );
+}

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -211,7 +211,34 @@ describe("accountInterventionsMiddleware", () => {
           PATH_NAMES.UNAVAILABLE_TEMPORARY
         );
         expect(next).to.be.calledOnce;
-      } )
+      });
+    });
+
+    describe("when reproveIdentity and temporarilySuspended is true", () => {
+      let accountIntervetionsWithReproveIdentity: AccountInterventionsInterface;
+
+      before(() => {
+        accountIntervetionsWithReproveIdentity = accountInterventionsFakeHelper(
+          {
+            passwordResetRequired: false,
+            blocked: false,
+            temporarilySuspended: true,
+            reproveIdentity: true,
+          }
+        );
+      });
+
+      it("should not redirect to UNAVAILABLE_TEMPORARY when handleSuspended status is true and handlePasswordResetStatus is false", async () => {
+        await callMiddleware(
+          true,
+          false,
+          accountIntervetionsWithReproveIdentity
+        );
+        expect(res.redirect).to.not.have.been.calledWith(
+          PATH_NAMES.UNAVAILABLE_TEMPORARY
+        );
+        expect(next).to.be.calledOnce;
+      });
     });
 
     describe("when temporarilySuspended is true", function () {

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -200,6 +200,18 @@ describe("accountInterventionsMiddleware", () => {
         );
         expect(next).to.have.been.calledOnce;
       });
+
+      it("should not redirect to UNAVAILABLE_TEMPORARY when handleSuspended status is true and handlePasswordResetStatus is false", async () => {
+        await callMiddleware(
+          true,
+          false,
+          accountInterventionsWithPasswordResetTrue
+        );
+        expect(res.redirect).to.not.have.been.calledWith(
+          PATH_NAMES.UNAVAILABLE_TEMPORARY
+        );
+        expect(next).to.be.calledOnce;
+      } )
     });
 
     describe("when temporarilySuspended is true", function () {


### PR DESCRIPTION
<!-- Describe what you have changed and why -->

Have made changes that allow for a user to either reset their password or change their security codes if they have an AIS suspension status placed against their account while also requiring that they reprove identity. Now they are allowed to to reset their password or change their MFA method before being taken on to the reprove identity process where they will continue their journey.

## How to review

1. Code Review
2. Run the front end against build with reprove identity and suspension statuses against your account
3. Go through the normal (non-forced) password reset journey successfully
4. Go through the change MFA journey successfully
