### PR TITLE
ATO-459: Performance: cache nunjucks templates

### DIFF
--- a/src/config/nunchucks.ts
+++ b/src/config/nunchucks.ts
@@ -3,6 +3,8 @@ import * as nunjucks from "nunjucks";
 import { Environment } from "nunjucks";
 import i18next from "i18next";
 import { returnLastCharactersOnly } from "../utils/phone-number";
+import { getNodeEnv } from "../config";
+import { ENVIRONMENT_NAME } from "../app.constants";
 
 export function configureNunjucks(
   app: express.Application,
@@ -11,7 +13,7 @@ export function configureNunjucks(
   const nunjucksEnv: nunjucks.Environment = nunjucks.configure(viewsPath, {
     autoescape: true,
     express: app,
-    noCache: true,
+    noCache: getNodeEnv() !== ENVIRONMENT_NAME.PROD,
   });
 
   nunjucksEnv.addFilter("translate", function (key: string, options?: any) {


### PR DESCRIPTION
## What?

Enable nunjucks caching in deployed environments

## Why?

This has been shown to improve performance by some Identity teams

See https://github.com/govuk-one-login/ipv-core-front/pull/1206/commits/b08319e95d055ac8437a24c45f5d6fab093a09d8