### PR TITLE
AUT-2021: Change content on 'No GOV.UK One Login found' screens

### DIFF
--- a/src/components/account-not-found/index-mandatory.njk
+++ b/src/components/account-not-found/index-mandatory.njk
@@ -20,6 +20,8 @@
     <span class="govuk-body govuk-!-font-weight-bold">{{email}}</span>
 </p>
 
+<p class="govuk-body">{{ 'pages.accountNotFoundMandatory.paragraph2' | translate }}</p>
+
 {% set insetTextHtml %}
 <p class="govuk-body">{{'pages.accountNotFoundMandatory.insetText1' | translate}}</p>
 {% endset %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -225,20 +225,21 @@
       "paragraph2": "Arhoswch 2 awr a mynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
     },
     "accountNotFoundOneLogin": {
-      "title": "Ni ddarganfyddwyd GOV.UK One Login",
-      "header": "Ni ddarganfyddwyd GOV.UK One Login",
+      "title": "Nid oes gennych GOV.UK One Login",
+      "header": "Nid oes gennych GOV.UK One Login",
       "paragraph1": "Nid oes GOV.UK One Login ar gyfer ",
       "insetText1": "Mae GOV.UK One Login yn newydd. Nid yw yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma.",
-      "paragraph2": "Os ydych chi’n ceisio cael mynediad i’ch cyfrif ar gyfer gwasanaeth y llywodraeth, fel Credyd Cynhwysol neu’ch cyfrif treth personol, mewngofnodwch i’ch cyfrif ar gyfer y gwasanaeth hwnnw.",
+      "paragraph2": "Os ydych yn ceisio cael mynediad at wasanaeth y llywodraeth, fel Credyd Cynhwysol, bydd angen i chi fynd i’r gwasanaeth hwnnw i fewngofnodi.",
       "signInToServiceButtonText": "Mewngofnodi i wasanaeth",
       "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",
       "tryAnotherLinkHref": "/enter-email-existing-account"
     },
     "accountNotFoundMandatory": {
-      "title": "Ni ddarganfyddwyd GOV.UK One Login",
-      "header": "Ni ddarganfyddwyd GOV.UK One Login",
+      "title": "Nid oes gennych GOV.UK One Login",
+      "header": "Nid oes gennych GOV.UK One Login",
       "paragraph1": "Nid oes GOV.UK One Login ar gyfer ",
-      "insetText1": "Mae GOV.UK One Login yn newydd. Nid yw yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma, er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol.",
+      "paragraph2": "Bydd angen i chi greu GOV.UK One Login i ddefnyddio’r gwasanaeth hwn.",
+      "insetText1": "Ar hyn o bryd, mae cyfrifon ar wahân ar gyfer mewngofnodi i wahanol wasanaethau’r llywodraeth.",
       "createAccountButtonText": "Creu GOV.UK One Login",
       "createAccountButtonHref": "/enter-email",
       "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -225,20 +225,21 @@
       "paragraph2": "Wait 2 hours and go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage."
     },
     "accountNotFoundOneLogin": {
-      "title": "No GOV.UK One Login found",
-      "header": "No GOV.UK One Login found",
+      "title": "You do not have a GOV.UK One Login",
+      "header": "You do not have a GOV.UK One Login",
       "paragraph1": "There is no GOV.UK One Login for ",
-      "insetText1": "GOV.UK One Login is new. It does not work with all government accounts or services yet.",
-      "paragraph2": "If you’re trying to access your account for a government service, such as Universal Credit or your personal tax account, sign in to your account for that service.",
+      "insetText1": "GOV.UK One Login is new. You cannot use it to access all government accounts or services yet.",
+      "paragraph2": "If you’re trying to access a government service, such as Universal Credit, you’ll need to go to that service to sign in.",
       "signInToServiceButtonText": "Sign in to a service",
       "tryAnotherLinkText": "Try another email address",
       "tryAnotherLinkHref": "/enter-email-existing-account"
     },
     "accountNotFoundMandatory": {
-      "title": "No GOV.UK One Login found",
-      "header": "No GOV.UK One Login found",
+      "title": "You do not have a GOV.UK One Login",
+      "header": "You do not have a GOV.UK One Login",
       "paragraph1": "There is no GOV.UK One Login for ",
-      "insetText1": "GOV.UK One Login is new. It does not work with all government accounts or services yet, for example Government Gateway or Universal Credit.",
+      "paragraph2": "You’ll need to create a GOV.UK One Login to use this service.",
+      "insetText1": "At the moment, there are separate accounts for signing in to different government services.",
       "createAccountButtonText": "Create a GOV.UK One Login",
       "createAccountButtonHref": "/enter-email",
       "tryAnotherLinkText": "Try another email address",


### PR DESCRIPTION
## What

Remove references to Personal Tax Account and introduce additional changes identified in recent user research. 

While working on this change I've identified an additional page not covered by the Jira ticket that will be presented if the `req.session.client.serviceType` is "OPTIONAL". I am working with Tech Lead and UCD to determine if a new ticket is needed to update that page.

### Screenshots

<details>
<summary>Coming from a government service (English)</summary>

<img width="519" alt="Coming from a government service - English" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/141e430b-e0ab-43e3-bf36-817e6eaabbc5">


</details>

<details>
<summary>Coming from a government service (Welsh)</summary>

<img width="520" alt="Coming from a government service - Welsh" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/76d613cf-2f59-44ca-bcf9-6de283244ac7">


</details>

<details>
<summary>Coming from One Login sign in (English)</summary>

<img width="518" alt="Coming from One Login sign in - English" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1d76cca6-7a59-4191-ab3a-01c89c192c44">

</details>

<details>
<summary>Coming from One Login sign in (Welsh)</summary>

<img width="519" alt="Coming from One Login sign in - Welsh" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/b2138bef-075c-4ecd-80a1-01e9e704d01d">

</details>

## How to review

1. Code Review
2. Run frontend from this branch

### Testing the journey for users coming from One Login

1. Try to sign in with a non-existent email
2. Set a breakpoint in `accountNotFoundGet`
3. While the debugger has paused execution, set the value of `req.session.client.isOneLoginService` to `true`
4. Resume execution and confirm that the page shows the updated content

### Testing the journey for users coming from a government service

1. Try to sign in with a non-existent email
2. Set a breakpoint in `accountNotFoundGet`
3. While the debugger has paused execution, set the value of `req.session.client.serviceType` to `"OPTIONAL"`
4. Resume execution and confirm that the page shows the updated content

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Acceptance tests have been updated

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made (Note: I am discussing this with QA and will update any Acceptance Tests before merging)
