### PR TITLE
DFC-427: add language toggle feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.366.0",
+    "@govuk-one-login/one-login-language-toggle": "^2.0.0",
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-base32-enc-dec": "^12.0.1",
     "aws-sdk": "^2.1356.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -90,6 +90,7 @@ import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-a
 const APP_VIEWS = [
   path.join(__dirname, "components"),
   path.resolve("node_modules/govuk-frontend/"),
+  path.resolve("node_modules/@govuk-one-login/"),
 ];
 
 function registerRoutes(app: express.Application) {

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -24,6 +24,8 @@
 @import "components/table/table";
 @import "components/warning-text/warning-text";
 
+@import "../../../node_modules/@govuk-one-login/one-login-language-toggle/stylesheet/styles";
+
 .interrupt-screen {
   background-color: #1d70b8;
   padding: 30px;

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "one-login-language-toggle/macro.njk" import oneloginLanguageSelect %}
 
 {% block head %}
 
@@ -62,6 +63,25 @@
             html: phaseBannerText
         }) }}
         {% block beforeContent %}{% endblock %}
+        {% if showLanguageToggle %}
+          {{ oneloginLanguageSelect({
+            ariaLabel: 'general.languageToggle.ariaLabel' | translate,
+            activeLanguage: htmlLang,
+            class: "",
+            languages: [
+            { 
+              code: 'en',
+              text: 'English',
+              visuallyHidden: 'Change to English'
+            },
+            {
+              code:'cy',
+              text: 'Cymraeg',
+              visuallyHidden: 'Newid yr iaith ir Gymraeg'
+            }]
+          })
+          }}
+        {% endif %}
         {% if showBack %}
             {{ govukBackLink({
                 text: "general.back" | translate,

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,6 +179,10 @@ export function supportReauthentication(): boolean {
   return process.env.SUPPORT_REAUTHENTICATION === "1";
 }
 
+export function getLanguageToggleEnabled(): boolean {
+  return process.env.LANGUAGE_TOGGLE_ENABLED === "1";
+}
+
 export function getEmailEnteredWrongBlockDurationInMinutes(): number {
   return Number(process.env.EMAIL_ENTERED_WRONG_BLOCKED_MINUTES) || 15;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -16,6 +16,9 @@
         "end": " yn ein helpu i’w wella."
       }
     },
+    "languageToggle": {
+      "ariaLabel": "Dewis iaith"
+    },
     "authenticatorAppIssuer": "GOV.UK One Login",
     "yes": "Gallwch",
     "no": "Na",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -16,6 +16,9 @@
         "end": " will help us to improve it."
       }
     },
+    "languageToggle": {
+      "ariaLabel": "Choose Language"
+    },
     "authenticatorAppIssuer": "GOV.UK One Login",
     "yes": "Yes",
     "no": "No",

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -3,6 +3,7 @@ import {
   getAccountManagementUrl,
   getAnalyticsCookieDomain,
   getGtmId,
+  getLanguageToggleEnabled,
 } from "../config";
 import { generateNonce } from "../utils/strings";
 
@@ -15,5 +16,6 @@ export function setLocalVarsMiddleware(
   res.locals.scriptNonce = generateNonce();
   res.locals.accountManagementUrl = getAccountManagementUrl();
   res.locals.analyticsCookieDomain = getAnalyticsCookieDomain();
+  res.locals.showLanguageToggle = getLanguageToggleEnabled();
   next();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -749,6 +749,11 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
+"@govuk-one-login/one-login-language-toggle@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/one-login-language-toggle/-/one-login-language-toggle-2.0.0.tgz#75f7b7831afd0b13fc40305b3c6a4b24e48f73e4"
+  integrity sha512-2+XO0qFOLJFFnRLCBFQF6lSb/XsPMR8uw74Jtj27kTVfaoNUXMTSHu3t/Ojm6aQmKXmTp79+73dGPp5xWpBrUQ==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"


### PR DESCRIPTION
## What
Add language toggle into all pages.
<!-- Describe what you have changed and why -->

## How to review
1/ Add a new env variable: LANGUAGE_TOGGLE_ENABLED (and set the value to 1)
2/ Run the app, and open it in the browser. 
3/ You will see new texts (just after the phase banner): English and Cymraeg.
Current language of the page is a text, the other language is a link. If you click on it, active language will change.
4/ Navigate into the app and check if language is still the same.
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->


## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

<!-- 

Include screenshots where possible, including those representing error states. Here are some examples:

- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged  

-->

<!-- Delete this section if the PR does not change the UI. -->

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
