### PR TITLE
AUT-2707: Fix issue with link on landing page

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -64,9 +64,8 @@
 
     </form>
 
-    <p>
-        
-        <a href="{{ 'pages.signInOrCreate.aboutLink' | translate }}" class="govuk-link" rel="noreferrer" target="_blank">
+    <p class="govuk-body">
+        <a href="{{ 'pages.signInOrCreate.aboutLink' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
             {{ 'pages.signInOrCreate.aboutLinkText' | translate }}
         </a>
     </p>


### PR DESCRIPTION
## What

This commit:

- Fixes a text sizing issue that has been raised by UCD colleagues this afternoon
- Adds 'noopener' to the rel attribute to reduce the risk of reverse tabnabbing (as described in the [GOV.UK Design System](https://design-system.service.gov.uk/styles/links/#opening-links-in-a-new-tab))

## How to review

1. Code Review
2. Run frontend via this branch to confirm that the link text size is correct (i.e. matches that of other text) and the relevant properties are present in the `rel` attribute. 

## Checklist

- [ ] A UCD review has been performed.
