### PR TITLE
Bau/remove email from interventions response

### DIFF
--- a/src/components/account-intervention/types.ts
+++ b/src/components/account-intervention/types.ts
@@ -11,7 +11,6 @@ export interface AccountInterventionsInterface {
 }
 
 export interface AccountInterventionStatus extends DefaultApiResponse {
-  email: string;
   passwordResetRequired: boolean;
   blocked: boolean;
   temporarilySuspended: boolean;

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -74,7 +74,6 @@ export function verifyCodePost(
     }
 
     let nextEvent;
-    let accountInterventionsResponse;
 
     switch (options.notificationType) {
       case NOTIFICATION_TYPE.VERIFY_EMAIL:
@@ -101,7 +100,7 @@ export function verifyCodePost(
         (nextEvent === USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED &&
           options.journeyType === JOURNEY_TYPE.PASSWORD_RESET_MFA)
       ) {
-        accountInterventionsResponse =
+        const accountInterventionsResponse =
           await accountInterventionsService.accountInterventionStatus(
             sessionId,
             email,

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -21,7 +21,6 @@ export const setupAccountInterventionsResponse = (
     .post(API_ENDPOINTS.ACCOUNT_INTERVENTIONS)
     .once()
     .reply(HTTP_STATUS_CODES.OK, {
-      email: "joe.bloggs@test.com",
       passwordResetRequired: flags.passwordResetRequired,
       blocked: flags.blocked,
       temporarilySuspended: flags.temporarilySuspended,
@@ -51,7 +50,6 @@ export function accountInterventionsFakeHelper(
   return {
     accountInterventionStatus: sinon.fake.returns({
       data: {
-        email: "joe.bloggs@test.com",
         passwordResetRequired: flags.passwordResetRequired,
         blocked: flags.blocked,
         temporarilySuspended: flags.temporarilySuspended,


### PR DESCRIPTION
## What

* Removes an unused field from the account interventions response to prevent confusion
* Minor refactor

## How to review

1. Code Review
