### PR TITLE
AUT-2697: Need two endpoints for the or statement here

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -265,7 +265,11 @@ variable "alb_idle_timeout" {
 variable "rate_limited_endpoints" {
   description = "List of endpoints that should be rate limited by session and IP"
   type        = list(string)
-  default     = []
+  default     = ["/dummy-77349847-9ce0-499c-b378-6d9b49a24d6a", "/dummy-168a5a48-62f9-44b1-b9ea-d4c8a74b8498"] # default to two uuids, which are not real endpoints. This prevents us from having an empty or statement
+  validation {
+    condition     = length(var.rate_limited_endpoints) < 2
+    error_message = "rate_limited_endpoints must contain at least two endpoints. If you only have one endpoint, add a non-existent dummy, eg. `/dummy-77349847-9ce0-499c-b378-6d9b49a24d6a`"
+  }
 }
 
 variable "rate_limited_endpoints_rate_limit_period" {


### PR DESCRIPTION
## What

The `or` statement needs at least two endpoints to work.

- Update the default to a list of two uuids (non-existant routes)

- Add a validation rule to catch this problem before running the terraform

## How to review

- Code Review
