### PR TITLE
AUT-2733: Fix server sent consent cookie

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -38,7 +38,7 @@ function createConsentCookie(
   res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
     expires: consentCookieValue.expiry,
     secure: true,
-    httpOnly: true,
+    httpOnly: false,
     domain: res.locals.analyticsCookieDomain,
   });
 }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -152,7 +152,7 @@ export function authorizeGet(
         cookiesConsentService.createConsentCookieValue(cookieConsent);
 
       res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
-        expires: consentCookieValue.expiry,
+        expires: consentCookieValue.expires,
         secure: true,
         httpOnly: false,
         domain: res.locals.analyticsCookieDomain,

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -30,7 +30,7 @@ import { Claims } from "./claims-config";
 
 export function authorizeGet(
   authService: AuthorizeServiceInterface = authorizeService(),
-  cookieService: CookieConsentServiceInterface = cookieConsentService(),
+  cookiesConsentService: CookieConsentServiceInterface = cookieConsentService(),
   kmsService: KmsDecryptionServiceInterface = new KmsDecryptionService(),
   jwtService: JwtServiceInterface = new JwtService()
 ): ExpressRouteFunc {
@@ -149,7 +149,7 @@ export function authorizeGet(
 
     if (req.session.client.cookieConsentEnabled && cookieConsent) {
       const consentCookieValue =
-        cookieService.createConsentCookieValue(cookieConsent);
+        cookiesConsentService.createConsentCookieValue(cookieConsent);
 
       res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
         expires: consentCookieValue.expiry,

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -8,10 +8,7 @@ import {
 import { getNextPathAndUpdateJourney, ERROR_CODES } from "../common/constants";
 import { BadRequestError, QueryParamsError } from "../../utils/error";
 import { ExpressRouteFunc } from "../../types";
-import {
-  CookieConsentModel,
-  CookieConsentServiceInterface,
-} from "../common/cookie-consent/types";
+import { CookieConsentServiceInterface } from "../common/cookie-consent/types";
 import { cookieConsentService } from "../common/cookie-consent/cookie-consent-service";
 import { sanitize } from "../../utils/strings";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
@@ -30,18 +27,6 @@ import {
 } from "../../config";
 import { logger } from "../../utils/logger";
 import { Claims } from "./claims-config";
-
-function createConsentCookie(
-  res: Response,
-  consentCookieValue: CookieConsentModel
-) {
-  res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
-    expires: consentCookieValue.expiry,
-    secure: true,
-    httpOnly: false,
-    domain: res.locals.analyticsCookieDomain,
-  });
-}
 
 export function authorizeGet(
   authService: AuthorizeServiceInterface = authorizeService(),
@@ -166,7 +151,12 @@ export function authorizeGet(
       const consentCookieValue =
         cookieService.createConsentCookieValue(cookieConsent);
 
-      createConsentCookie(res, consentCookieValue);
+      res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
+        expires: consentCookieValue.expiry,
+        secure: true,
+        httpOnly: false,
+        domain: res.locals.analyticsCookieDomain,
+      });
 
       if (
         startAuthResponse.data.user.gaCrossDomainTrackingId &&

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -156,6 +156,7 @@ export function authorizeGet(
         secure: true,
         httpOnly: false,
         domain: res.locals.analyticsCookieDomain,
+        encode: String,
       });
 
       if (

--- a/src/components/common/cookie-consent/cookie-consent-service.ts
+++ b/src/components/common/cookie-consent/cookie-consent-service.ts
@@ -39,7 +39,7 @@ export function cookieConsentService(): CookieConsentServiceInterface {
       cookieExpires.setFullYear(cookieExpires.getFullYear() - 1);
     }
 
-    return { value: JSON.stringify(cookieValue), expiry: cookieExpires };
+    return { value: JSON.stringify(cookieValue), expires: cookieExpires };
   };
 
   return {

--- a/src/components/common/cookie-consent/tests/cookie-consent-service.test.ts
+++ b/src/components/common/cookie-consent/tests/cookie-consent-service.test.ts
@@ -36,7 +36,7 @@ describe("cookie consent service", () => {
         COOKIE_CONSENT.NOT_ENGAGED
       );
       expect(result.value).to.have.be.equal("{}");
-      expect(result.expiry.getFullYear()).to.have.be.equal(
+      expect(result.expires.getFullYear()).to.have.be.equal(
         new Date().getFullYear() - 1
       );
     });
@@ -46,7 +46,7 @@ describe("cookie consent service", () => {
         COOKIE_CONSENT.ACCEPT
       );
       expect(result.value).to.have.be.equal('{"analytics":true}');
-      expect(result.expiry.getFullYear()).to.have.be.equal(
+      expect(result.expires.getFullYear()).to.have.be.equal(
         new Date().getFullYear() + 1
       );
     });
@@ -56,7 +56,7 @@ describe("cookie consent service", () => {
         COOKIE_CONSENT.REJECT
       );
       expect(result.value).to.have.be.equal('{"analytics":false}');
-      expect(result.expiry.getFullYear()).to.have.be.equal(
+      expect(result.expires.getFullYear()).to.have.be.equal(
         new Date().getFullYear() + 1
       );
     });

--- a/src/components/common/cookie-consent/types.ts
+++ b/src/components/common/cookie-consent/types.ts
@@ -5,5 +5,5 @@ export interface CookieConsentServiceInterface {
 
 export interface CookieConsentModel {
   value: string;
-  expiry: Date;
+  expires: Date;
 }

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -42,7 +42,7 @@ function createConsentCookie(
   res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
     expires: consentCookieValue.expiry,
     secure: true,
-    httpOnly: true,
+    httpOnly: false,
     domain: res.locals.analyticsCookieDomain,
   });
 }

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -31,6 +31,7 @@ export function cookiesPost(req: Request, res: Response): void {
     secure: true,
     httpOnly: false,
     domain: res.locals.analyticsCookieDomain,
+    encode: String,
   });
 
   res.locals.backUrl = req.body.originalReferer;

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -5,7 +5,6 @@ import {
   COOKIES_PREFERENCES_SET,
   COOKIE_CONSENT,
 } from "../../../app.constants";
-import { CookieConsentModel } from "../cookie-consent/types";
 
 const cookieService = cookieConsentService();
 
@@ -27,22 +26,15 @@ export function cookiesPost(req: Request, res: Response): void {
     consentValue === "true" ? COOKIE_CONSENT.ACCEPT : COOKIE_CONSENT.REJECT
   );
 
-  createConsentCookie(res, consentCookieValue);
-
-  res.locals.backUrl = req.body.originalReferer;
-  res.locals.analyticsConsent = consentValue === "true";
-  res.locals.updated = true;
-  res.render("common/cookies/index.njk");
-}
-
-function createConsentCookie(
-  res: Response,
-  consentCookieValue: CookieConsentModel
-) {
   res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
     expires: consentCookieValue.expiry,
     secure: true,
     httpOnly: false,
     domain: res.locals.analyticsCookieDomain,
   });
+
+  res.locals.backUrl = req.body.originalReferer;
+  res.locals.analyticsConsent = consentValue === "true";
+  res.locals.updated = true;
+  res.render("common/cookies/index.njk");
 }

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -27,7 +27,7 @@ export function cookiesPost(req: Request, res: Response): void {
   );
 
   res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
-    expires: consentCookieValue.expiry,
+    expires: consentCookieValue.expires,
     secure: true,
     httpOnly: false,
     domain: res.locals.analyticsCookieDomain,

--- a/test/helpers/mock-cookie-consent-service-helper.ts
+++ b/test/helpers/mock-cookie-consent-service-helper.ts
@@ -1,0 +1,19 @@
+import { sinon } from "../utils/test-utils";
+import { CookieConsentServiceInterface } from "../../src/components/common/cookie-consent/types";
+
+export function createMockCookieConsentService(
+  userCookieConsentPreference: string
+): CookieConsentServiceInterface {
+  const expiryDate: Date = new Date();
+  expiryDate.setFullYear(expiryDate.getFullYear() + 1);
+
+  return {
+    getCookieConsent: sinon.fake(),
+    createConsentCookieValue: sinon.fake.returns({
+      value: JSON.stringify({
+        analytics: userCookieConsentPreference === "true",
+      }),
+      expiry: expiryDate,
+    }),
+  };
+}

--- a/test/helpers/mock-cookie-consent-service-helper.ts
+++ b/test/helpers/mock-cookie-consent-service-helper.ts
@@ -13,7 +13,7 @@ export function createMockCookieConsentService(
       value: JSON.stringify({
         analytics: userCookieConsentPreference === "true",
       }),
-      expiry: expiryDate,
+      expires: expiryDate,
     }),
   };
 }


### PR DESCRIPTION
## What

* Removes `HttpOnly` flag from `cookie_preferences_set` cookie included in HTTP responses. The [commit message](https://github.com/govuk-one-login/authentication-frontend/commit/b9e295d24fd67acfbd6d844fbd3030fba0334ee2) provides more context on the reasons for this change
* Removes duplicated `createConsentCookie` function that served only to wrap the `res.cookie` function provided by Express
* Applies `String` encoding to the cookie for consistency with encoding when the cookie is set on the client.
* Updates associated tests to ensure calls to `res.cookie` include the expected arguments and flags that will set the `HttpOnly` and `Secure` attributes. The [commit message](https://github.com/govuk-one-login/authentication-frontend/pull/1588/commits/939071fb1ceeaaa7c51132f76b1fdb7532d06e48) provides further information.
* Changes `CookieConsentModel`'s 'expiry' property to match the 'expires' property used in Express `res.cookie`

## How to review

1. Code Review
1. Run the tests
1. Run the code locally and, using an Incognito window (or having cleared cookies for the host), verify that:
   a. The cookie is set to reflect the HTTP headers included in the response from `/authorize`
   b. The server-sent cookie value is not URL encoded
   c. The banner is not shown 
   d. Interacting with the cookie banner updates the cookie value as expected (both when accepting and rejecting). You'll need to remove the server-sent cookie, reload the page, change settings and proceed to the next page to do this

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1224 introduced the `HttpOnly` flag for the `cookie_preferences_set` cookie
