### PR TITLE
AUT-1432: Fix secret key display in error state and tests

### DIFF
--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -102,7 +102,9 @@ export function setupAuthenticatorAppPost(
         );
         return renderBadRequest(res, req, TEMPLATE, error, {
           qrCode: req.session.user.authAppQrCodeUrl,
-          secretKey: req.session.user.authAppSecret,
+          secretKeyFragmentArray: splitSecretKeyIntoFragments(
+            req.session.user.authAppSecret
+          ),
         });
       }
 

--- a/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
@@ -2,7 +2,10 @@ import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { Request } from "express";
-import { containsNumbersOnly } from "../../utils/strings";
+import {
+  containsNumbersOnly,
+  splitSecretKeyIntoFragments,
+} from "../../utils/strings";
 
 export function validateSetupAuthAppRequest(): ValidationChainFunc {
   return [
@@ -47,6 +50,8 @@ const postValidationLocals = function locals(
 ): Record<string, unknown> {
   return {
     qrCode: req.session.user.authAppQrCodeUrl,
-    secretKey: req.session.user.authAppSecret,
+    secretKeyFragmentArray: splitSecretKeyIntoFragments(
+      req.session.user.authAppSecret
+    ),
   };
 };

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -15,6 +15,7 @@ describe("Integration::setup-authenticator-app", () => {
   let cookies: string;
   let app: any;
   let baseApi: string;
+  const AUTH_APP_SECRET: string = "MJRGA2KMETI7BEVNT33MOITMEQQUJMAQ";
 
   before(async () => {
     decache("../../../app");
@@ -33,7 +34,7 @@ describe("Integration::setup-authenticator-app", () => {
           journey: {
             nextPath: PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP,
           },
-          authAppSecret: "secret",
+          authAppSecret: AUTH_APP_SECRET,
         };
 
         next();
@@ -89,7 +90,7 @@ describe("Integration::setup-authenticator-app", () => {
         expect($("#code-error").text()).to.contains(
           "Enter the security code shown in your authenticator app"
         );
-        expect($("#secret-key").text()).to.not.be.empty;
+        expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
       .expect(400, done);
   });
@@ -108,7 +109,7 @@ describe("Integration::setup-authenticator-app", () => {
         expect($("#code-error").text()).to.contains(
           "Enter the security code using only 6 digits"
         );
-        expect($("#secret-key").text()).to.not.be.empty;
+        expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
       .expect(400, done);
   });
@@ -127,7 +128,7 @@ describe("Integration::setup-authenticator-app", () => {
         expect($("#code-error").text()).to.contains(
           "Enter the security code using only 6 digits"
         );
-        expect($("#secret-key").text()).to.not.be.empty;
+        expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
       .expect(400, done);
   });


### PR DESCRIPTION
## What

Fixes a bug reported by QA where authenticator app secret keys were not displayed following a validation error.

The fix ensures the secret will display both:

- where the **code format is invalid** and therefore fails the validation rules as set in `setup-authenticator-app-validation.ts`
- where the **code is incorrect**, as demonstrated by the `verifyMfaCode` service not returning a success

The related integration tests have also been updated to prevent assertions passing where the code is not included (the previous non-empty test would always pass because the text included whitespace and line break characters)

## How to review

1. Code Review
1. Run this branch locally
1. Go through an account creation journey choosing authenticator app when asked to choose a method for second factor. 
1. On the "Set up an authenticator app" screen confirm that the secret key can be seen when expanding "I cannot scan the QR code"
1. Confirm that the secret key is still included in error states when you submit different permutations of invalid formats. This includes: not entering a code; entering a code that is too long; entering a six digit code that contains a letter
1. Confirm that the secret key is still included when you enter a valid code that is incorrect.
1. Confirm that a correct code can be submitted

