### PR TITLE
Aut 2602/fix lockout units

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -26,7 +26,11 @@ import {
   renderBadRequest,
 } from "../../utils/validation";
 import { getNewCodePath } from "../security-code-error/security-code-error-controller";
-import { isLocked, timestampNMinutesFromNow } from "../../utils/lock-helper";
+import {
+  isLocked,
+  timestampNMinutesFromNow,
+  timestampNSecondsFromNow,
+} from "../../utils/lock-helper";
 
 export const RE_ENTER_EMAIL_TEMPLATE =
   "enter-email/index-re-enter-email-account.njk";
@@ -238,7 +242,7 @@ function handleBadRequest(
 function setUpAuthAppLocks(req: any, lockoutArray: LockoutInformation[]) {
   lockoutArray.forEach(function (lockoutInformation) {
     if (lockoutInformation.lockType == "codeBlock") {
-      const lockTime = timestampNMinutesFromNow(
+      const lockTime = timestampNSecondsFromNow(
         parseInt(lockoutInformation.lockTTL)
       );
       switch (lockoutInformation.journeyType) {

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -9,7 +9,7 @@ import {
   enterEmailGet,
   enterEmailPost,
 } from "../enter-email-controller";
-import { EnterEmailServiceInterface } from "../types";
+import { EnterEmailServiceInterface, LockoutInformation } from "../types";
 import { JOURNEY_TYPE, ERROR_CODES } from "../../common/constants";
 import { PATH_NAMES } from "../../../app.constants";
 import { SendNotificationServiceInterface } from "../../common/send-notification/types";
@@ -24,6 +24,8 @@ import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
 describe("enter email controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
+  let clock: sinon.SinonFakeTimers;
+  const date = new Date(2024, 1, 1);
 
   beforeEach(() => {
     req = mockRequest({
@@ -32,9 +34,13 @@ describe("enter email controller", () => {
       i18n: { language: "en" },
     });
     res = mockResponse();
+    clock = sinon.useFakeTimers({
+      now: date.valueOf(),
+    });
   });
 
   afterEach(() => {
+    clock.restore();
     sinon.restore();
   });
 
@@ -160,6 +166,41 @@ describe("enter email controller", () => {
       await enterEmailPost(fakeService)(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ACCOUNT_NOT_FOUND);
+      expect(fakeService.userExists).to.have.been.calledOnce;
+    });
+
+    it("should set a lock with the correct timestamp when the response contains lockout information", async () => {
+      const lockTTlInSeconds = 60;
+
+      const lockoutInformation: LockoutInformation = {
+        lockType: "codeBlock",
+        lockTTL: lockTTlInSeconds.toString(),
+        journeyType: "SIGN_IN",
+        mfaMethodType: "SMS",
+      };
+      const fakeService: EnterEmailServiceInterface = {
+        userExists: sinon.fake.returns({
+          success: true,
+          data: {
+            doesUserExist: true,
+            lockoutInformation: [lockoutInformation],
+          },
+        }),
+      } as unknown as EnterEmailServiceInterface;
+
+      req.body.email = "test@test.com";
+      res.locals.sessionId = "sadl990asdald";
+      req.path = PATH_NAMES.ENTER_EMAIL_SIGN_IN;
+
+      await enterEmailPost(fakeService)(req as Request, res as Response);
+
+      const expectedLockTime = new Date(
+        date.getTime() + lockTTlInSeconds * 1000
+      ).toUTCString();
+
+      expect(req.session.user.wrongCodeEnteredLock).to.eq(expectedLockTime);
+
+      expect(res.redirect).to.have.calledWith("/enter-password");
       expect(fakeService.userExists).to.have.been.calledOnce;
     });
 

--- a/src/utils/lock-helper.ts
+++ b/src/utils/lock-helper.ts
@@ -2,6 +2,10 @@ export function timestampNMinutesFromNow(numberOfMinutes: number) {
   return new Date(Date.now() + numberOfMinutes * 60000).toUTCString();
 }
 
+export function timestampNSecondsFromNow(numberOfSeconds: number) {
+  return new Date(Date.now() + numberOfSeconds * 1000).toUTCString();
+}
+
 export function isLocked(maybeLockTimestamp?: string) {
   return (
     maybeLockTimestamp &&

--- a/test/unit/utils/lock-helper.test.ts
+++ b/test/unit/utils/lock-helper.test.ts
@@ -3,6 +3,7 @@ import { describe } from "mocha";
 import {
   isLocked,
   timestampNMinutesFromNow,
+  timestampNSecondsFromNow,
 } from "../../../src/utils/lock-helper";
 import sinon from "sinon";
 describe("lockout-helper", () => {
@@ -34,6 +35,27 @@ describe("lockout-helper", () => {
 
       TEST_SCENARIO_PARAMS.forEach((params) => {
         expect(timestampNMinutesFromNow(params.numberOfMinutes)).to.eq(
+          params.expectedTimestamp
+        );
+      });
+    });
+  });
+
+  describe("timestampNSecondsFromNow", () => {
+    it("should return the correct timestamp from the current datetime", () => {
+      const TEST_SCENARIO_PARAMS = [
+        {
+          numberOfSeconds: 60,
+          expectedTimestamp: "Thu, 01 Feb 2024 00:01:00 GMT",
+        },
+        {
+          numberOfSeconds: 1,
+          expectedTimestamp: "Thu, 01 Feb 2024 00:00:01 GMT",
+        },
+      ];
+
+      TEST_SCENARIO_PARAMS.forEach((params) => {
+        expect(timestampNSecondsFromNow(params.numberOfSeconds)).to.eq(
           params.expectedTimestamp
         );
       });


### PR DESCRIPTION
## What

On the backend, we handle locks in seconds. On the frontend, we largely treat them as minutes. In a recent change, we started reading locks from the backend in a small number of cases, in order to ensure they were locked in the session. However, there was a mismatch - we were assuming the backend time to live was also in seconds.

This corrects this mismatch.

## How to review

1. Code Review

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
