### PR TITLE
AUT-2393: Axios upgrade from 0.25.0 to 0.1.6.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-base32-enc-dec": "^12.0.1",
     "aws-sdk": "^2.1356.0",
-    "axios": "^0.25.0",
+    "axios": "^1.6.8",
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.5",
     "copyfiles": "^2.4.1",

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -9,8 +9,8 @@ export class BadRequestError extends Error {
 
 export class ApiError extends Error {
   private status?: number;
-  private data?: string;
-  constructor(message: string, status?: number, data?: string) {
+  private data?: unknown;
+  constructor(message: string, status?: number, data?: unknown) {
     super(message);
     this.data = data;
     this.status = status;

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -10,7 +10,9 @@ import { ApiResponseResult } from "../types";
 import { HTTP_STATUS_CODES } from "../app.constants";
 import { ApiError } from "./error";
 
-const headers: AxiosRequestHeaders = {
+interface CustomAxiosRequestHeaders extends Partial<AxiosRequestHeaders> {}
+
+const headers: CustomAxiosRequestHeaders = {
   Accept: "application/json",
   "Content-Type": "application/json; charset=utf-8",
   "Access-Control-Allow-Credentials": "true",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,12 +1816,14 @@ aws-sdk@^2.1356.0:
     uuid "8.0.0"
     xml2js "0.6.2"
 
-axios@^0.25.0:
-  version "0.25.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz"
-  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+axios@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
+  integrity sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==
   dependencies:
-    follow-redirects "^1.14.7"
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2882,7 +2884,7 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz"
   integrity sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
 
-follow-redirects@^1.14.7:
+follow-redirects@^1.15.6:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
@@ -4199,6 +4201,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.8.0"


### PR DESCRIPTION
## What

Bumps [axios](https://github.com/axios/axios) from 0.25.0 to 1.6.8.

### Release notes:
**Bug Fixes**

- AxiosHeaders: fix AxiosHeaders conversion to an object during config merging (https://github.com/axios/axios/issues/6243) ([2656612](https://github.com/axios/axios/commit/2656612bc10fe2757e9832b708ed773ab340b5cb))
- import: use named export for EventEmitter; ([7320430](https://github.com/axios/axios/commit/7320430aef2e1ba2b89488a0eaf42681165498b1))
- vulnerability: update follow-redirects to 1.15.6 (https://github.com/axios/axios/issues/6300) ([8786e0f](https://github.com/axios/axios/commit/8786e0ff55a8c68d4ca989801ad26df924042e27))
