### PR TITLE
BAU: Set environment vars for GA4 and Universal Analytics

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -37,3 +37,6 @@ orch_to_auth_audience           = "https://signin.authdev1.sandpit.account.gov.u
 
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.authdev1.sandpit.account.gov.uk/"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -37,3 +37,6 @@ orch_to_auth_audience           = "https://signin.authdev2.sandpit.account.gov.u
 
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.authdev2.sandpit.account.gov.uk/"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -41,3 +41,6 @@ dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:Dyn
 cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 cloudfront_WafAcl_Logdestination = "csls_cw_logs_destination_prodpython"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.build.account.gov.uk/"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -164,6 +164,26 @@ locals {
         name  = "LANGUAGE_TOGGLE_ENABLED"
         value = var.language_toggle_enabled
       },
+      {
+        name  = "GA4_DISABLED"
+        value = var.ga4_disabled
+      },
+      {
+        name  = "UA_DISABLED"
+        value = var.ua_disabled
+      },
+      {
+        name  = "UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID"
+        value = var.universal_analytics_gtm_container_id
+      },
+      {
+        name  = "GOOGLE_ANALYTICS_4_GTM_CONTAINER_ID"
+        value = var.google_analytics_4_gtm_container_id
+      },
+      {
+        name  = "ANALYTICS_COOKIE_DOMAIN"
+        value = var.analytics_cookie_domain
+      }
     ]
 
     secrets = [

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -28,3 +28,6 @@ dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:Dyn
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7\nppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.integration.account.gov.uk/"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.integration.account.gov.uk/"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -31,3 +31,6 @@ dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:Dyn
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5\n+3VZPbjHv+v0AjQ5Ps+avkXWKwOeScG9sS0cDf0utEXi3fN3cEraa9WuKQ==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.account.gov.uk/"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.account.gov.uk/"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -43,3 +43,6 @@ logging_endpoint_arns = [
 ]
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.sandpit.account.gov.uk/"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -38,3 +38,6 @@ dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:Dyn
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+\nKKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.staging.account.gov.uk/"
+
+ua_disabled             = "false"
+analytics_cookie_domain = "https://signin.staging.account.gov.uk/"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -342,4 +342,32 @@ variable "language_toggle_enabled" {
   description = "Enables English / Welsh language toggle in the user interface"
 }
 
+variable "ga4_disabled" {
+  type        = string
+  default     = "true"
+  description = "Enables Google Analytics 4"
+}
 
+variable "ua_disabled" {
+  type        = string
+  default     = "true"
+  description = "Enables Universal Analytics"
+}
+
+variable "universal_analytics_gtm_container_id" {
+  type        = string
+  default     = "GTM-TK92W68"
+  description = "Universal Analytics Container ID"
+}
+
+variable "google_analytics_4_gtm_container_id" {
+  type        = string
+  default     = "GTM-KD86CMZ"
+  description = "Google Analytics 4 Container ID"
+}
+
+variable "analytics_cookie_domain" {
+  type        = string
+  default     = ""
+  description = "Analytics cookie domain where cookie is set"
+}


### PR DESCRIPTION
## What

Adds several environment variables used by the Frontend Capability Team `@govuk-one-login/frontend-analytics` NPM package to support GA4 and Universal Analytics.

## How to review

1. Code Review

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1522 introduced the `@govuk-one-login/frontend-analytics` NPM package.