### PR TITLE
BAU: send isForcedPasswordReset in request to backend

### DIFF
--- a/src/components/reset-password/reset-password-service.ts
+++ b/src/components/reset-password/reset-password-service.ts
@@ -25,6 +25,7 @@ export function resetPasswordService(
       API_ENDPOINTS.RESET_PASSWORD,
       {
         password: newPassword,
+        isForcedPasswordReset: isForcedPasswordReset,
       },
       getInternalRequestConfigWithSecurityHeaders(
         {

--- a/src/components/reset-password/tests/reset-password-service.test.ts
+++ b/src/components/reset-password/tests/reset-password-service.test.ts
@@ -62,7 +62,10 @@ describe("reset password service", () => {
     const expectedApiCallDetails = {
       expectedPath: API_ENDPOINTS.RESET_PASSWORD,
       expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
-      expectedBody: { password: newPassword },
+      expectedBody: {
+        password: newPassword,
+        isForcedPasswordReset: isForcedPasswordReset,
+      },
     };
 
     checkApiCallMadeWithExpectedBodyAndHeaders(


### PR DESCRIPTION
We had [previously](https://github.com/govuk-one-login/authentication-frontend/commit/d9e8001c238ff3c6a299eccf562e8103f8c489df) added this parameter to the interface, but not used it. In the backend, this [controls](https://github.com/govuk-one-login/authentication-api/blob/0a1a1d414d24fa7cd8e51962e2b57706023a165c/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java#L190-L207) whether we send the `PASSWORD_RESET_INTERVENTION_COMPLETE` audit event through, so this change should mean these events are being sent.

Detailed rationale for this change:

[Here](https://github.com/govuk-one-login/authentication-api/blob/0a1a1d414d24fa7cd8e51962e2b57706023a165c/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java) is the handler where this is received on the backend (it's the handler that's mapped to the endpoint we're making a call to here - "/reset-password" - as seen [here](https://github.com/govuk-one-login/authentication-api/blob/0a1a1d414d24fa7cd8e51962e2b57706023a165c/ci/terraform/oidc/reset_password.tf#L28-L46)), and the [request object it takes](https://github.com/govuk-one-login/authentication-api/blob/0a1a1d414d24fa7cd8e51962e2b57706023a165c/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java#L7-L9). It seems like, although this is declared as "required" on the request object, if it's not present it returns false in the code, so effectively this is currently always false. 


## How to review


1. Code Review

