### PR TITLE
AUT-2598: Update success status code for reset password check email service

### DIFF
--- a/src/components/reset-password-check-email/reset-password-check-email-service.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-service.ts
@@ -32,6 +32,7 @@ export function resetPasswordCheckEmailService(
       })
     );
     return createApiResponse<DefaultApiResponse>(response, [
+      HTTP_STATUS_CODES.OK,
       HTTP_STATUS_CODES.NO_CONTENT,
     ]);
   };


### PR DESCRIPTION
Currently, the api response for a reset password request returns a 204 (no content). We want to start returning some content, so we'll need to support it returning a 200. This adds 200 as a possible API response code, as a preparatory step before we start returning a 200 from the API.

When we have switched the API response over, we can remove 204 as a possible response code from here.

## How to review

1. Code Review

## Related PRs

[PR](https://github.com/govuk-one-login/authentication-api/pull/4162) that updates this response on the backend.

We'll need to first merge this PR in frontend, and then the above backend PR.