### PR TITLE
BAU: Add STUB_HOSTNAME as a required env var

### DIFF
--- a/dev-check-environment.js
+++ b/dev-check-environment.js
@@ -15,6 +15,7 @@ describe("environment", function () {
     "SMARTAGENT_API_URL",
     "SMARTAGENT_WEBFORM_ID",
     "URL_FOR_SUPPORT_LINKS",
+    "STUB_HOSTNAME",
   ];
 
   requiredEnvVars.forEach((envVar) => {


### PR DESCRIPTION
## What

Adds `STUB_HOSTNAME` to the array of environment variables that should be both defined and not empty. It is already included in `.env.authdev1` and `.env.build` 

## How to review

1. Code Review
