### PR TITLE
BAU: Update STUB_HOSTNAME for authdev1

### DIFF
--- a/.env.authdev1
+++ b/.env.authdev1
@@ -14,7 +14,7 @@ API_BASE_URL=https://oidc.authdev1.sandpit.account.gov.uk
 FRONTEND_API_BASE_URL=https://auth.authdev1.sandpit.account.gov.uk
 
 # Redirect host for the local stub client
-STUB_HOSTNAME=di-auth-stub-relying-party-authdev1.london.cloudapps.digital
+STUB_HOSTNAME=rp-dev.build.stubs.account.gov.uk
 
 # Test Client for local testing, must be configured in the client registry - Ask for value
 TEST_CLIENT_ID=


### PR DESCRIPTION

## What

Update STUB_HOSTNAME for authdev1

The previous value is no longer in the client registry so is causing an error on authorisation to orchestration.

## How to review

1. Shutdown your local frontend using 'shutdown.sh'
2. Delete your docker images for the local stub.
3. Make sure your .env file is configured to point to authdev1.
4. Update  STUB_HOSTNAME to the value in this PR.
5. Run 'startup.sh -lc'
6. Navigate to 'localhost:2000'.  You should be redirect to the 'Sign in or create' page.






- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- 

This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 

## Associated documentation has been updated

- [ ] Documentation has been updated to reflect these changes

The sample .env for authdev1 has been updated by this PR
