### PR TITLE
ATO-450: Create a new endpoint for rp auth codes

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -54,6 +54,7 @@ export const PATH_NAMES = {
   DOC_CHECKING_APP: "/doc-checking-app",
   DOC_CHECKING_APP_CALLBACK: "/doc-app-callback",
   PROVE_IDENTITY_CALLBACK: "/ipv-callback",
+  RP_AUTH_CODE: "/rp-auth-code",
   PROVE_IDENTITY_CALLBACK_SESSION_EXPIRY_ERROR:
     "/ipv-callback-session-expiry-error",
   HEALTHCHECK: "/healthcheck",

--- a/src/app.ts
+++ b/src/app.ts
@@ -86,6 +86,7 @@ import { accountInterventionRouter } from "./components/account-intervention/pas
 import { permanentlyBlockedRouter } from "./components/account-intervention/permanently-blocked/permanently-blocked-router";
 import { temporarilyBlockedRouter } from "./components/account-intervention/temporarily-blocked/temporarily-blocked-router";
 import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes";
+import { rpAuthCodeRouter } from "./components/rp-auth-code/rp-auth-code-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -135,6 +136,7 @@ function registerRoutes(app: express.Application) {
   app.use(proveIdentityRouter);
   app.use(proveIdentityWelcomeRouter);
   app.use(proveIdentityCallbackRouter);
+  app.use(rpAuthCodeRouter);
   app.use(cookiesRouter);
   app.use(docCheckingAppRouter);
   app.use(docCheckingAppCallbackRouter);

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -678,11 +678,16 @@ const authStateMachine = createMachine(
       },
       [PATH_NAMES.PROVE_IDENTITY_CALLBACK]: {
         on: {
-          [USER_JOURNEY_EVENTS.PROVE_IDENTITY_CALLBACK]: [PATH_NAMES.AUTH_CODE],
+          [USER_JOURNEY_EVENTS.PROVE_IDENTITY_CALLBACK]: [
+            PATH_NAMES.RP_AUTH_CODE,
+          ],
         },
         meta: {
           optionalPaths: [PATH_NAMES.PROVE_IDENTITY],
         },
+      },
+      [PATH_NAMES.RP_AUTH_CODE]: {
+        type: "final",
       },
       [PATH_NAMES.DOC_CHECKING_APP]: {
         on: {

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -39,8 +39,6 @@ export function proveIdentityCallbackGet(
     let redirectPath;
 
     if (response.data.status === IdentityProcessingStatus.COMPLETED) {
-      req.session.user.authCodeReturnToRP = true;
-
       redirectPath = getNextPathAndUpdateJourney(
         req,
         req.path,

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -48,7 +48,7 @@ describe("prove identity callback controller", () => {
   });
 
   describe("proveIdentityCallbackGet", () => {
-    it("should redirect to auth code when identity processing complete", async () => {
+    it("should redirect to rp auth code when identity processing complete", async () => {
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
         processIdentity: sinon.fake.returns({
           success: true,
@@ -62,7 +62,7 @@ describe("prove identity callback controller", () => {
         res as Response
       );
 
-      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.RP_AUTH_CODE);
     });
 
     it("should render index when identity is being processed", async () => {

--- a/src/components/rp-auth-code/rp-auth-code-controller.ts
+++ b/src/components/rp-auth-code/rp-auth-code-controller.ts
@@ -1,15 +1,15 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
-import { authCodeService } from "./auth-code-service";
-import { AuthCodeServiceInterface } from "./types";
+import { rpAuthCodeService } from "./rp-auth-code-service";
+import { RpAuthCodeServiceInterface } from "./types";
 import { BadRequestError } from "../../utils/error";
 import { CookieConsentServiceInterface } from "../common/cookie-consent/types";
 import { cookieConsentService } from "../common/cookie-consent/cookie-consent-service";
 import { sanitize } from "../../utils/strings";
 import { COOKIE_CONSENT } from "../../app.constants";
 
-export function authCodeGet(
-  service: AuthCodeServiceInterface = authCodeService(),
+export function rpAuthCodeGet(
+  service: RpAuthCodeServiceInterface = rpAuthCodeService(),
   cookieService: CookieConsentServiceInterface = cookieConsentService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
@@ -20,11 +20,8 @@ export function authCodeGet(
       sessionId,
       clientSessionId,
       req.ip,
-      persistentSessionId,
-      req.session.client,
-      req.session.user
+      persistentSessionId
     );
-    delete req.session.user.reauthenticate;
 
     if (!result.success) {
       throw new BadRequestError(result.data.message, result.data.code);

--- a/src/components/rp-auth-code/rp-auth-code-routes.ts
+++ b/src/components/rp-auth-code/rp-auth-code-routes.ts
@@ -1,0 +1,18 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import * as express from "express";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { rpAuthCodeGet } from "./rp-auth-code-controller";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { asyncHandler } from "../../utils/async";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RP_AUTH_CODE,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(rpAuthCodeGet())
+);
+
+export { router as rpAuthCodeRouter };

--- a/src/components/rp-auth-code/rp-auth-code-service.ts
+++ b/src/components/rp-auth-code/rp-auth-code-service.ts
@@ -1,0 +1,37 @@
+import { ApiResponseResult } from "../../types";
+import { API_ENDPOINTS } from "../../app.constants";
+import {
+  createApiResponse,
+  getRequestConfig,
+  http,
+  Http,
+} from "../../utils/http";
+import { AuthCodeResponse, RpAuthCodeServiceInterface } from "./types";
+import { getApiBaseUrl } from "../../config";
+
+export function rpAuthCodeService(
+  axios: Http = http
+): RpAuthCodeServiceInterface {
+  const getAuthCode = async function (
+    sessionId: string,
+    clientSessionId: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ): Promise<ApiResponseResult<AuthCodeResponse>> {
+    const baseUrl = getApiBaseUrl();
+    const config = getRequestConfig({
+      baseURL: baseUrl,
+      sessionId: sessionId,
+      clientSessionId: clientSessionId,
+      sourceIp: sourceIp,
+      persistentSessionId: persistentSessionId,
+    });
+    const response = await axios.client.get(API_ENDPOINTS.AUTH_CODE, config);
+
+    return createApiResponse<AuthCodeResponse>(response);
+  };
+
+  return {
+    getAuthCode,
+  };
+}

--- a/src/components/rp-auth-code/tests/rp-auth-code-controller.test.ts
+++ b/src/components/rp-auth-code/tests/rp-auth-code-controller.test.ts
@@ -1,0 +1,210 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+
+import { rpAuthCodeGet } from "../rp-auth-code-controller";
+import { RpAuthCodeServiceInterface } from "../types";
+import { CookieConsentServiceInterface } from "../../common/cookie-consent/types";
+import { COOKIE_CONSENT } from "../../../app.constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+
+describe("RP auth code controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  const AUTH_CODE_DUMMY_URL =
+    "https://test-idp-url.com/callback?code=123-4ddkk0sdkkd-ad";
+
+  beforeEach(() => {
+    req = mockRequest({
+      session: {
+        client: { cookieConsentEnabled: true },
+        user: { isUserAuthenticated: false },
+      },
+      i18n: { language: "en" },
+    });
+
+    res = mockResponse({
+      locals: {
+        sessionId: "sessiondid",
+        clientSessionId: "sdmm",
+        persistentSessionId: "snncjh",
+      },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("authCodeGet", () => {
+    it("should redirect to the auth code url with cookie consent param set as not-engaged", async () => {
+      req.cookies = {};
+      const fakeAuthCodeService: RpAuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as RpAuthCodeServiceInterface;
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake.returns({
+          cookie_consent: COOKIE_CONSENT.NOT_ENGAGED,
+        }),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await rpAuthCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(
+        `${AUTH_CODE_DUMMY_URL}&cookie_consent=not-engaged`
+      );
+    });
+
+    it("should redirect to the auth code url with cookie consent param set as accept", async () => {
+      const fakeAuthCodeService: RpAuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as RpAuthCodeServiceInterface;
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake.returns({
+          cookie_consent: COOKIE_CONSENT.ACCEPT,
+        }),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await rpAuthCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(
+        `${AUTH_CODE_DUMMY_URL}&cookie_consent=accept`
+      );
+    });
+
+    it("should redirect to the auth code url with cookie consent param set as reject", async () => {
+      const fakeAuthCodeService: RpAuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as RpAuthCodeServiceInterface;
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake.returns({
+          cookie_consent: COOKIE_CONSENT.REJECT,
+        }),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      req.session.client.crossDomainGaTrackingId =
+        "2.172053219.3232.1636392870-444224.1635165988";
+
+      await rpAuthCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(
+        `${AUTH_CODE_DUMMY_URL}&cookie_consent=reject`
+      );
+    });
+
+    it("should redirect to the auth code url without the cookie consent param present", async () => {
+      req.session.client.cookieConsentEnabled = false;
+
+      const fakeAuthCodeService: RpAuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as RpAuthCodeServiceInterface;
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await rpAuthCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(AUTH_CODE_DUMMY_URL);
+    });
+
+    it("should redirect to auth code API endpoint with cookie consent param set as reject and no _ga param", async () => {
+      req.cookies = {
+        cookies_preferences_set: '{"analytics":false}',
+      };
+
+      req.session.client.cookieConsentEnabled = false;
+
+      req.session.client.crossDomainGaTrackingId =
+        "2.172053219.3232.1636392870-444224.1635165988";
+
+      const fakeAuthCodeService: RpAuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as RpAuthCodeServiceInterface;
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await rpAuthCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(AUTH_CODE_DUMMY_URL);
+    });
+
+    it("should redirect to auth code API endpoint with cookie consent param set as accept and with the _ga param set", async () => {
+      req.cookies = {
+        cookies_preferences_set: '{"analytics":true}',
+      };
+
+      req.session.client.cookieConsentEnabled = true;
+
+      const fakeAuthCodeService: RpAuthCodeServiceInterface = {
+        getAuthCode: sinon.fake.returns({
+          data: { location: AUTH_CODE_DUMMY_URL },
+          success: true,
+        }),
+      } as unknown as RpAuthCodeServiceInterface;
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake.returns({
+          cookie_consent: COOKIE_CONSENT.ACCEPT,
+        }),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      req.session.client.crossDomainGaTrackingId =
+        "2.172053219.3232.1636392870-444224.1635165988";
+
+      await rpAuthCodeGet(fakeAuthCodeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(
+        `${AUTH_CODE_DUMMY_URL}&cookie_consent=accept&_ga=2.172053219.3232.1636392870-444224.1635165988`
+      );
+    });
+  });
+});

--- a/src/components/rp-auth-code/tests/rp-auth-code-service.test.ts
+++ b/src/components/rp-auth-code/tests/rp-auth-code-service.test.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { rpAuthCodeService } from "../rp-auth-code-service";
+import { SinonStub } from "sinon";
+import { API_ENDPOINTS } from "../../../app.constants";
+import { RpAuthCodeServiceInterface } from "../types";
+import { Http } from "../../../utils/http";
+
+describe("authentication auth code service", () => {
+  const redirectUriReturnedFromResponse =
+    "/redirect-here?with-some-params=added-by-the-endpoint";
+  const apiBaseUrl = "/base-url";
+
+  const axiosResponse = Promise.resolve({
+    data: {
+      location: redirectUriReturnedFromResponse,
+    },
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: {},
+  });
+  let getStub: SinonStub;
+  let service: RpAuthCodeServiceInterface;
+
+  beforeEach(() => {
+    process.env.API_KEY = "api-key";
+    process.env.API_BASE_URL = apiBaseUrl;
+    const httpInstance = new Http();
+    service = rpAuthCodeService(httpInstance);
+    getStub = sinon.stub(httpInstance.client, "get");
+    getStub.resolves(axiosResponse);
+  });
+
+  afterEach(() => {
+    getStub.reset();
+  });
+
+  it("it should make a get request to the auth code endpoint with no body", async () => {
+    process.env.SUPPORT_AUTH_ORCH_SPLIT = "0";
+
+    const result = await service.getAuthCode(
+      "sessionId",
+      "clientSessionId",
+      "sourceIp",
+      "persistentSessionId"
+    );
+
+    expect(
+      getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
+        headers: sinon.match.object,
+        baseURL: apiBaseUrl,
+        proxy: sinon.match.bool,
+      })
+    ).to.be.true;
+    expect(result.data.location).to.deep.eq(redirectUriReturnedFromResponse);
+  });
+});

--- a/src/components/rp-auth-code/types.ts
+++ b/src/components/rp-auth-code/types.ts
@@ -1,0 +1,14 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+
+export interface AuthCodeResponse extends DefaultApiResponse {
+  location: string;
+}
+
+export interface RpAuthCodeServiceInterface {
+  getAuthCode: (
+    sessionId: string,
+    clientSessionId: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ) => Promise<ApiResponseResult<AuthCodeResponse>>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,6 @@ export interface UserSession {
   isAccountRecoveryCodeResent?: boolean;
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
-  authCodeReturnToRP?: boolean;
   enterEmailMfaType?: string;
   withinForcedPasswordResetJourney?: boolean;
   passwordResetTime?: number;


### PR DESCRIPTION
## What

Replace the dual functionality of the `/auth-code` endpoint with a new `/rp-auth-code`. 

Currently, `/auth-code` either generates a code to return the user to Orchestration, or to return to the RP if they have completed identity. This seems to be causing some hard to diagnose issues with users occasionally being directed to the wrong place. Splitting the endpoints allows us to make better use of the state machine to make sure the user ends up in the right place, even if they use the browser back button.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

<!-- 

Include screenshots where possible, including those representing error states. Here are some examples:

- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged  

-->

<!-- Delete this section if the PR does not change the UI. -->

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
