### PR TITLE
INCIDEN-723: increase query param length limit

### DIFF
--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -229,7 +229,7 @@ resource "aws_wafv2_web_acl" "frontend_alb_waf_regional_web_acl" {
     statement {
       size_constraint_statement {
         comparison_operator = "GT"
-        size                = 4096
+        size                = 8192
         field_to_match {
           query_string {}
         }


### PR DESCRIPTION
As part of ATO-449, we started passing through the state param in authorize JARs, which increased the length of the query params to this endpoint. We're seeing requests just over the 4096 limit, so this should give us a bit of headroom.

Not to be merged until approval given by security