### PR TITLE
AUT-2654: Fix forced pw reset check email content

### DIFF
--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -12,7 +12,7 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resetPasswordCheckEmail.header' | translate}}</h1>
 
-    {% if support2FABeforePasswordResetFlag %}
+    {% if support2FABeforePasswordResetFlag and not isForcedPasswordResetJourney %}
 
     <p class="govuk-body" id="confirmationParagraph">
             {{

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -60,8 +60,11 @@ export function resetPasswordCheckEmailGet(
 
     if (!requestCode || result.success) {
       const support2FABeforePasswordResetFlag = support2FABeforePasswordReset();
+      const isForcedPasswordResetJourney =
+        req.session.user.withinForcedPasswordResetJourney || false;
       return res.render(TEMPLATE_NAME, {
         support2FABeforePasswordResetFlag,
+        isForcedPasswordResetJourney,
         email,
       });
     }


### PR DESCRIPTION
## What

Removed "We need to make sure this is your GOV.UK One Login before you can reset your password" paragraph from reset password check email screen if req.session.user.withinForcedPasswordResetJourney is true. This content should not have been being shown during a forced password reset journey.

## How to review

1. Code Review
2. Run through journey with AIS statuses temporarilySuspended == true && resetPasswordRequired == true

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

After change with AIS statuses applied going through forced password reset journey: 

<img width="1728" alt="Screenshot 2024-04-03 at 14 33 01 (2)" src="https://github.com/govuk-one-login/authentication-frontend/assets/65968889/57862bed-fbb3-4457-9467-bce17d070522">

After change without AIS statuses applied going through regular password reset journey:

<img width="1728" alt="Screenshot 2024-04-03 at 15 03 12 (2)" src="https://github.com/govuk-one-login/authentication-frontend/assets/65968889/93191695-0acf-434c-8572-8aec74b4adb6">
