### PR TITLE
adding idle_timeout to ALB

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -4,6 +4,7 @@ resource "aws_lb" "frontend_alb" {
   load_balancer_type = "application"
   security_groups    = [aws_security_group.frontend_alb_sg.id]
   subnets            = local.public_subnet_ids
+  idle_timeout       = var.alb_idle_timeout
 
   depends_on = [
     aws_s3_bucket_policy.allow_access_alb

--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -19,6 +19,8 @@ frontend_task_definition_cpu     = 256
 frontend_task_definition_memory  = 512
 frontend_auto_scaling_v2_enabled = true
 
+alb_idle_timeout = 30
+
 url_for_support_links = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -19,6 +19,8 @@ frontend_task_definition_cpu     = 256
 frontend_task_definition_memory  = 512
 frontend_auto_scaling_v2_enabled = true
 
+alb_idle_timeout = 30
+
 url_for_support_links = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -6,6 +6,8 @@ frontend_auto_scaling_v2_enabled = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
+alb_idle_timeout = 30
+
 support_international_numbers                       = "1"
 support_account_recovery                            = "1"
 support_auth_orch_split                             = "1"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -20,6 +20,8 @@ frontend_task_definition_cpu     = 256
 frontend_task_definition_memory  = 512
 frontend_auto_scaling_v2_enabled = true
 
+alb_idle_timeout = 30
+
 url_for_support_links = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -261,3 +261,8 @@ variable "email_entered_wrong_blocked_minutes" {
   description = "The duration, in minutes, for which a user is blocked after entering the wrong email multiple times during reauthentication"
   default     = "15"
 }
+
+variable "alb_idle_timeout" {
+  description = "Frontend Application Load Balancer idle timeout"
+  default     = 60
+}


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

We are deploying cloudfront in front of all frontends and performing some reconnaissance to ensure that the front end times out before we do. Currently auth ALB timeout is at default 60 seconds.  We would like to drop your timeout to 30 seconds to align with other frontends using api gateway.
## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

<!-- 

Include screenshots where possible, including those representing error states. Here are some examples:

- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged  

-->

<!-- Delete this section if the PR does not change the UI. -->

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Acceptance tests have been updated

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- 

This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 

-->

## Associated documentation has been updated

- [ ] Documentation has been updated to reflect these changes

<!-- 

This might include updates to the README.md, Confluence pages etc.

-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
