### PR TITLE
BAU: Unit and integration test execution improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   root: true,
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint","no-only-tests"],
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
@@ -25,5 +25,6 @@ module.exports = {
       "error",
       { blankLine: "any", prev: "*", next: "*" },
     ],
+    "no-only-tests/no-only-tests": "error",
   },
 };

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -32,6 +32,8 @@ jobs:
         run: yarn install
       - name: Check formatting
         run: yarn check-pretty
+      - name: Run lint
+        run: yarn lint
       - name: Build app
         run: yarn build
       - name: Run unit tests
@@ -40,8 +42,6 @@ jobs:
         run: yarn test:integration-no-clear-cov
       - name: Run test coverage
         run: yarn test:coverage
-      - name: Run lint
-        run: yarn lint
       - name: SonarCloud Scan
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: sonarsource/sonarcloud-github-action@master

--- a/README.md
+++ b/README.md
@@ -217,10 +217,14 @@ using mocha.
 
 ### Integration tests
 
+The application stack must be started before the integration tests can be run, either with frontend running in a docker container or on the local machine (./startup -l).
+In either case the command to run the integration tests is the same, but the tests usually run faster when frontend is started outside of docker.
+
+In both cases frontend must have started successfully with the message 'Server listening on port 3000' before the tests can be run.  If running frontend in a container check the actual container logs in docker desktop to make sure that frontend has started correctly, otherwise the test run will be invalid.
 > To run the integration tests
 
 ```shell script
-yarn test:integration
+REDIS_PORT=6379 REDIS_HOST=localhost yarn test:integration
 ```
 
 ### Install dependencies

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "dotenv": "^16.4.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^9.0.10",
     "mocha": "10.1.0",

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -28,6 +28,6 @@ pre-commit run --all-files
 
 yarn test:unit
 
-REDIS_PORT=6389 REDIS_HOST=localhost yarn test:integration
+REDIS_PORT=6379 REDIS_HOST=localhost yarn test:integration
 
 ./shutdown.sh

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
@@ -68,7 +68,7 @@ describe("Integration::2fa sms (in reset password flow)", () => {
     request(app).get("/reset-password-2fa-sms").expect(200, done);
   });
 
-  it.only("should render index-security-code-entered-exceeded.njk when user is locked out due to too many incorrect codes", (done) => {
+  it("should render index-security-code-entered-exceeded.njk when user is locked out due to too many incorrect codes", (done) => {
     process.env.SUPPORT_2HR_LOCKOUT = "1";
     nock(baseApi).persist().post("/mfa").reply(400, {
       code: ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,6 +2566,11 @@ eslint-config-prettier@^9.1.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
   integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
 
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"


### PR DESCRIPTION
## What

Unit and integration test execution improvements

- Add eslint plugin and rule to prevent commiting 'it.only' tests
- Remove an 'it.only' that has been commited.
- Change and document the redis port used to run integration tests.

## How to review

1. Code Review.
1. Change a test to 'it.only' and run 'yarn lint'.  You should see a linting error. 
1. If you commit this change and create a PR then the 'lint' action will fail, making the PR impossible to merge.
1. Follow the instructions in the readme to run integration tests.  They run cleanly in GHA, but there should only be the same 3 or 4 failures locally.







