### PR TITLE
AUT-2602:refactor naming of variables

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -117,8 +117,11 @@ export function enterEmailPost(
       throw new BadRequestError(result.data.message, result.data.code);
     }
 
-    if (result.data.authAppLockoutInformation != null)
-      setUpLocks(req, result.data.authAppLockoutInformation);
+    if (
+      result.data.lockoutInformation != null &&
+      result.data.lockoutInformation.length > 0
+    )
+      setUpAuthAppLocks(req, result.data.lockoutInformation);
     req.session.user.enterEmailMfaType = result.data.mfaMethodType;
     req.session.user.redactedPhoneNumber = result.data.phoneNumberLastThree;
     const nextState = result.data.doesUserExist
@@ -232,7 +235,7 @@ function handleBadRequest(
   return renderBadRequest(res, req, RE_ENTER_EMAIL_TEMPLATE, error);
 }
 
-function setUpLocks(req: any, lockoutArray: LockoutInformation[]) {
+function setUpAuthAppLocks(req: any, lockoutArray: LockoutInformation[]) {
   lockoutArray.forEach(function (lockoutInformation) {
     if (lockoutInformation.lockType == "codeBlock") {
       const lockTime = timestampNMinutesFromNow(

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -5,7 +5,7 @@ export interface UserExists extends DefaultApiResponse {
   doesUserExist: boolean;
   mfaMethodType: string;
   phoneNumberLastThree?: string;
-  authAppLockoutInformation?: LockoutInformation[];
+  lockoutInformation?: LockoutInformation[];
 }
 export interface LockoutInformation {
   lockType: string;


### PR DESCRIPTION
## What
Refactor the API interface variables to coincide with what BE is sending. 

## How to review

1. Code Review
2. Ensure environment variables 'SUPPORT_2HR_LOCKOUT' and 'SUPPORT_2FA_B4_PASSWORD_RESET' are set to 1
3. Deploy to sandpit with `./deploy-sandpit.sh -l` (or run local)
4. Proceed through PW reset journey and enter the correct OTP email
5. Enter 5 wrong AUTH_APP OTPS, check that you are redirected to the screen corresponding to the first Screenshot below
6. Restart the journey by going to localhost:2000, or going through the stub again, go to the reset-password journey and verify that you're redirected to the 2nd screenshot below, after entering the correct email OTP. 
7. Proceed through the SIGN_IN journey
8. Enter 5 wrong AUTH_APP OTPS, check that you are redirected to the screen corresponding to the first Screenshot below
9. Restart the journey by going to localhost:2000, or going through the stub again, go through the sign-in journey again
10. Verify that you're redirected to the 2nd screenshot below, after entering the correct password.


Expected 2hr screens to be redirected to during the PW reset and SIGN_IN journey, when entering too many wrong codes:


![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/72e8f1d4-abad-42d4-acbb-2304d0da3b39)

Expected 2hr screens to be redirected to during PW reset and SIGN_IN, when user is locked and tries to complete the journey: 
![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/25f621b4-8ee7-4db1-abb3-1eeea9772192)


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated
The changes were demonstrated in a demo to Kim Clayden


[AUT-2646]: https://govukverify.atlassian.net/browse/AUT-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ