### PR TITLE
AUT-2606: Update page titles for too many codes requested error page …

### DIFF
--- a/src/components/security-code-error/index-wait.njk
+++ b/src/components/security-code-error/index-wait.njk
@@ -1,7 +1,11 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% if support2hrLockout %}
-    {% set pageTitleName = 'pages.securityCodeWaitToRequest.title' | translate %}
+    {% if isAccountCreationJourney %}
+        {% set pageTitleName = 'pages.securityCodeWaitToRequest.title_create' | translate %}
+    {% else %}
+        {% set pageTitleName = 'pages.securityCodeWaitToRequest.title' | translate %}
+    {% endif %}
 {% else %}
     {% set pageTitleName = 'pages.securityCodeWaitToRequest.title_old' | translate %}
 {% endif %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -504,6 +504,7 @@
       "header_old": "Ni allwch gael cod diogelwch newydd ar hyn o bryd ",
       "header": "Ni allwch fewngofnodi ar hyn o bryd ",
       "header_create": "Ni allwch greu GOV.UK One Login ar hyn o bryd ",
+      "title_create": "Ni allwch greu GOV.UK One Login ar hyn o bryd ",
       "info_old": {
         "paragraph1": "Mae hyn oherwydd eich bod wedi gofyn i ailanfon cod diogelwch ormod o weithiau.",
         "paragraph2Start": "Gallwch ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -504,6 +504,7 @@
       "header_old": "You cannot get a new security code at the moment ",
       "header": "You cannot sign in at the moment ",
       "header_create": "You cannot create a GOV.UK One Login at the moment ",
+      "title_create": "You cannot create a GOV.UK One Login at the moment ",
       "info_old": {
         "paragraph1": "This is because you asked to resend the security code too many times.",
         "paragraph2Start": "You can ",


### PR DESCRIPTION
…in the creation journey

## What

We need to update the error page titles for the too many codes requested lock in the account creation journey. Previously the title was "You cannot sign in .." when "You cannot create ..." was expected.

## How to review

1. Deploy to sandpit with `./deploy-sandpit.sh -l` or test locally by staring the service with './startup.sh -l'
2. Click on "Create a GOV.UK One Login'
3. Enter a valid email address
4. Request codes until locked out
5. Go to '/sign-in-or-create' and click on "Create a GOV.UK One Login'
6. Enter the same email address as entered on step 3
7. When redirected to the lockout page, verify that the title is "You cannot create .. "


## Change have been demonstrated
Changes to the user interface are not required to be demonstrated to the UCD team, the screenshots below should do.

Before: 
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/9c7274cf-6eb3-4dd3-9d48-ceca02615cf9)

After:
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/1b2cf57d-d942-4d74-8ca0-7b6c84597d90)



