### PR TITLE
AUT-2600: update lockout error screen after entering correct password with too many incorrect mfa codes

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -215,7 +215,10 @@ export function enterPasswordPost(
 
         if (result.data.code === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES) {
           return res.render(
-            "security-code-error/index-security-code-entered-exceeded.njk"
+            "security-code-error/index-security-code-entered-exceeded.njk",
+            {
+              show2HrScreen: support2hrLockout(),
+            }
           );
         }
 


### PR DESCRIPTION
## What

Support 2hr lockout flag was not passed to index-security-code-entered-exceeded.njk from enter-password-controller when a user is locked out due to too many failed sms mfa attempts.

## How to review

1. Code Review
2. Deploy to sandpit with `./deploy-sandpit.sh -a`
3. Follow steps in [ticket](https://govukverify.atlassian.net/browse/AUT-2600)

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated


<img width="631" alt="Screenshot 2024-03-26 at 14 46 00" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/fda29568-bcd5-461e-9f1b-f5e652f98a74">



