### PR TITLE
AUT-2575: copy update to sign in or create page

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -19,7 +19,11 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate }}</h1>
 
-    <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph1' | translate }}</p>
+
+    <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph2' | translate }}</p>
+
+    <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph3' | translate }}</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
           <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
@@ -60,9 +64,11 @@
 
     </form>
 
-    {{ govukDetails({
-        summaryText: 'pages.signInOrCreate.moreAbout.header' | translate,
-        html: moreAboutTextHtml
-    }) }}
+    <p>
+        
+        <a href="{{ 'pages.signInOrCreate.aboutLink' | translate }}" class="govuk-link" rel="noreferrer" target="_blank">
+            {{ 'pages.signInOrCreate.aboutLinkText' | translate }}
+        </a>
+    </p>
 
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -159,14 +159,16 @@
   "pages": {
     "signInOrCreate": {
       "mandatory": {
-        "title": "Creu GOV.UK One Login neu fewngofnodi",
-        "header": "Creu GOV.UK One Login neu fewngofnodi"
+        "title": "Creu eich GOV.UK One Login neu fewngofnodi",
+        "header": "Creu eich GOV.UK One Login neu fewngofnodi"
       },
       "optional": {
         "title": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd",
         "header": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd"
       },
-      "paragraph": "Byddwch angen:",
+      "paragraph1": "Gallwch ddefnyddio eich GOV.UK One Login i gael mynediad at rai gwasanaethau’r llywodraeth.",
+      "paragraph2": "Yn y dyfodol, gallwch ei ddefnyddio i gael mynediad i bob gwasanaeth ar GOV.UK.",
+      "paragraph3": "Byddwch angen:",
       "bullet1": "cyfeiriad e-bost",
       "bullet2": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu’n ap dilysydd",
       "insetAlternativeLanguage": {
@@ -179,13 +181,9 @@
         "linkHref": "?lng=en"
       },
       "signInText": "Fewngofnodi",
-      "moreAbout": {
-        "header": "Am GOV.UK One Login",
-        "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond ei ddefnyddio i gael mynediad i rai gwasanaethau’r llywodraeth.",
-        "paragraph2": "Nid yw’n gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
-        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio GOV.UK One Login i gael mynediad i’r holl wasanaethau ar GOV.UK."
-      },
-      "createButtonText": "Creu GOV.UK One Login"
+      "aboutLinkText": "Gwasanaethau y gallwch eu defnyddio gyda GOV.UK One Login (agor mewn tab newydd)",
+      "aboutLink": "https://www.gov.uk/using-your-gov-uk-one-login/services",
+      "createButtonText": "Creu eich GOV.UK One Login"
     },
     "enterEmailCreateAccount": {
       "title": "Rhowch eich cyfeiriad e-bost",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -159,14 +159,16 @@
   "pages": {
     "signInOrCreate": {
       "mandatory": {
-        "title": "Create a GOV.UK One Login or sign in",
-        "header": "Create a GOV.UK One Login or sign in"
+        "title": "Create your GOV.UK One Login or sign in",
+        "header": "Create your GOV.UK One Login or sign in"
       },
       "optional": {
         "title": "Create a GOV.UK One Login or sign in to save your progress",
         "header": "Create a GOV.UK One Login or sign in to save your progress"
       },
-      "paragraph": "You’ll need:",
+      "paragraph1": "You can use your GOV.UK One Login to access some government services.",
+      "paragraph2": "In the future, you’ll be able to use it to access all services on GOV.UK.",
+      "paragraph3": "You’ll need:",
       "bullet1": "an email address",
       "bullet2": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
@@ -179,13 +181,9 @@
         "linkHref": "?lng=cy"
       },
       "signInText": "Sign in",
-      "moreAbout": {
-        "header": "About GOV.UK One Login",
-        "paragraph1": "GOV.UK One Login is new. At the moment you can only use it to access some government services.",
-        "paragraph2": "It does not work with all government accounts or services yet (for example Government Gateway or Universal Credit).",
-        "paragraph3": "In the future, you’ll be able to use GOV.UK One Login to access all services on GOV.UK."
-      },
-      "createButtonText": "Create a GOV.UK One Login"
+      "aboutLinkText": "Services you can use with GOV.UK One Login (opens in new tab)",
+      "aboutLink": "https://www.gov.uk/using-your-gov-uk-one-login/services",
+      "createButtonText": "Create your GOV.UK One Login"
     },
     "enterEmailCreateAccount": {
       "title": "Enter your email address",


### PR DESCRIPTION
## What

Update the content of the 'Create or sign in' screen

## How to review

1. Code Review
2. Run locally
3. Validate create or sign in page

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they are aware of changes and behaviours (for example, how error screens appear and whether invalid entries can be amended), and can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated


## Screenshots

### English

<img width="441" alt="Screenshot 2024-04-10 at 09 41 30" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/6072b6b6-fd96-4d78-855d-076a66b0f42a">


### Welsh

<img width="441" alt="Screenshot 2024-04-10 at 09 41 49" src="https://github.com/govuk-one-login/authentication-frontend/assets/144702012/521c44d4-6152-42c1-8ada-ee8b5a3f651c">
