### PR TITLE
Auth-2737 change waf log subscription default behaviour

### DIFF
--- a/ci/terraform/waf-cf.tf
+++ b/ci/terraform/waf-cf.tf
@@ -477,7 +477,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "frontend_cloudfront_waf_logg
   resource_arn            = aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl[0].arn
 
   logging_filter {
-    default_behavior = "DROP"
+    default_behavior = "KEEP"
 
     filter {
       behavior = "KEEP"

--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -404,7 +404,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "frontend_alb_waf_logging_con
   resource_arn            = aws_wafv2_web_acl.frontend_alb_waf_regional_web_acl.arn
 
   logging_filter {
-    default_behavior = "DROP"
+    default_behavior = "KEEP"
 
     filter {
       behavior    = "KEEP"


### PR DESCRIPTION
## What

Auth-2737 change Waf log subscription default behaviour , ask from Security team DISEC-3686

## How to review



1. Code Review
2. Deploy to sandpit with `./deploy-sandpit.sh -t -p 
```
See for this change in 
 # aws_wafv2_web_acl_logging_configuration.frontend_alb_waf_logging_config will be updated in-place
  ~ resource "aws_wafv2_web_acl_logging_configuration" "frontend_alb_waf_logging_config" {
        id                      = "arn:aws:wafv2:eu-west-2:653994557586:regional/webacl/authdev2-frontend-alb-waf-web-acl/eb07190f-10c0-4df6-b095-f649d2594d26"
        # (2 unchanged attributes hidden)

      ~ logging_filter {
          **~ default_behavior = "DROP" -> "KEEP"**

            # (1 unchanged block hidden)
        }
    }
```


