### PR TITLE
Aut 2680/fix text on sign in screen

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -22,11 +22,7 @@
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
-        {% if supportInternationalNumbers %}
-            <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
-        {% else %}
-            <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
-        {% endif %}
+          <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
     </ul>
     {% set altLangInsetHtml %}
         {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -22,7 +22,7 @@
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
-          <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
+          <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
     </ul>
     {% set altLangInsetHtml %}
         {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -168,7 +168,7 @@
       },
       "paragraph": "Byddwch angen:",
       "bullet1": "cyfeiriad e-bost",
-      "bullet2IntNumbers": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu’n ap dilysydd",
+      "bullet2": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu’n ap dilysydd",
       "insetAlternativeLanguage": {
         "paragraph1": "Gallwch hefyd ",
         "linkText": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -168,7 +168,6 @@
       },
       "paragraph": "Byddwch angen:",
       "bullet1": "cyfeiriad e-bost",
-      "bullet2": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol y DU neu’n ap dilysydd",
       "bullet2IntNumbers": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu’n ap dilysydd",
       "insetAlternativeLanguage": {
         "paragraph1": "Gallwch hefyd ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -168,7 +168,7 @@
       },
       "paragraph": "You’ll need:",
       "bullet1": "an email address",
-      "bullet2IntNumbers": "a way to get security codes - this can be a mobile phone number or an authenticator app",
+      "bullet2": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
         "paragraph1": "You can also ",
         "linkText": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -168,7 +168,6 @@
       },
       "paragraph": "You’ll need:",
       "bullet1": "an email address",
-      "bullet2": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
       "bullet2IntNumbers": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
         "paragraph1": "You can also ",


### PR DESCRIPTION
## What

Corrects text on the sign in or create screen. In a previous PR, I removed the feature flag to support international numbers but missed this bit of the view where it is used.

## Screenshots with changes in this PR:

| English | Welsh |
|----|---|
|<img width="476" alt="Screenshot 2024-04-05 at 09 58 52" src="https://github.com/govuk-one-login/authentication-frontend/assets/25515510/b07d54d5-dfa9-4354-b153-203bff76596d">|<img width="521" alt="Screenshot 2024-04-05 at 09 59 12" src="https://github.com/govuk-one-login/authentication-frontend/assets/25515510/dcbcc3b0-a970-43b8-b607-09409af3c0d6">|

## How to review

1. Code Review
1. Review screenshots

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

<!-- 

Include screenshots where possible, including those representing error states. Here are some examples:

- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged  

-->

<!-- Delete this section if the PR does not change the UI. -->

## Related PRs

Original PR which removed feature flags: https://github.com/govuk-one-login/authentication-frontend/pull/1516
