### PR TITLE
AUT-2617: add the correct journey type to resend-mfa-code-controller.ts

### DIFF
--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
@@ -54,7 +54,11 @@ export const resendMfaCodePost = (
 ): ExpressRouteFunc => {
   return async function (req: Request, res: Response) {
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
-    const { email, phoneNumber } = req.session.user;
+    const { email, isAccountRecoveryJourney, phoneNumber } = req.session.user;
+
+    const journeyType = isAccountRecoveryJourney
+      ? JOURNEY_TYPE.ACCOUNT_RECOVERY
+      : JOURNEY_TYPE.REGISTRATION;
 
     const sendNotificationResponse = await service.sendNotification(
       sessionId,
@@ -64,7 +68,7 @@ export const resendMfaCodePost = (
       req.ip,
       persistentSessionId,
       xss(req.cookies.lng as string),
-      JOURNEY_TYPE.REGISTRATION,
+      journeyType,
       phoneNumber
     );
 

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
@@ -65,5 +65,63 @@ describe("resend mfa controller", () => {
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
       expect(fakeService.sendNotification).to.have.been.calledOnce;
     });
+
+    it("should request new phone verification code from send notification service and if successful redirect to /enter-code view", async () => {
+      const fakeService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as SendNotificationServiceInterface;
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "654321-djjad";
+      res.locals.persistentSessionId = "123123-djjad";
+
+      req.session.user = {
+        email: "test@test.com",
+        isAccountRecoveryJourney: true,
+      };
+      req.path = PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION;
+      req.ip = "127.0.0.1";
+      await resendMfaCodePost(fakeService)(req as Request, res as Response);
+      expect(fakeService.sendNotification).to.have.been.calledWith(
+        "123456-djjad",
+        "654321-djjad",
+        "test@test.com",
+        "VERIFY_PHONE_NUMBER",
+        "127.0.0.1",
+        "123123-djjad",
+        "",
+        "ACCOUNT_RECOVERY"
+      );
+    });
+
+    it("should request new phone verification code from send notification service and if successful redirect to /enter-code view", async () => {
+      const fakeService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as SendNotificationServiceInterface;
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "654321-djjad";
+      res.locals.persistentSessionId = "123123-djjad";
+
+      req.session.user = {
+        email: "test@test.com",
+        isAccountCreationJourney: true,
+      };
+      req.path = PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION;
+      req.ip = "127.0.0.1";
+      await resendMfaCodePost(fakeService)(req as Request, res as Response);
+      expect(fakeService.sendNotification).to.have.been.calledWith(
+        "123456-djjad",
+        "654321-djjad",
+        "test@test.com",
+        "VERIFY_PHONE_NUMBER",
+        "127.0.0.1",
+        "123123-djjad",
+        "",
+        "REGISTRATION"
+      );
+    });
   });
 });

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -84,7 +84,9 @@ export function enterPhoneNumberPost(
             req.query.actionType as SecurityCodeErrorType
           ),
           support2hrLockout: support2hrLockout(),
-          isAccountCreationJourney: true,
+          isAccountCreationJourney:
+            req.session.user.isAccountCreationJourney ||
+            req.session.user.isAccountPartCreated,
         });
       }
       const path = getErrorPathByCode(sendNotificationResponse.data.code);

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -152,5 +152,77 @@ describe("enter phone number controller", () => {
         "security-code-error/index-wait.njk"
       );
     });
+
+    it(
+      "should render security-code-error/index-wait.njk and isAccountCreationJourney as true pass page " +
+        "when user is locked and tries to complete the journey again for account part created journey",
+      async () => {
+        const fakeNotificationService: SendNotificationServiceInterface = {
+          sendNotification: sinon.fake.returns({
+            success: false,
+            data: {
+              code: ERROR_CODES.VERIFY_PHONE_NUMBER_MAX_CODES_SENT,
+            },
+          }),
+        } as unknown as SendNotificationServiceInterface;
+        process.env.SUPPORT_2HR_LOCKOUT = "1";
+        res.locals.sessionId = "123456-djjad";
+        req.body.phoneNumber = "+33645453322";
+        req.session.user.email = "test@test.com";
+        req.session.user.isAccountPartCreated = true;
+
+        await enterPhoneNumberPost(fakeNotificationService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(fakeNotificationService.sendNotification).to.have.been
+          .calledOnce;
+        expect(res.render).to.have.calledWith(
+          "security-code-error/index-wait.njk",
+          {
+            newCodeLink: undefined,
+            support2hrLockout: true,
+            isAccountCreationJourney: true,
+          }
+        );
+      }
+    );
+
+    it(
+      "should render security-code-error/index-wait.njk and isAccountCreationJourney as true pass page " +
+        "when user is locked and tries to complete the journey again for account creation journey",
+      async () => {
+        const fakeNotificationService: SendNotificationServiceInterface = {
+          sendNotification: sinon.fake.returns({
+            success: false,
+            data: {
+              code: ERROR_CODES.VERIFY_PHONE_NUMBER_MAX_CODES_SENT,
+            },
+          }),
+        } as unknown as SendNotificationServiceInterface;
+        process.env.SUPPORT_2HR_LOCKOUT = "1";
+        res.locals.sessionId = "123456-djjad";
+        req.body.phoneNumber = "+33645453322";
+        req.session.user.email = "test@test.com";
+        req.session.user.isAccountCreationJourney = true;
+
+        await enterPhoneNumberPost(fakeNotificationService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(fakeNotificationService.sendNotification).to.have.been
+          .calledOnce;
+        expect(res.render).to.have.calledWith(
+          "security-code-error/index-wait.njk",
+          {
+            newCodeLink: undefined,
+            support2hrLockout: true,
+            isAccountCreationJourney: true,
+          }
+        );
+      }
+    );
   });
 });


### PR DESCRIPTION
To implement the correct locking for code requests, we need to send the correct journey type to the backend API. Because the resend-mfa-code-controller.ts is used in the creation, account-part-created and account recovery journeys, we need to make sure that we send the current journey type, not JOURNEY_TYPE.REGISTRATION. Backend implements locking on the 6th requests. The enter-phone-controller sent the correct journey type, while the resend-mfa-code-controller.ts sent the wrong one, reason why we were blocked on the 6th, not 5th request. Obs: part-created and creation are using JOURNEY_TYPE.REGISTRATION, while account recovery has its own journey type.

## What

Update resend-mfa-code-controller.ts to send correct journey type

## How to review

1. Deploy to sandpit with ./deploy-sandpit.sh -l or test locally by staring the service with './startup.sh -l'
2. Sign in to existing account, or create a new one if you do not have one
4. Sign in
5. On the enter-code (auth app or sms), click 'change how you get security codes"
7. Enter email OTP
8. Select SMS option and enter a correct phone number
9. On the verify phone number page, request 5 codes and verify that on the 5th request you get locked out.

- [] Changes to the user interface have been demonstrated

