### PR TITLE
fixing Template version & ignoring the changes to header parameter

### DIFF
--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "cloudfront" {
   count = var.cloudfront_auth_frontend_enabled ? 1 : 0
   name  = "${var.environment}-auth-fe-cloudfront"
-  #using fixed version of template for now 
+  #using fixed version of cloudfron disturbution template for now 
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-distribution/template.yaml?versionId=EKk9m9vMv10qF5vHzWZogFLnQQw6_Yjc"
 
   capabilities = ["CAPABILITY_NAMED_IAM"]
@@ -20,13 +20,21 @@ resource "aws_cloudformation_stack" "cloudfront" {
     StandardLoggingEnabled         = true
   }
   tags = local.default_tags
+  
+  #ignoring below parameter as these parameter are been read via secret manager and terraform continually detects changes
+  # Note : we need to remove the below lifecycle if the Header are changed in Secret manager to appy new cloainking header value 
+  lifecycle {
+    ignore_changes = [parameters["OriginCloakingHeader"],parameters["PreviousOriginCloakingHeader"]]
+  }
+
 }
 
 resource "aws_cloudformation_stack" "cloudfront-monitoring" {
   count        = var.cloudfront_auth_frontend_enabled ? 1 : 0
   provider     = aws.cloudfront
   name         = "${var.environment}-auth-fe-cloudfront-monitoring"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-monitoring-alarm/template.yaml?z=${timestamp()}"
+  #using fixed version of cloudfront monitoring  disturbution template for now 
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-monitoring-alarm/template.yaml?versionId=td2KHIlG7KGXl0mkMrRDkgBWxdXPEMZ."
 
   capabilities = ["CAPABILITY_NAMED_IAM"]
 

--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -20,19 +20,19 @@ resource "aws_cloudformation_stack" "cloudfront" {
     StandardLoggingEnabled         = true
   }
   tags = local.default_tags
-  
+
   #ignoring below parameter as these parameter are been read via secret manager and terraform continually detects changes
   # Note : we need to remove the below lifecycle if the Header are changed in Secret manager to appy new cloainking header value 
   lifecycle {
-    ignore_changes = [parameters["OriginCloakingHeader"],parameters["PreviousOriginCloakingHeader"]]
+    ignore_changes = [parameters["OriginCloakingHeader"], parameters["PreviousOriginCloakingHeader"]]
   }
 
 }
 
 resource "aws_cloudformation_stack" "cloudfront-monitoring" {
-  count        = var.cloudfront_auth_frontend_enabled ? 1 : 0
-  provider     = aws.cloudfront
-  name         = "${var.environment}-auth-fe-cloudfront-monitoring"
+  count    = var.cloudfront_auth_frontend_enabled ? 1 : 0
+  provider = aws.cloudfront
+  name     = "${var.environment}-auth-fe-cloudfront-monitoring"
   #using fixed version of cloudfront monitoring  disturbution template for now 
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-monitoring-alarm/template.yaml?versionId=td2KHIlG7KGXl0mkMrRDkgBWxdXPEMZ."
 


### PR DESCRIPTION
## What

fixing Template version & ignoring the changes to header parameter

## Why
1 ) Fixing the cloud-front Monitoring version making sure no changes to cloud front distribution or cloud front Monitoring is applied without testing 
2)  Ignoring parameter changes as these parameter are been read via secret manager and terraform continually detects changes to stack even though there aren't

## How to review

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -t -p `
