### PR TITLE
Bau/fix extending lock timeouts

### DIFF
--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -25,7 +25,7 @@ describe("enter email controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
   let clock: sinon.SinonFakeTimers;
-  const date = new Date(2024, 1, 1);
+  const date = new Date(Date.UTC(2024, 1, 1));
 
   beforeEach(() => {
     req = mockRequest({

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -70,9 +70,11 @@ export function securityCodeTriesExceededGet(
   req: Request,
   res: Response
 ): void {
-  req.session.user.codeRequestLock = timestampNMinutesFromNow(
-    getCodeRequestBlockDurationInMinutes()
-  );
+  if (!isLocked(req.session.user.codeRequestLock)) {
+    req.session.user.codeRequestLock = timestampNMinutesFromNow(
+      getCodeRequestBlockDurationInMinutes()
+    );
+  }
 
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -13,7 +13,7 @@ import {
   support2hrLockout,
 } from "../../config";
 import { UserSession } from "../../types";
-import { timestampNMinutesFromNow } from "../../utils/lock-helper";
+import { isLocked, timestampNMinutesFromNow } from "../../utils/lock-helper";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
   const actionType = req.query.actionType;
@@ -25,20 +25,26 @@ export function securityCodeInvalidGet(req: Request, res: Response): void {
     .map((e) => e.valueOf())
     .includes(actionType.toString());
 
-  if (!isEmailCode) {
+  if (!isEmailCode && !isLocked(req.session.user.wrongCodeEnteredLock)) {
     req.session.user.wrongCodeEnteredLock = timestampNMinutesFromNow(
       getCodeEnteredWrongBlockDurationInMinutes()
     );
   }
 
-  if (actionType === SecurityCodeErrorType.ChangeSecurityCodesEmailMaxRetries) {
+  if (
+    actionType === SecurityCodeErrorType.ChangeSecurityCodesEmailMaxRetries &&
+    !isLocked(req.session.user.wrongCodeEnteredAccountRecoveryLock)
+  ) {
     req.session.user.wrongCodeEnteredAccountRecoveryLock =
       timestampNMinutesFromNow(
         getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes()
       );
   }
 
-  if (actionType === SecurityCodeErrorType.InvalidPasswordResetCodeMaxRetries) {
+  if (
+    actionType === SecurityCodeErrorType.InvalidPasswordResetCodeMaxRetries &&
+    !isLocked(req.session.user.wrongCodeEnteredPasswordResetLock)
+  ) {
     req.session.user.wrongCodeEnteredPasswordResetLock =
       timestampNMinutesFromNow(
         getPasswordResetCodeEnteredWrongBlockDurationInMinutes()

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -448,7 +448,7 @@ describe("security code controller", () => {
     describe("securityCodeTriesExceededGet", () => {
       let clock: sinon.SinonFakeTimers;
       const date = new Date(Date.UTC(2024, 0, 1, 0));
-      before(() => {
+      beforeEach(() => {
         clock = sinon.useFakeTimers({
           now: date.valueOf(),
         });
@@ -554,6 +554,20 @@ describe("security code controller", () => {
           );
         }
       );
+
+      it("should not extend a lock that already exists", () => {
+        req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
+
+        const dateInTheFuture = new Date(
+          date.getTime() + 1 * 1000
+        ).toUTCString();
+
+        req.session.user.codeRequestLock = dateInTheFuture;
+
+        securityCodeTriesExceededGet(req as Request, res as Response);
+
+        expect(req.session.user.codeRequestLock).to.eq(dateInTheFuture);
+      });
     });
   });
 });

--- a/test/unit/utils/lock-helper.test.ts
+++ b/test/unit/utils/lock-helper.test.ts
@@ -8,7 +8,7 @@ import {
 import sinon from "sinon";
 describe("lockout-helper", () => {
   let clock: sinon.SinonFakeTimers;
-  const date = new Date(2024, 1, 1);
+  const date = new Date(Date.UTC(2024, 1, 1));
   before(() => {
     clock = sinon.useFakeTimers({
       now: date.valueOf(),


### PR DESCRIPTION
## What

If someone refreshes a security error page that implements locking within the controller method, their session lockout is refreshed. We want to ensure that an existing session lockout does not get overwritten by a new lockout, thereby extending the total duration of the session lockout.

This also contains:
* Some missing tests added to check existing locking behaviour
* A fix to a date constructed in tests that caused the test to fail if a user's system timezone was different.

## How to review

1. Code Review
