### PR TITLE
[AUT-2759] Better error handling for _create_env_file

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -9,24 +9,18 @@ services:
       - "${DOCKER_FRONTEND_NODEMON_PORT:-9230}:${DOCKER_FRONTEND_NODEMON_PORT:-9230}"
     volumes:
       - ./:/app
+    env_file:
+      - .env
     environment:
-      ENVIRONMENT: ${ENVIRONMENT:?this should be set in your .env file.}
-
-      SESSION_EXPIRY: ${SESSION_EXPIRY:?this should be set in your .env file.}
-      SESSION_SECRET: ${SESSION_SECRET:?this should be set in your .env file.}
-
-      API_BASE_URL: ${API_BASE_URL:?this should be set in your .env file.}
-      API_KEY: ${API_KEY:?this should be set in your .env file.}
-      FRONTEND_API_BASE_URL: ${FRONTEND_API_BASE_URL:?this should be set in your .env file.}
-
       ANALYTICS_COOKIE_DOMAIN: localhost
-
-      SUPPORT_ACCOUNT_RECOVERY: ${SUPPORT_ACCOUNT_RECOVERY:?this should be set in your .env file.}
 
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required. This should be set by `startup.sh` so there may be an issue with the startup script.}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required. This should be set by `startup.sh` so there may be an issue with the startup script.}
 
-      REDIS_PORT: ${DOCKER_REDIS_PORT:-6379}
+      # We ignore `.env` values here, as we're using the docker network for redis.
+      REDIS_PORT: 6379 # This is the default port for Redis
+      REDIS_HOST: redis # This is the name of the service in `docker-compose.yml`
+
       PORT: ${DOCKER_FRONTEND_PORT:-3000}
     restart: on-failure
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   redis:
     image: redis:6.0.5-alpine
     ports:
-      - "${DOCKER_REDIS_PORT:-6379}:6379"
+      - "${REDIS_PORT:-6379}:6379"
     networks:
       - di-net
 

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 
 EXPOSE $PORT
 
-CMD yarn install && yarn copy-assets && yarn dev
+CMD yarn install && yarn test:dev-evironment-variables && yarn copy-assets && yarn dev


### PR DESCRIPTION
## What

- Check if the token plain doesn't exist (ie. the user has never run
  `aws sso login`), and give a more helpful error message.
- Check if the environment exists in the remote state when setting up
  the state getter, to fail fast if the environment doesn't exist. Also
  add a more helpful error message if the environment doesn't exist.

## How to review

- Code review

Functional tests, but this will kinda involve blatting your AWS config, so unsure if people will want to do this.
