### PR TITLE
AUT-2610: add checking for user lockouts for too many codes in new se…

### DIFF
--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -84,6 +84,18 @@ export function resetPassword2FASmsGet(
           isAccountCreationJourney: false,
         });
       }
+      if (mfaResponse.data.code == ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES) {
+        return res.render(
+          "security-code-error/index-security-code-entered-exceeded.njk",
+          {
+            newCodeLink: getNewCodePath(
+              req.query.actionType as SecurityCodeErrorType
+            ),
+            show2HrScreen: support2hrLockout(),
+            isAccountCreationJourney: false,
+          }
+        );
+      }
       const path = getErrorPathByCode(mfaResponse.data.code);
       if (path) {
         return res.redirect(path);


### PR DESCRIPTION
When a user restarts the journey with new session variables, checking the session lockout is not enough, we have to check for an existing user lockout code from the backend api.

## What
Implement redirect to error page when user is locked out due to too many incorrect codes entered.

## How to review

1. Code Review
2. Ensure environment variables 'SUPPORT_2HR_LOCKOUT' and 'SUPPORT_2FA_B4_PASSWORD_RESET' are set to 1
3. Deploy to sandpit with `./deploy-sandpit.sh -l` (or run local)
4. Proceed through PW reset journey and enter the correct OTP email
5. Enter 5 wrong SMS OTPS, check that you are redirected to the screen corresponding to the first Screenshot below
6. Restart the journey by going to localhost:2000, or going through the stub again, go to the reset-password journey and verify that you're redirected to the 2nd screenshot below, after entering the correct email OTP. 


Expected 2hr screens to be redirected to during the PW reset journey, when entering too many wrong codes:

![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/72e8f1d4-abad-42d4-acbb-2304d0da3b39)

Expected 2hr screens to be redirected to during PW reset, when user is locked and tries to complete the journey: 
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/25f621b4-8ee7-4db1-abb3-1eeea9772192)


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated
The changes were demonstrated in a demo to Kim Clayden
