### PR TITLE
AUT-2711: add the AIS forced pw reset to the reset-password-request P…

### DIFF
--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -33,7 +33,8 @@ export function resetPasswordCheckEmailGet(
         sessionId,
         req.ip,
         res.locals.clientSessionId,
-        res.locals.persistentSessionId
+        res.locals.persistentSessionId,
+        req.session.user.withinForcedPasswordResetJourney
       );
     }
 

--- a/src/components/reset-password-check-email/reset-password-check-email-service.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-service.ts
@@ -20,11 +20,13 @@ export function resetPasswordCheckEmailService(
     sessionId: string,
     sourceIp: string,
     clientSessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    withinForcedPasswordResetJourney: boolean
   ): Promise<ApiResponseResult<ResetPasswordRequestResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.RESET_PASSWORD_REQUEST,
       {
+        withinForcedPasswordResetJourney: withinForcedPasswordResetJourney,
         email: email,
       },
       getRequestConfig({

--- a/src/components/reset-password-check-email/types.ts
+++ b/src/components/reset-password-check-email/types.ts
@@ -6,7 +6,8 @@ export interface ResetPasswordCheckEmailServiceInterface {
     sessionId: string,
     sourceIp: string,
     clientSessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    withinForcedPasswordResetJourney: boolean
   ) => Promise<ApiResponseResult<ResetPasswordRequestResponse>>;
 }
 


### PR DESCRIPTION
add the AIS forced pw reset to the reset-password-request POST

## What

We need a way to indicate the AIS response in the backend to determine when a forced pw journey started

## How to review


1. Code Review

## UCD review

- [x] no changes to FE, UCD review is not required

Demonstration of changes:
The following screenshot proves that the data is being sent to the BE correctly 

![image](https://github.com/govuk-one-login/authentication-frontend/assets/146068663/72059e1d-05a8-4eca-b692-4277c9681236)


