### PR TITLE
AUT-2633: Fix the resend code link for the check-your-phone page

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -11,7 +11,6 @@ import {
   getErrorPathByCode,
   getNextPathAndUpdateJourney,
   pathWithQueryParam,
-  SecurityCodeErrorType,
 } from "../common/constants";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
@@ -25,7 +24,6 @@ import {
 import { BadRequestError } from "../../utils/error";
 import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
 import { getJourneyTypeFromUserSession } from "../common/journey/journey";
-import { getNewCodePath } from "../security-code-error/security-code-error-controller";
 import { support2hrLockout } from "../../config";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
@@ -41,9 +39,7 @@ export function checkYourPhoneGet(req: Request, res: Response): void {
     new Date().getTime() < new Date(req.session.user.codeRequestLock).getTime()
   ) {
     return res.render("security-code-error/index-wait.njk", {
-      newCodeLink: getNewCodePath(
-        req.query.actionType as SecurityCodeErrorType
-      ),
+      newCodeLink: RESEND_CODE_LINK,
       support2hrLockout: support2hrLockout(),
       isAccountCreationJourney: req.session.user.isAccountCreationJourney,
     });

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -66,7 +66,10 @@ export function securityCodeInvalidGet(req: Request, res: Response): void {
   }
 
   return res.render("security-code-error/index.njk", {
-    newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    newCodeLink: getNewCodePath(
+      req.query.actionType as SecurityCodeErrorType,
+      req.session.user.isAccountCreationJourney
+    ),
     isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
     isBlocked: isNotEmailCode || showFifteenMinutesParagraph,
     show2HrScreen: show2HrScreen,
@@ -99,7 +102,10 @@ export function securityCodeTriesExceededGet(
   }
 
   return res.render("security-code-error/index-too-many-requests.njk", {
-    newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    newCodeLink: getNewCodePath(
+      req.query.actionType as SecurityCodeErrorType,
+      req.session.user.isAccountCreationJourney
+    ),
     isResendCodeRequest: req.query.isResendCodeRequest,
     show2HrScreen: show2HrScreen,
     isAccountCreationJourney: req.session.user?.isAccountCreationJourney,
@@ -129,7 +135,10 @@ export function securityCodeEnteredExceededGet(
   });
 }
 
-export function getNewCodePath(actionType: SecurityCodeErrorType): string {
+export function getNewCodePath(
+  actionType: SecurityCodeErrorType,
+  isAccountCreationJourney?: boolean
+): string {
   switch (actionType) {
     case SecurityCodeErrorType.MfaMaxCodesSent:
     case SecurityCodeErrorType.MfaBlocked:
@@ -150,11 +159,17 @@ export function getNewCodePath(actionType: SecurityCodeErrorType): string {
     case SecurityCodeErrorType.OtpBlocked:
       return PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER;
     case SecurityCodeErrorType.OtpMaxRetries:
-      return pathWithQueryParam(
-        PATH_NAMES.RESEND_MFA_CODE,
-        "isResendCodeRequest",
-        "true"
-      );
+      return isAccountCreationJourney
+        ? pathWithQueryParam(
+            PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+            "isResendCodeRequest",
+            "true"
+          )
+        : pathWithQueryParam(
+            PATH_NAMES.RESEND_MFA_CODE,
+            "isResendCodeRequest",
+            "true"
+          );
     case SecurityCodeErrorType.EmailMaxCodesSent:
     case SecurityCodeErrorType.EmailBlocked:
       return PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT;


### PR DESCRIPTION
## What
Redirect to correct resend-mfa page when user is locked out due to too many incorrect codes entered in the account creation journey, and requests a new code.

## How to review

1. Code Review
2. Ensure environment variables 'SUPPORT_2HR_LOCKOUT' and 'SUPPORT_2FA_B4_PASSWORD_RESET' are set to 1
3. Deploy to sandpit with `./deploy-sandpit.sh -l` (or run local)
4. Create a new account with an unregistered email address 
5. Enter correct email OTP
6. Enter 5 wrong SMS OTPS, check that you are redirected to the 15 min error screen 
7. Click on "get a new code" and verify that you are redirected to /resend-code-create-account?isResendCodeRequest=true

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated
Changes have been demonstrated to Kim Clayden in a recorded demo

