### PR TITLE
Aut 2578/convert more services common headers

### DIFF
--- a/src/components/auth-code/auth-code-controller.ts
+++ b/src/components/auth-code/auth-code-controller.ts
@@ -22,7 +22,8 @@ export function authCodeGet(
       req.ip,
       persistentSessionId,
       req.session.client,
-      req.session.user
+      req.session.user,
+      req
     );
 
     req.session.user.authCodeReturnToRP = false;

--- a/src/components/auth-code/auth-code-controller.ts
+++ b/src/components/auth-code/auth-code-controller.ts
@@ -19,7 +19,6 @@ export function authCodeGet(
     const result = await service.getAuthCode(
       sessionId,
       clientSessionId,
-      req.ip,
       persistentSessionId,
       req.session.client,
       req.session.user,

--- a/src/components/auth-code/auth-code-service.ts
+++ b/src/components/auth-code/auth-code-service.ts
@@ -14,7 +14,6 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
   const getAuthCode = async function (
     sessionId: string,
     clientSessionId: string,
-    sourceIp: string,
     persistentSessionId: string,
     clientSession: UserSessionClient,
     userSession: UserSession,
@@ -31,7 +30,6 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
         baseURL: baseUrl,
         sessionId: sessionId,
         clientSessionId: clientSessionId,
-        sourceIp: sourceIp,
         persistentSessionId: persistentSessionId,
       },
       req,

--- a/src/components/auth-code/auth-code-service.ts
+++ b/src/components/auth-code/auth-code-service.ts
@@ -2,14 +2,14 @@ import { ApiResponseResult, UserSession, UserSessionClient } from "../../types";
 import { API_ENDPOINTS } from "../../app.constants";
 import {
   createApiResponse,
-  getRequestConfig,
+  getInternalRequestConfigWithSecurityHeaders,
   http,
   Http,
 } from "../../utils/http";
 import { AuthCodeResponse, AuthCodeServiceInterface } from "./types";
 import { getApiBaseUrl, getFrontendApiBaseUrl } from "../../config";
 import { AxiosResponse } from "axios";
-
+import { Request } from "express";
 export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
   const getAuthCode = async function (
     sessionId: string,
@@ -17,7 +17,8 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
     sourceIp: string,
     persistentSessionId: string,
     clientSession: UserSessionClient,
-    userSession: UserSession
+    userSession: UserSession,
+    req: Request
   ): Promise<ApiResponseResult<AuthCodeResponse>> {
     const useOrchAuthCode = shouldCallOrchAuthCode(userSession);
     const baseUrl = useOrchAuthCode ? getFrontendApiBaseUrl() : getApiBaseUrl();
@@ -25,13 +26,17 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
       ? API_ENDPOINTS.ORCH_AUTH_CODE
       : API_ENDPOINTS.AUTH_CODE;
 
-    const config = getRequestConfig({
-      baseURL: baseUrl,
-      sessionId: sessionId,
-      clientSessionId: clientSessionId,
-      sourceIp: sourceIp,
-      persistentSessionId: persistentSessionId,
-    });
+    const config = getInternalRequestConfigWithSecurityHeaders(
+      {
+        baseURL: baseUrl,
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
+      },
+      req,
+      path
+    );
 
     let response: AxiosResponse;
 

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -21,6 +21,19 @@ describe("authentication auth code service", () => {
     "/redirect-here?with-some-params=added-by-the-endpoint";
   const apiBaseUrl = "/base-url";
   const frontendBaseUrl = "/frontend-base-url";
+  const sessionId = "sessionId";
+  const apiKey = "apiKey";
+  const clientSessionId = "clientSessionId";
+  const sourceIp = "sourceIp";
+  const persistentSessionId = "persistentSessionId";
+
+  const expectedHeaders = {
+    "X-API-Key": apiKey,
+    "Session-Id": sessionId,
+    "Client-Session-Id": clientSessionId,
+    "X-Forwarded-For": sourceIp,
+    "di-persistent-session-id": persistentSessionId,
+  };
 
   const axiosResponse = Promise.resolve({
     data: {
@@ -36,7 +49,7 @@ describe("authentication auth code service", () => {
   let service: AuthCodeServiceInterface;
 
   beforeEach(() => {
-    process.env.API_KEY = "api-key";
+    process.env.API_KEY = apiKey;
     process.env.FRONTEND_API_BASE_URL = frontendBaseUrl;
     process.env.API_BASE_URL = apiBaseUrl;
     const httpInstance = new Http();
@@ -69,10 +82,10 @@ describe("authentication auth code service", () => {
       };
 
       const result = await service.getAuthCode(
-        "sessionId",
-        "clientSessionId",
-        "sourceIp",
-        "persistentSessionId",
+        sessionId,
+        clientSessionId,
+        sourceIp,
+        persistentSessionId,
         sessionClient,
         userSessionClient
       );
@@ -91,7 +104,7 @@ describe("authentication auth code service", () => {
           API_ENDPOINTS.ORCH_AUTH_CODE,
           expectedBody,
           {
-            headers: sinon.match.object,
+            headers: expectedHeaders,
             proxy: sinon.match.bool,
             baseURL: frontendBaseUrl,
           }
@@ -103,17 +116,17 @@ describe("authentication auth code service", () => {
 
     it("should make a request for an RP auth code following the prove identity callback page", async () => {
       const result = await service.getAuthCode(
-        "sessionId",
-        "clientSessionId",
-        "sourceIp",
-        "persistentSessionId",
+        sessionId,
+        clientSessionId,
+        sourceIp,
+        persistentSessionId,
         {},
         { authCodeReturnToRP: true }
       );
 
       expect(
         getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
-          headers: sinon.match.object,
+          headers: expectedHeaders,
           baseURL: apiBaseUrl,
           proxy: sinon.match.bool,
         })

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -94,7 +94,6 @@ describe("authentication auth code service", () => {
       const result = await service.getAuthCode(
         sessionId,
         clientSessionId,
-        sourceIp,
         persistentSessionId,
         sessionClient,
         userSessionClient,
@@ -135,7 +134,6 @@ describe("authentication auth code service", () => {
       const result = await service.getAuthCode(
         sessionId,
         clientSessionId,
-        sourceIp,
         persistentSessionId,
         {},
         { authCodeReturnToRP: true },

--- a/src/components/auth-code/types.ts
+++ b/src/components/auth-code/types.ts
@@ -14,7 +14,6 @@ export interface AuthCodeServiceInterface {
   getAuthCode: (
     sessionId: string,
     clientSessionId: string,
-    sourceIp: string,
     persistentSessionId: string,
     clientSession: UserSessionClient,
     userSession: UserSession,

--- a/src/components/auth-code/types.ts
+++ b/src/components/auth-code/types.ts
@@ -4,6 +4,7 @@ import {
   UserSession,
   UserSessionClient,
 } from "../../types";
+import { Request } from "express";
 
 export interface AuthCodeResponse extends DefaultApiResponse {
   location: string;
@@ -16,6 +17,7 @@ export interface AuthCodeServiceInterface {
     sourceIp: string,
     persistentSessionId: string,
     clientSession: UserSessionClient,
-    userSession: UserSession
+    userSession: UserSession,
+    req: Request
   ) => Promise<ApiResponseResult<AuthCodeResponse>>;
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -88,11 +88,12 @@ export function getRequestConfig(options: ConfigOptions): AxiosRequestConfig {
   return config;
 }
 
-function getSecurityHeaders(path: string, req: Request) {
+function getSecurityHeaders(path: string, req: Request, baseUrl?: string) {
   let personalDataHeaders = {};
   let url = "";
   try {
-    url = new URL(path, getFrontendApiBaseUrl()).toString();
+    const basePath = baseUrl || getFrontendApiBaseUrl();
+    url = new URL(path, basePath).toString();
     personalDataHeaders = createPersonalDataHeaders(url, req);
   } catch (err) {
     logger.warn(
@@ -110,7 +111,7 @@ export function getInternalRequestConfigWithSecurityHeaders(
   const config: AxiosRequestConfig = {
     headers: {
       "X-API-Key": getApiKey(),
-      ...getSecurityHeaders(path, req),
+      ...getSecurityHeaders(path, req, options.baseURL),
     },
     proxy: false,
   };


### PR DESCRIPTION
## What

Converts the auth code service to use the new getInternalRequestConfigWithSecurityHeaders function, which adds common security headers via the govuk-one-login/frontend-passthrough-headers library.

This needed a change to the way we construct the url that we pass through to the library, since in the auth code service sometimes we call a different base url, depending on the context. So this PR also updates that function to respect an optional base path that gets passed through to the config function.

## How to review

1. Code Review

## Related PRs

[Original PR](https://github.com/govuk-one-login/authentication-frontend/pull/1609) that converted one of the existing services