### PR TITLE
BAU: Fix issue with landing page heading text wrap

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -17,7 +17,7 @@
 {% block content %}
     {% include "common/errors/errorSummary.njk" %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate | striptags | safe }} </h1>
 
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph1' | translate }}</p>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -160,7 +160,7 @@
     "signInOrCreate": {
       "mandatory": {
         "title": "Creu eich GOV.UK One Login neu fewngofnodi",
-        "header": "Creu eich GOV.UK One Login neu fewngofnodi"
+        "header": "Creu eich GOV.UK One&nbsp;Login neu fewngofnodi"
       },
       "optional": {
         "title": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -160,7 +160,7 @@
     "signInOrCreate": {
       "mandatory": {
         "title": "Create your GOV.UK One Login or sign in",
-        "header": "Create your GOV.UK One Login or sign in"
+        "header": "Create your GOV.UK One&nbsp;Login or sign&nbsp;in"
       },
       "optional": {
         "title": "Create a GOV.UK One Login or sign in to save your progress",


### PR DESCRIPTION
## What

Fixes an issue raised by UCD where the word "in" had been appearing on a line alone following a recent content change. This has been fixed by introducing non-breaking space HTML entities to ensure the words in 'sign in' and 'One Login' do not split across lines as text wraps across different screen sizes. 

By default, Nunjucks escapes HTML entities so I've introduced the 'safe' filter in conjunction with 'striptags' for this element.

## Screenshots

### Before

<details>

<summary>"in" appears alone on second line</summary>

<img width="980" alt="Screenshot 2024-04-18 at 15 30 25" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/94cb789f-d0d2-42b7-8eda-97a60224f780">
</details>

### After

<details>

<summary>Initial wrap (largest screen) - "sign in" appears on second line</summary>
<img width="974" alt="Screenshot 2024-04-18 at 15 35 04" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/a589f1b1-f3db-4314-9aec-c163e175c974">

</details>

<details>

<summary>Second wrap point - "or" joins "sign in" on second line</summary>

<img width="780" alt="Screenshot 2024-04-18 at 15 35 24" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/e00176e6-f2a4-428e-bee2-9e29086f4b5c">

</details>


<details>

<summary>Third wrap point - "One Login" joins "or sign in" on second line</summary>

<img width="769" alt="Screenshot 2024-04-18 at 15 35 40" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/6ff8dc6c-e2a5-43b3-b437-12be2cb23834">

</details>


<details>

<summary>Breakpoint - heading appears on one line as container width increases and text size reduces</summary>

<img width="610" alt="Screenshot 2024-04-18 at 15 36 00" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1e122e73-b95b-434d-95fd-af4021b22d8a">


</details>


## How to review

1. Code Review
1. Run the branch locally and visit the "Create your GOV.UK One Login or sign in"
1. Change the size of the browser window to confirm that neither "One Login" or "sign in" split across lines as the heading text wraps.

## Checklist

- [x] A UCD review has been performed.

