### PR TITLE
BAU: Ignore additional assets in pino-http logging

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -50,6 +50,8 @@ const loggerMiddleware = PinoHttp({
         "/public/style.css",
         "/public/scripts",
         "/public/scripts/application.js",
+        "/public/scripts/showPassword.js",
+        "/assets/images/govuk-crest.png",
         "/assets/images/govuk-crest-2x.png",
         "/assets/fonts/bold-b542beb274-v2.woff2",
         "/assets/fonts/bold-b542beb274-v2.woff2",
@@ -58,13 +60,13 @@ const loggerMiddleware = PinoHttp({
       ].includes(req.url),
   },
   customErrorMessage: function (_req, res) {
-    return "request errored with status code: " + res.statusCode;
+    return `request errored with status code: ${res.statusCode}`;
   },
   customSuccessMessage: function (_req, res) {
     if (res.statusCode === 404) {
       return "resource not found";
     }
-    return `request completed with status code of:${res.statusCode}`;
+    return `request completed with status code of: ${res.statusCode}`;
   },
   customAttributeKeys: {
     responseTime: "timeTaken",


### PR DESCRIPTION
## What

We should avoid stuffing our logging capacity with HTTP request logs for asset files in order to reduce the cost of logging (as these are requested very often and often not useful in debugging issues).

The following files are ignored: `/public/scripts/showPassword.js` and `/assets/images/govuk-crest.png`.

## How to review

1. Run the service locally.
2. Open http://localhost:2000
3. See the logs in console do not include a 200 success response for `govuk-crest.png`.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Noticed after updating the pino dependencies in https://github.com/govuk-one-login/authentication-frontend/pull/1367
