### PR TITLE
AUT-2841 - add new radio button options into "A problem proving your identity" contact form

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -14,6 +14,7 @@ support_authorize_controller  = "1"
 support_2fa_b4_password_reset = "1"
 support_check_email_fraud     = "1"
 language_toggle_enabled       = "1"
+no_photo_id_contact_forms     = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -14,6 +14,7 @@ support_authorize_controller  = "1"
 support_2fa_b4_password_reset = "1"
 support_check_email_fraud     = "1"
 language_toggle_enabled       = "1"
+no_photo_id_contact_forms     = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -26,6 +26,7 @@ code_entered_wrong_blocked_minutes                  = "1"
 reduced_code_block_duration_minutes                 = "0.5"
 url_for_support_links                               = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 language_toggle_enabled                             = "1"
+no_photo_id_contact_forms                           = "1"
 
 
 logging_endpoint_arns = [

--- a/ci/terraform/dev.tfvars
+++ b/ci/terraform/dev.tfvars
@@ -26,6 +26,7 @@ code_entered_wrong_blocked_minutes                  = "1"
 reduced_code_block_duration_minutes                 = "0.5"
 url_for_support_links                               = "https://home.dev.account.gov.uk/contact-gov-uk-one-login"
 language_toggle_enabled                             = "1"
+no_photo_id_contact_forms                           = "1"
 
 logging_endpoint_arns = []
 

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -161,6 +161,10 @@ locals {
         value = var.support_2hr_lockout
       },
       {
+        name  = "NO_PHOTO_ID_CONTACT_FORMS"
+        value = var.no_photo_id_contact_forms
+      },
+      {
         name  = "SUPPORT_CHECK_EMAIL_FRAUD"
         value = var.support_check_email_fraud
       },

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -11,6 +11,7 @@ support_authorize_controller  = "1"
 support_2fa_b4_password_reset = "1"
 support_2hr_lockout           = "1"
 support_reauthentication      = "1"
+no_photo_id_contact_forms     = "0"
 
 code_request_blocked_minutes                        = "120"
 account_recovery_code_entered_wrong_blocked_minutes = "120"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -19,6 +19,7 @@ code_entered_wrong_blocked_minutes                  = "120"
 email_entered_wrong_blocked_minutes                 = "120"
 password_reset_code_entered_wrong_blocked_minutes   = "120"
 reduced_code_block_duration_minutes                 = "15"
+no_photo_id_contact_forms                           = "0"
 
 url_for_support_links = "https://home.account.gov.uk/contact-gov-uk-one-login"
 

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -16,6 +16,7 @@ support_account_interventions = "1"
 support_2fa_b4_password_reset = "1"
 support_check_email_fraud     = "1"
 language_toggle_enabled       = "1"
+no_photo_id_contact_forms     = "0"
 
 
 frontend_task_definition_cpu     = 512

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -28,6 +28,7 @@ reduced_code_block_duration_minutes                 = "15"
 support_reauthentication                            = "1"
 language_toggle_enabled                             = "1"
 prove_identity_welcome_enabled                      = "0"
+no_photo_id_contact_forms                           = "1"
 
 url_for_support_links = "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -235,6 +235,12 @@ variable "support_2hr_lockout" {
   default     = "0"
 }
 
+variable "no_photo_id_contact_forms" {
+  description = "When true enables no photo id contact forms"
+  type        = string
+  default     = "0"
+}
+
 variable "support_account_interventions" {
   description = "When true, turns on account interventions in environment"
   type        = string

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -92,6 +92,8 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
             "SUPPORT_REAUTHENTICATION": 1,
             "SUPPORT_2HR_LOCKOUT": 1,
             "SUPPORT_CHECK_EMAIL_FRAUD": 1,
+            "NO_PHOTO_ID_CONTACT_FORMS": 1,
+            "LANGUAGE_TOGGLE_ENABLED": 1,
         },
     },
     {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -11,7 +11,11 @@ import { Questions, ThemeQuestions } from "./types";
 import { ExpressRouteFunc } from "../../types";
 import crypto from "crypto";
 import { logger } from "../../utils/logger";
-import { getServiceDomain, getSupportLinkUrl } from "../../config";
+import {
+  getServiceDomain,
+  getSupportLinkUrl,
+  supportNoPhotoIdContactForms,
+} from "../../config";
 import { contactUsServiceSmartAgent } from "./contact-us-service-smart-agent";
 
 const themeToPageTitle = {
@@ -360,6 +364,7 @@ export function furtherInformationGet(req: Request, res: Response): void {
       ...(getAppErrorCode(req.query.appErrorCode as string) && {
         appErrorCode: getAppErrorCode(req.query.appErrorCode as string),
       }),
+      supportNoPhotoIdContactForms: supportNoPhotoIdContactForms(),
     });
   }
 
@@ -374,6 +379,7 @@ export function furtherInformationGet(req: Request, res: Response): void {
     referer: encodeValue(
       validateReferer(req.query.referer as string, serviceDomain)
     ),
+    supportNoPhotoIdContactForms: supportNoPhotoIdContactForms(),
   });
 }
 

--- a/src/components/contact-us/further-information/_proving-identity-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-further-information.njk
@@ -11,16 +11,7 @@
 
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
-    {{ govukRadios({
-        name: "subtheme",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: [
+    {% set items = [
             {
                 value: "proving_identity_problem_answering_security_questions",
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio1' | translate
@@ -34,14 +25,45 @@
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio3' | translate
             },
             {
-            value: "proving_identity_technical_problem",
-            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio4' | translate
+                value: "proving_identity_technical_problem",
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio4' | translate
             },
             {
                 value: "proving_identity_something_else",
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio5' | translate
             }
-        ],
+        ]
+    %}
+
+    {% if supportNoPhotoIdContactForms %}
+    {% set no_photo_id_bank_item = {
+            value: "proving_identity_problem_with_bank_building_society_details",
+            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio6' | translate
+        }
+    %}
+
+    {% set no_photo_id_nin_item = {
+            value: "proving_identity_problem_with_national_insurance_number",
+            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio7.label' | translate,
+            hint: {
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio7.hint' | translate | safe
+            }
+        }
+    %}
+    {% set items = (items.splice(2, 0, no_photo_id_bank_item), items) %}
+    {% set items = (items.splice(3, 0, no_photo_id_nin_item), items) %}
+    {% endif %}
+
+    {{ govukRadios({
+        name: "subtheme",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
           errorMessage: {
           text: errors['subtheme'].text
           } if (errors['subtheme'])

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -10,6 +10,8 @@ import {
 import { PATH_NAMES, CONTACT_US_THEMES } from "../../../app.constants";
 import { RequestGet, ResponseRedirect } from "../../../types";
 
+import { supportNoPhotoIdContactForms } from "../../../config";
+
 describe("contact us further information controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
@@ -44,6 +46,7 @@ describe("contact us further information controller", () => {
           theme: "signing_in",
           referer: encodeURIComponent(REFERER),
           hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${CONTACT_US_THEMES.SIGNING_IN}`,
+          supportNoPhotoIdContactForms: false,
         }
       );
     });
@@ -60,6 +63,7 @@ describe("contact us further information controller", () => {
           theme: "account_creation",
           referer: encodeURIComponent(REFERER),
           hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${CONTACT_US_THEMES.ACCOUNT_CREATION}`,
+          supportNoPhotoIdContactForms: false,
         }
       );
     });
@@ -195,6 +199,23 @@ describe("contact us further information controller", () => {
       expect(res.redirect).to.have.calledWith(
         "/contact-us-questions?theme=account_creation&subtheme=something_else&referer=http%3A%2F%2Flocalhost%3A3000%2Fenter-email"
       );
+    });
+  });
+
+  describe("supportNoPhotoIdContactForms() with the support No photo id contact forms", () => {
+    it("should return true when NO_PHOTO_ID_CONTACT_FORMS is set to '1'", async () => {
+      process.env.NO_PHOTO_ID_CONTACT_FORMS = "1";
+      expect(supportNoPhotoIdContactForms()).to.be.true;
+    });
+
+    it("should return false  when NO_PHOTO_ID_CONTACT_FORMS is set to '0'", async () => {
+      process.env.NO_PHOTO_ID_CONTACT_FORMS = "0";
+      expect(supportNoPhotoIdContactForms()).to.be.false;
+    });
+
+    it("should return false when NO_PHOTO_ID_CONTACT_FORMS is undefined", async () => {
+      process.env.NO_PHOTO_ID_CONTACT_FORMS = undefined;
+      expect(supportNoPhotoIdContactForms()).to.be.false;
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -171,6 +171,10 @@ export function support2hrLockout(): boolean {
   return process.env.SUPPORT_2HR_LOCKOUT === "1";
 }
 
+export function supportNoPhotoIdContactForms(): boolean {
+  return process.env.NO_PHOTO_ID_CONTACT_FORMS === "1";
+}
+
 export function supportAccountInterventions(): boolean {
   return process.env.SUPPORT_ACCOUNT_INTERVENTIONS === "1";
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1771,6 +1771,11 @@
           "radio3": "Mae angen i chi ddiweddaru eich gwybodaeth bersonol",
           "radio4": "Roedd problem dechnegol (er enghraifft fe welsoch neges gwall)",
           "radio5": "Rhywbeth arall",
+          "radio6": "Cawsoch broblem gyda’ch manylion banc neu gymdeithas adeiladu",
+          "radio7": {
+            "label": "Cawsoch broblem gyda’ch rhif Yswiriant Gwladol",
+            "hint": "Gallwch ddarllen mwy am gael neu ddod o hyd i’ch rhif Yswiriant Gwladol yn <a href=\"https://www.gov.uk/rhif-yswiriant-gwladol-coll\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">www.gov.uk/rhif-yswiriant-gwladol-coll</a>"
+          },
           "errorMessage": "Dewiswch y broblem oedd gennych wrth brofi eich hunaniaeth"
         }
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1771,6 +1771,11 @@
           "radio3": "You need to update your personal information",
           "radio4": "There was a technical problem (for example, you saw an error message)",
           "radio5": "Something else",
+          "radio6": "You had a problem with your bank or building society details",
+          "radio7": {
+            "label": "You had a problem with your National insurance number",
+            "hint": "You can read more about getting or finding your National Insurance number at <a href=\"https://www.gov.uk/find-national-insurance-number\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">www.gov.uk/find-national-insurance-number</a>"
+          },
           "errorMessage": "Select the problem you had proving your identity"
         }
       }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->
Add two new radio options (one of which includes hint text and a hyperlink) into "A problem proving your identity" contact form.


## How to review
in the contact form page, choose the option "A problem proving your identity" and submit the form.
"A problem proving your identity" form will appears and you will be able to see the 2 new options:
- "You had a problem with your bank or building society details"
- You had a problem with your National insurance number
You can read more about getting or finding your National Insurance number at [www.gov.uk/find-national-insurance-number](https://www.gov.uk/find-national-insurance-number)

Welsh version:
In the same page, add a new query parameter to your url: &lng=cy.
The text will appears in welsh.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
![aut-2841-screenshot-en](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/c5efb859-d046-4061-9344-589836a7917a)
![aut-2841-screenshot-cy](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/9e0e30d5-1944-453c-ab23-895bcff884da)

- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
