### PR TITLE
AUTH-2655 Initial cloud-front resource creation

### DIFF
--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -1,0 +1,42 @@
+resource "aws_cloudformation_stack" "cloudfront" {
+  count = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name  = "${var.environment}-auth-fe-cloudfront"
+  #using fixed version of template for now 
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-distribution/template.yaml?versionId=7ocAAm29iU.S.por3ZU8zQMDNCHr1lYf"
+
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+
+  parameters = {
+    AddWWWPrefix                   = var.Add_WWWPrefix
+    ApplyCloakingHeaderWAFToOrigin = var.Apply_CloakingHeader_WAFToOrigin
+    CloudFrontCertArn              = aws_acm_certificate.cloudfront_frontend_certificate[0].arn
+    CloudfrontWafAcl               = aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl[0].arn
+    DistributionAlias              = local.frontend_fqdn
+    FraudHeaderEnabled             = var.Fraud_Header_Enabled
+    OriginCloakingHeader           = var.auth_origin_cloakingheader
+    OriginResourceArn              = aws_lb.frontend_alb.id
+    OriginWafAcl                   = "none"
+    PreviousOriginCloakingHeader   = var.previous_auth_origin_cloakingheader
+    StandardLoggingEnabled         = true
+  }
+  depends_on = [aws_acm_certificate.cloudfront_frontend_certificate, aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl, aws_lb.frontend_alb]
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudformation_stack" "cloudfront-monitoring" {
+  count        = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  provider     = aws.cloudfront
+  name         = "${var.environment}-auth-fe-cloudfront-monitoring"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-monitoring-alarm/template.yaml?z=${timestamp()}"
+
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+
+  parameters = {
+    CacheHitAlarmSNSTopicARN            = aws_sns_topic.slack_events[0].arn
+    CloudFrontAdditionaldMetricsEnabled = false
+    CloudfrontDistribution              = aws_cloudformation_stack.cloudfront[0].outputs["DistributionId"]
+  }
+  depends_on = [aws_cloudformation_stack.cloudfront]
+  tags       = local.default_tags
+}

--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -8,9 +8,10 @@ locals {
 
   account_management_fqdn = var.environment == "production" ? "home.account.gov.uk" : "home.${var.environment}.account.gov.uk"
 
-  frontend_fqdn     = "signin.${local.service_domain}"
-  frontend_api_fqdn = "auth.${local.service_domain}"
-  oidc_api_fqdn     = "oidc.${local.service_domain}"
+  frontend_fqdn        = "signin.${local.service_domain}"
+  frontend_api_fqdn    = "auth.${local.service_domain}"
+  oidc_api_fqdn        = "oidc.${local.service_domain}"
+  frontend_fqdn_origin = "origin.signin.${local.service_domain}"
 }
 
 data "aws_route53_zone" "service_domain" {

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -83,3 +83,58 @@ resource "aws_acm_certificate_validation" "frontend_acm_alb_certificate_validati
 output "signin_nameservers" {
   value = aws_route53_zone.zone.name_servers
 }
+
+#DNS Record for cloufront origin Domain & TLS certificate
+
+resource "aws_route53_record" "Cloudfront_frontend_record" {
+  count   = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name    = local.frontend_fqdn_origin
+  type    = "A"
+  zone_id = aws_route53_zone.zone.zone_id
+
+  alias {
+    evaluate_target_health = false
+    name                   = "dualstack.${aws_lb.frontend_alb.dns_name}"
+    zone_id                = aws_lb.frontend_alb.zone_id
+  }
+}
+
+resource "aws_acm_certificate" "cloudfront_frontend_certificate" {
+  provider          = aws.cloudfront
+  count             = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  domain_name       = aws_route53_record.frontend.name
+  validation_method = "DNS"
+
+  tags = local.default_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cloudfront_frontend_certificate_validation" {
+  provider = aws.cloudfront
+  for_each = var.cloudfront_auth_frontend_enabled ? {
+    for dvo in aws_acm_certificate.cloudfront_frontend_certificate[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.zone.zone_id
+  depends_on      = [aws_acm_certificate.cloudfront_frontend_certificate]
+}
+
+resource "aws_acm_certificate_validation" "frontend_acm_cloudfront_certificate_validation" {
+  provider                = aws.cloudfront
+  count                   = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  certificate_arn         = aws_acm_certificate.cloudfront_frontend_certificate[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.cloudfront_frontend_certificate_validation : record.fqdn]
+  depends_on              = [aws_route53_record.cloudfront_frontend_certificate_validation]
+}

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -4,6 +4,7 @@ aws_region                    = "eu-west-2"
 account_management_fqdn       = "acc-mgmt-fg.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 oidc_api_fqdn                 = "oidc.sandpit.account.gov.uk"
 frontend_fqdn                 = "signin.sandpit.account.gov.uk"
+frontend_fqdn_origin          = "origin.signin.sandpit.account.gov.uk"
 frontend_api_fqdn             = "auth.sandpit.account.gov.uk"
 service_domain                = "sandpit.account.gov.uk"
 zone_id                       = "Z1031735QZMC84WYW1TP"
@@ -15,9 +16,15 @@ support_authorize_controller  = "1"
 support_account_interventions = "1"
 support_2fa_b4_password_reset = "1"
 
+
 frontend_task_definition_cpu     = 256
 frontend_task_definition_memory  = 512
 frontend_auto_scaling_v2_enabled = true
+
+#cloudfront varaibles
+cloudfront_auth_frontend_enabled    = true
+auth_origin_cloakingheader          = "dsxUBpHUdcOYUBICSm3LuxA4V6yKGkz0"
+previous_auth_origin_cloakingheader = "dsxUBpHUdcOYUBICSm3LuxA4V6yKGkz0"
 
 alb_idle_timeout = 30
 

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -24,6 +24,16 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias = "cloudfront"
+
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = var.deployer_role_arn
+  }
+}
+
 data "aws_availability_zones" "available" {}
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/sns.tf
+++ b/ci/terraform/sns.tf
@@ -1,0 +1,125 @@
+#This is  SNS topic created in us-east-1 region for cloudwatch Alarm for Cloudfront
+
+resource "aws_sns_topic" "slack_events" {
+  provider                         = aws.cloudfront
+  count                            = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name                             = "${var.environment}-cloudfront-alerts"
+  lambda_failure_feedback_role_arn = aws_iam_role.sns_logging_iam_role[0].arn
+
+  tags = local.default_tags
+}
+
+data "aws_iam_policy_document" "sns_topic_policy" {
+  version  = "2012-10-17"
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  statement {
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_sns_topic.slack_events[0].arn,
+    ]
+  }
+}
+
+resource "aws_sns_topic_policy" "sns_alert_policy" {
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  arn      = aws_sns_topic.slack_events[0].arn
+
+  policy = data.aws_iam_policy_document.sns_topic_policy[0].json
+}
+
+resource "aws_iam_role" "sns_logging_iam_role" {
+  provider           = aws.cloudfront
+  count              = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name_prefix        = "sns-failed-slack-alerts-role"
+  path               = "/${var.environment}/"
+  assume_role_policy = data.aws_iam_policy_document.sns_can_assume_policy[0].json
+
+  tags = local.default_tags
+}
+
+data "aws_iam_policy_document" "sns_can_assume_policy" {
+  version  = "2012-10-17"
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "sns.amazonaws.com"
+      ]
+      type = "Service"
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "sns_logging_policy" {
+  version  = "2012-10-17"
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "api_gateway_logging_policy" {
+  count       = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  provider    = aws.cloudfront
+  name_prefix = "sns-failed-alert-logging"
+  path        = "/${var.environment}/"
+  description = "IAM policy for logging failed SNS alerts"
+
+  policy = data.aws_iam_policy_document.sns_logging_policy[0].json
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_role_policy_attachment" "api_gateway_logging_logs" {
+  provider   = aws.cloudfront
+  count      = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  role       = aws_iam_role.sns_logging_iam_role[0].name
+  policy_arn = aws_iam_policy.api_gateway_logging_policy[0].arn
+}

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -2,6 +2,9 @@ environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
+
+cloudfront_auth_frontend_enabled = true
+
 frontend_auto_scaling_v2_enabled                    = true
 frontend_task_definition_cpu                        = 1024
 frontend_task_definition_memory                     = 2048

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -283,3 +283,46 @@ variable "rate_limited_endpoints_requests_per_period" {
   type        = number
   default     = 100000
 }
+
+#cloudfront varaible 
+variable "cloudfront_auth_frontend_enabled" {
+  type        = bool
+  default     = false
+  description = "Feature flag to control the creation cloudfront DNS record origin & Cloudfront Certificate"
+}
+
+variable "auth_origin_cloakingheader" {
+  type        = string
+  sensitive   = true
+  description = "This is header value for Cloufront to to verify requests are coming from the correct CloudFront distribution to ALB "
+}
+
+variable "previous_auth_origin_cloakingheader" {
+  type        = string
+  sensitive   = true
+  description = "This is previous header value when the value is rotated to ensure WAF will allow requests during rotation "
+}
+
+variable "Add_WWWPrefix" {
+  type        = bool
+  default     = false
+  description = "flag to to add subdomain (www) to the frontend url eg www.signin.sandpit.account.gov.uk"
+}
+
+variable "Apply_CloakingHeader_WAFToOrigin" {
+  type        = bool
+  default     = false
+  description = "flag to add a cloacking header WAf to ALB so only requiest comming from cloudfront are allowed "
+}
+
+variable "Fraud_Header_Enabled" {
+  type        = bool
+  default     = false
+  description = "flag to switch on Fraud header on cloudfront disturbution"
+}
+
+variable "Standard_Logging_Enabled" {
+  type        = bool
+  default     = false
+  description = "Enables Standard logging to push logs to S3 bucket"
+}

--- a/ci/terraform/waf-cf.tf
+++ b/ci/terraform/waf-cf.tf
@@ -1,0 +1,511 @@
+# The IP address blocks below are referenced from here:
+# https://sites.google.com/a/digital.cabinet-office.gov.uk/gds/working-at-gds/gds-internal-it/gds-internal-it-network-public-ip-addresses
+resource "aws_wafv2_ip_set" "cf_gds_ip_set" {
+  provider           = aws.cloudfront
+  count              = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name               = "${var.environment}-gds-ip-set"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV4"
+
+  addresses = [
+    "217.196.229.77/32",
+    "217.196.229.79/32",
+    "217.196.229.80/32", # (BYOD VPN Only)
+    "217.196.229.81/32",
+    "51.149.8.0/25",   # (GDS and CO VPN)
+    "51.149.8.128/29", # (BYOD VPN only)
+    "213.86.153.212/32",
+    "213.86.153.213/32",
+    "213.86.153.214/32",
+    "213.86.153.235/32",
+    "213.86.153.236/32",
+    "213.86.153.237/32",
+    "213.86.153.211/32",
+    "213.86.153.231/32",
+    # The following are Pentesters, requested on AUT-2360
+    "51.142.180.30/32",
+    "185.120.72.241/32",
+    "185.120.72.242/32",
+    "185.120.72.243/32",
+    # The following are Pentesters, requested on AUT-2596
+    "3.9.227.33/32",
+    "18.132.149.145/32"
+
+  ]
+
+  tags = local.default_tags
+}
+
+resource "aws_wafv2_web_acl" "frontend_cloudfront_waf_web_acl" {
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name     = "${var.environment}-frontend-cloudfront-waf-web-acl"
+  scope    = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  dynamic "rule" {
+    for_each = var.environment == "staging" ? [1] : []
+    content {
+      name     = "GDSIPs"
+      priority = 10
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement {
+          arn = aws_wafv2_ip_set.gds_ip_set.arn
+
+          ip_set_forwarded_ip_config {
+            fallback_behavior = "MATCH"
+            header_name       = "X-Forwarded-For"
+            position          = "FIRST"
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafGDSIPs"
+        sampled_requests_enabled   = false
+      }
+    }
+  }
+
+  rule {
+    action {
+      block {}
+    }
+    priority = 20
+    name     = "${var.environment}-frontend-cloudfront-waf-rate-based-rule"
+    statement {
+      rate_based_statement {
+        limit              = var.environment == "staging" ? 20000000 : 25000
+        aggregate_key_type = "IP"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafMaxRequestRate"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "BlockMoreThan100CheckYourEmailRequestsFromIPPer5Minutes"
+    priority = 21
+    rule_label {
+      name = "MoreThan100CheckYourEmailRequestsFromIPPer5Minutes"
+    }
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit                 = var.environment == "staging" ? 20000000 : var.rate_limited_endpoints_requests_per_period
+        evaluation_window_sec = var.rate_limited_endpoints_rate_limit_period
+        aggregate_key_type    = "IP"
+
+
+        scope_down_statement {
+          or_statement {
+            dynamic "statement" {
+              for_each = var.rate_limited_endpoints
+              content {
+                byte_match_statement {
+                  positional_constraint = "STARTS_WITH"
+                  search_string         = statement.value
+                  field_to_match {
+                    uri_path {}
+                  }
+                  text_transformation {
+                    priority = 0
+                    type     = "LOWERCASE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafMoreThan100CheckYourEmailRequestsFromIPPer5Minutes"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "BlockMoreThan100CheckYourEmailRequestsFromApsSessionPer5Minutes"
+    priority = 22
+
+    rule_label {
+      name = "MoreThan100CheckYourEmailRequestsFromApsSessionPer5Minutes"
+    }
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit                 = var.environment == "staging" ? 20000000 : var.rate_limited_endpoints_requests_per_period
+        evaluation_window_sec = var.rate_limited_endpoints_rate_limit_period
+        aggregate_key_type    = "CUSTOM_KEYS"
+        custom_key {
+          cookie {
+            name = "aps"
+            text_transformation {
+              priority = 0
+              type     = "URL_DECODE"
+            }
+          }
+        }
+        scope_down_statement {
+          or_statement {
+            dynamic "statement" {
+              for_each = var.rate_limited_endpoints
+              content {
+                byte_match_statement {
+                  positional_constraint = "STARTS_WITH"
+                  search_string         = statement.value
+                  field_to_match {
+                    uri_path {}
+                  }
+                  text_transformation {
+                    priority = 0
+                    type     = "LOWERCASE"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafMoreThan100CheckYourEmailRequestsFromApsSessionPer5Minutes"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    override_action {
+      none {}
+    }
+    priority = 30
+    name     = "${var.environment}-frontend-cloudfront-common-rule-set"
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name = "GenericRFI_QUERYARGUMENTS"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "SizeRestrictions_QUERYSTRING"
+          action_to_use {
+            count {}
+          }
+        }
+        dynamic "rule_action_override" {
+          for_each = var.environment != "production" ? ["1"] : []
+          content {
+            name = "EC2MetaDataSSRF_BODY"
+            action_to_use {
+              count {}
+            }
+          }
+        }
+        dynamic "rule_action_override" {
+          for_each = var.environment != "production" ? ["1"] : []
+          content {
+            name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+            action_to_use {
+              count {}
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    override_action {
+      none {}
+    }
+    priority = 40
+    name     = "${var.environment}-frontend-cloudfront-bad-rule-set"
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafBaduleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "default_query_param_limit"
+    priority = 50
+
+    action {
+      block {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          size_constraint_statement {
+            comparison_operator = "GT"
+            size                = 2048
+            field_to_match {
+              query_string {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+
+        statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                search_string         = "/authorize"
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "LOWERCASE"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafQueryParamSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "extended_query_param_limit"
+    priority = 60
+
+    action {
+      block {}
+    }
+
+    statement {
+      size_constraint_statement {
+        comparison_operator = "GT"
+        size                = 8192
+        field_to_match {
+          query_string {}
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafAuthorizeQueryParamSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "contact_us_logging_count"
+    priority = 90
+
+    action {
+      count {}
+    }
+
+    rule_label {
+      name = "contact-us"
+    }
+
+    statement {
+      byte_match_statement {
+        positional_constraint = "STARTS_WITH"
+        search_string         = "/contact-us"
+        field_to_match {
+          uri_path {}
+        }
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafContactUsCount"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${replace(var.environment, "-", "")}FrontendcloudfrontWafRules"
+    sampled_requests_enabled   = true
+  }
+
+  tags = local.default_tags
+}
+
+# Cloudwatch Logging for frontend Cloudfront WAF 
+# Adding Local variable for splunk Logging for US east region as 
+
+locals {
+  logging_endpoint_arns_us_east = "arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython"
+}
+
+data "aws_iam_policy_document" "frontend_cloudfront_cloudwatch" {
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  policy_id = "key-policy-cloudwatch"
+
+  statement {
+    sid = "Enable IAM User Permissions for root user"
+    actions = [
+      "kms:*",
+    ]
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowCloudWatchLogs"
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:Describe*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+    ]
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "logs.us-east-1.amazonaws.com",
+      ]
+    }
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "frontent_cloudfront_cw_log_encryption" {
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  description             = "KMS key for Core Cloudwatch logs"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.frontend_cloudfront_cloudwatch[0].json
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_log_group" "frontend_cloudfront_waf_log_group" {
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  name              = "aws-waf-logs-frontend-cloudfront-${var.environment}"
+  kms_key_id        = aws_kms_key.frontent_cloudfront_cw_log_encryption[0].arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = local.default_tags
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "frontend_cloudfront_waf_logging_config" {
+  provider = aws.cloudfront
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+
+  log_destination_configs = [aws_cloudwatch_log_group.frontend_cloudfront_waf_log_group[0].arn]
+  resource_arn            = aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl[0].arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+}
+
+
+resource "aws_cloudwatch_log_subscription_filter" "frontend_cloudfront_waf_subscription" {
+  provider = aws.cloudfront
+
+  count           = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  name            = "${aws_cloudwatch_log_group.frontend_cloudfront_waf_log_group[0].name}-splunk-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.frontend_cloudfront_waf_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = local.logging_endpoint_arns_us_east
+  depends_on      = [aws_cloudwatch_log_group.frontend_cloudfront_waf_log_group[0]]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}
+


### PR DESCRIPTION
## What

Initial cloud-front resource creation for AUTH 
This PR is to create a Cloud front resource for each Env with` cloudfront_auth_frontend_enabled = true` flag
Most of the resource for cloud front get created in region `us-east-1` 
 TLS certificate , DNS records for CF origin, SNS for Notification , WAF for Cloud front & Cloud-front distribution & monitoring 


## How to review

1. Code Review
  Deploy to sandpit with `./deploy-sandpit.sh -t -p ` 


