### PR TITLE
Auth-2656 deploy Cloud front in Build

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -32,3 +32,6 @@ orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.build.account.gov.uk/"
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+
+#cloudfront enabled flag 
+cloudfront_auth_frontend_enabled = true

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -300,11 +300,13 @@ variable "cloudfront_zoneid" {
 
 variable "auth_origin_cloakingheader" {
   type        = string
+  sensitive   = true
   description = "This is header value for Cloufront to to verify requests are coming from the correct CloudFront distribution to ALB "
 }
 
 variable "previous_auth_origin_cloakingheader" {
   type        = string
+  sensitive   = true
   description = "This is previous header value when the value is rotated to ensure WAF will allow requests during rotation "
 }
 


### PR DESCRIPTION
## What

Auth-2656 deploy Cloud front in Build no DNS switch

## How to review

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -t -p


