### PR TITLE
ATO-449: use the correct state when returning to RP

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -29,6 +29,7 @@ import {
   supportReauthentication,
 } from "../../config";
 import { logger } from "../../utils/logger";
+import { Claims } from "./claims-config";
 
 function createConsentCookie(
   res: Response,
@@ -54,7 +55,7 @@ export function authorizeGet(
 
     const clientId = req.query.client_id as string;
     const responseType = req.query.response_type as string;
-    let claims;
+    let claims: Claims;
     try {
       validateQueryParams(clientId, responseType);
 
@@ -109,6 +110,7 @@ export function authorizeGet(
     req.session.client.isOneLoginService = claims.is_one_login_service;
     req.session.client.rpSectorHost = claims.rp_sector_host;
     req.session.client.rpRedirectUri = claims.rp_redirect_uri;
+    req.session.client.rpState = claims.rp_state;
 
     req.session.client.consentEnabled =
       startAuthResponse.data.user.consentRequired;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -31,6 +31,7 @@ export type Claims = {
   redirect_uri: string;
   rp_sector_host: string;
   rp_redirect_uri: string;
+  rp_state: string;
   reauthenticate?: string;
   claim?: string;
 };

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -9,7 +9,6 @@ import {
 import { proveIdentityCallbackService } from "./prove-identity-callback-service";
 import { IPV_ERROR_CODES, OIDC_ERRORS } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
-import { supportAuthOrchSplit } from "../../config";
 
 export function proveIdentityCallbackGet(
   service: ProveIdentityCallbackServiceInterface = proveIdentityCallbackService()
@@ -51,12 +50,10 @@ export function proveIdentityCallbackGet(
       );
     } else {
       redirectPath = createServiceRedirectErrorUrl(
-        supportAuthOrchSplit()
-          ? req.session.client.rpRedirectUri
-          : req.session.client.redirectUri,
+        req.session.client.rpRedirectUri,
         OIDC_ERRORS.ACCESS_DENIED,
         IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT,
-        req.session.client.state
+        req.session.client.rpState
       );
     }
 

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -32,10 +32,9 @@ describe("prove identity callback controller", () => {
       path: PATH_NAMES.PROVE_IDENTITY_CALLBACK,
       session: {
         client: {
-          redirectUri: "http://someservice.com/auth",
           rpRedirectUri: "http://rpservice.com/auth",
           clientName: "test service",
-          state: STATE,
+          rpState: STATE,
         },
         user: { email: "test@test.com" },
       },
@@ -66,7 +65,7 @@ describe("prove identity callback controller", () => {
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
     });
 
-    it("should render index when identity is being processed ", async () => {
+    it("should render index when identity is being processed", async () => {
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
         processIdentity: sinon.fake.returns({
           success: true,
@@ -87,30 +86,6 @@ describe("prove identity callback controller", () => {
     });
 
     it("should redirect back to service when identity processing has errored", async () => {
-      const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
-        processIdentity: sinon.fake.returns({
-          success: true,
-          data: {
-            status: IdentityProcessingStatus.ERROR,
-          },
-        }),
-      } as unknown as ProveIdentityCallbackServiceInterface;
-
-      await proveIdentityCallbackGet(fakeProveIdentityService)(
-        req as Request,
-        res as Response
-      );
-
-      expect(res.redirect).to.have.been.calledWith(
-        `http://someservice.com/auth?error=${
-          OIDC_ERRORS.ACCESS_DENIED
-        }&error_description=${encodeURIComponent(
-          IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
-        )}&state=${encodeURIComponent(STATE)}`
-      );
-    });
-
-    it("should redirect back to service when identity processing has errored and split is enabled", async () => {
       process.env.SUPPORT_AUTH_ORCH_SPLIT = "1";
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
         processIdentity: sinon.fake.returns({

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,4 +99,5 @@ export interface UserSessionClient {
   claim?: string[];
   rpSectorHost?: string;
   rpRedirectUri?: string;
+  rpState?: string;
 }


### PR DESCRIPTION
## What
Accept RP state from Orchestration and use this when redirecting to RP for identity errors. Not to be merged until Orch changes are in.

API change to pass state in https://github.com/govuk-one-login/authentication-api/pull/4139
