### PR TITLE
Aut-2843 add new contact form problem with bank or building society details

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -178,6 +178,8 @@ export const CONTACT_US_THEMES = {
     "proving_identity_problem_answering_security_questions",
   PROVING_IDENTITY_PROBLEM_WITH_IDENTITY_DOCUMENT:
     "proving_identity_problem_with_identity_document",
+  PROVING_IDENTITY_PROBLEM_WITH_BANK_BUILDING_SOCIETY_DETAILS:
+    "proving_identity_problem_with_bank_building_society_details",
   PROVING_IDENTITY_NEED_TO_UPDATE_PERSONAL_INFORMATION:
     "proving_identity_need_to_update_personal_information",
   PROVING_IDENTITY_SOMETHING_ELSE: "proving_identity_something_else",

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -819,7 +819,7 @@ export function getQuestionsFromFormTypeForMessageBody(
       serviceTryingToUse: req.t(
         "pages.contactUsQuestions.serviceTryingToUse.header",
         { lng: "en" }
-      )
+      ),
     },
     provingIdentityNeedToUpdatePersonalInformation: {
       issueDescription: req.t(

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -67,6 +67,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.provingIdentityProblemAnsweringSecurityQuestions.title",
   [CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_IDENTITY_DOCUMENT]:
     "pages.contactUsQuestions.provingIdentityProblemWithIdentityDocument.title",
+  [CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_BANK_BUILDING_SOCIETY_DETAILS]:
+    "pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.title",
   [CONTACT_US_THEMES.PROVING_IDENTITY_NEED_TO_UPDATE_PERSONAL_INFORMATION]:
     "pages.contactUsQuestions.provingIdentityNeedToUpdatePersonalInformation.title",
   [CONTACT_US_THEMES.PROVING_IDENTITY_SOMETHING_ELSE]:
@@ -494,6 +496,7 @@ export function contactUsQuestionsFormPostToSmartAgent(
       preferredLanguage: getPreferredLanguage(res.locals.language),
       securityCodeSentMethod: req.body.securityCodeSentMethod,
       identityDocumentUsed: req.body.identityDocumentUsed,
+      problemWith: req.body.problemWith,
     });
 
     logger.info(
@@ -808,6 +811,16 @@ export function getQuestionsFromFormTypeForMessageBody(
         { lng: "en" }
       ),
     },
+    provingIdentityProblemWithBankBuildingSocietyDetails: {
+      issueDescription: req.t(
+        "pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section2.label",
+        { lng: "en" }
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      )
+    },
     provingIdentityNeedToUpdatePersonalInformation: {
       issueDescription: req.t(
         "pages.contactUsQuestions.provingIdentityNeedToUpdatePersonalInformation.section1.label",
@@ -993,6 +1006,10 @@ export function getQuestionFromThemes(
     ),
     proving_identity_problem_with_identity_document: req.t(
       "pages.contactUsQuestions.provingIdentityProblemWithIdentityDocument.title",
+      { lng: "en" }
+    ),
+    provingIdentityProblemWithBankBuildingSocietyDetails: req.t(
+      "pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.title",
       { lng: "en" }
     ),
     proving_identity_need_to_update_personal_information: req.t(

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -1008,7 +1008,7 @@ export function getQuestionFromThemes(
       "pages.contactUsQuestions.provingIdentityProblemWithIdentityDocument.title",
       { lng: "en" }
     ),
-    provingIdentityProblemWithBankBuildingSocietyDetails: req.t(
+    proving_identity_problem_with_bank_building_society_details: req.t(
       "pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.title",
       { lng: "en" }
     ),

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -50,6 +50,20 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value, lng: req.i18n.lng }
         );
       }),
+    body("problemWith")
+      .if(body("theme").equals("proving_identity"))
+      .if(
+        body("subtheme").equals(
+          "proving_identity_problem_with_bank_building_society_details"
+        )
+      )
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section1.errorMessage",
+          { value, lng: req.i18n.lng }
+        );
+      }),
     body("issueDescription")
       .optional()
       .notEmpty()

--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -55,16 +55,15 @@ export function prepareIdentityDocumentTitle(
   return documentUsedDescription;
 }
 
-export function prepareProblemWithTitle(
-  problemWith: string
-): string {
+export function prepareProblemWithTitle(problemWith: string): string {
   let problemWithDescription = "";
   switch (problemWith) {
     case "name":
       problemWithDescription = "Entering your name";
       break;
     case "bankOrBuildingSocietyDetails":
-      problemWithDescription = "Entering your bank or building society account details";
+      problemWithDescription =
+        "Entering your bank or building society account details";
       break;
   }
 
@@ -170,7 +169,9 @@ export function contactUsServiceSmartAgent(
       contactForm.identityDocumentUsed
     );
 
-    customAttributes["sa-tag-building-society"] = prepareProblemWithTitle(contactForm.problemWith);
+    customAttributes["sa-tag-building-society"] = prepareProblemWithTitle(
+      contactForm.problemWith
+    );
 
     customAttributes["sa-webformrefer"] = getRefererTag(contactForm);
 

--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -55,6 +55,22 @@ export function prepareIdentityDocumentTitle(
   return documentUsedDescription;
 }
 
+export function prepareProblemWithTitle(
+  problemWith: string
+): string {
+  let problemWithDescription = "";
+  switch (problemWith) {
+    case "name":
+      problemWithDescription = "Entering your name";
+      break;
+    case "bankOrBuildingSocietyDetails":
+      problemWithDescription = "Entering your bank or building society account details";
+      break;
+  }
+
+  return problemWithDescription;
+}
+
 export function getIdentifierTag(theme: string): string {
   if (theme === CONTACT_US_THEMES.ID_CHECK_APP) {
     return "sign_in_app";
@@ -153,6 +169,8 @@ export function contactUsServiceSmartAgent(
     customAttributes["sa-identity-document"] = prepareIdentityDocumentTitle(
       contactForm.identityDocumentUsed
     );
+
+    customAttributes["sa-tag-building-society"] = prepareProblemWithTitle(contactForm.problemWith);
 
     customAttributes["sa-webformrefer"] = getRefererTag(contactForm);
 

--- a/src/components/contact-us/further-information/_proving-identity-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-further-information.njk
@@ -34,10 +34,6 @@
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio3' | translate
             },
             {
-                value: "proving_identity_problem_with_bank_building_society_details",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio6' | translate
-            },
-            {
             value: "proving_identity_technical_problem",
             text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio4' | translate
             },

--- a/src/components/contact-us/further-information/_proving-identity-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-further-information.njk
@@ -34,6 +34,10 @@
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio3' | translate
             },
             {
+                value: "proving_identity_problem_with_bank_building_society_details",
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio6' | translate
+            },
+            {
             value: "proving_identity_technical_problem",
             text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio4' | translate
             },

--- a/src/components/contact-us/questions/_proving-identity-problem-with-bank-building-society-details.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-with-bank-building-society-details.njk
@@ -1,0 +1,85 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+    {{ 'pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.header' | translate }}
+</h1>
+
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="theme" value="{{theme}}"/>
+    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
+    <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
+    <input type="hidden" name="formType" value="provingIdentityProblemWithBankBuildingSocietyDetails"/>
+    <input type="hidden" name="referer" value="{{referer}}"/>
+    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
+
+    {% set items = [
+        {
+            value: 'name',
+            checked: problemWith === 'name',
+            text: 'pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section1.radio1' | translate
+        },
+        {
+            value: 'bankOrBuildingSocietyDetails',
+            checked: problemWith === 'bankOrBuildingSocietyDetails',
+            text: 'pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section1.radio2' | translate
+        }
+    ] %}
+
+    {{ govukRadios({
+        name: "problemWith",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--s"
+            }
+        },
+        items: items,
+        errorMessage: {
+            text: errors['problemWith'].text
+        } if (errors['problemWith'])
+    }) }}
+
+    {{ govukCharacterCount({
+        label: {
+            text: 'pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section2.label' | translate,
+            classes: "govuk-label--s"
+        },
+        hint: {
+            text: 'pages.contactUsQuestions.provingIdentityProblemWithBankBuildingSocietyDetails.section2.hint' | translate
+        },
+        id: "issueDescription",
+        name: "issueDescription",
+        maxlength: contactUsFieldMaxLength,
+        value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
+        },
+        errorMessage: {
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
+        } if (errors['issueDescription'])
+    }) }}
+
+    {% include 'contact-us/questions/_service-trying-to-use.njk' %}
+
+    {{ govukWarningText({
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+        iconFallbackText: "Warning"
+    }) }}
+
+    {% include 'contact-us/questions/_reply_by_email.njk' %}
+
+    {{ govukButton({
+        "text": "general.sendMessage" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -123,6 +123,10 @@
         {% include 'contact-us/questions/_proving-identity-problem-with-identity-document.njk' %}
     {% endif %}
 
+    {% if (theme == 'proving_identity') and (subtheme == 'proving_identity_problem_with_bank_building_society_details') %}
+        {% include 'contact-us/questions/_proving-identity-problem-with-bank-building-society-details.njk' %}
+    {% endif %}
+
     {% if (theme == 'proving_identity') and (subtheme == 'proving_identity_need_to_update_personal_information') %}
         {% include 'contact-us/questions/_proving-identity-need-to-update-personal-information.njk' %}
     {% endif %}

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -343,6 +343,24 @@ describe("Integration:: contact us - public user", () => {
     });
   });
 
+  describe("when a user had a problem with their bank or building society details", () => {
+    it("should return validation error when user has not selected which problem they had", (done) => {
+      const data = {
+        _csrf: token,
+        theme: "proving_identity",
+        subtheme: "proving_identity_problem_with_bank_building_society_details",
+        contact: "false",
+      };
+      expectValidationErrorOnPost(
+        "/contact-us-questions",
+        data,
+        "#problemWith-error",
+        "Select which problem you were having with your bank or building society details",
+        done
+      );
+    });
+  });
+
   describe("when a user had a problem taking a photo of your identity document using the GOV.UK ID Check app", () => {
     it("should return validation error when user has not selected which identity document they were using", (done) => {
       const data = {

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -12,6 +12,7 @@ export interface ContactForm {
   preferredLanguage?: string;
   securityCodeSentMethod?: string;
   identityDocumentUsed?: string;
+  problemWith?: string;
   fromURL?: string;
 }
 
@@ -78,6 +79,7 @@ export interface SmartAgentCustomAttributes {
   "sa-tag-subtheme"?: string;
   "sa-app-error-code"?: string;
   "sa-security-mobile-country"?: string;
+  "sa-tag-building-society"?: string;
   "sa-tag-national-insurance-number"?: string;
 }
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2144,6 +2144,20 @@
           "hint": "Er enghraifft, os ydych am ychwanegu mwy o fanylion"
         }
       },
+      "provingIdentityProblemWithBankBuildingSocietyDetails": {
+        "title": "Problem gyda’ch manylion banc neu gymdeithas adeiladu",
+        "header": "Problem gyda’ch manylion banc neu gymdeithas adeiladu",
+        "section1": {
+          "header": "Pa broblem oeddech chi’n ei chael gyda’ch manylion banc neu gymdeithas adeiladu?",
+          "radio1": "Rhoi eich enw",
+          "radio2": "Rhoi eich manylion banc neu gymdeithas adeiladu",
+          "errorMessage": "Dewiswch pa broblem oeddech chi’n ei chael gyda’ch manylion banc neu gymdeithas adeiladu"
+        },
+        "section2": {
+          "label": "Unrhyw beth arall rydych angen dweud wrthym?",
+          "hint": "Er enghraifft, os ydych am ychwanegu mwy o fanylion"
+        }
+      },
       "provingIdentityNeedToUpdatePersonalInformation": {
         "title": "Mae angen i chi ddiweddaru eich gwybodaeth bersonol",
         "header": "Mae angen i chi ddiweddaru eich gwybodaeth bersonol",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2144,6 +2144,20 @@
           "hint": "For example, if you want to add more detail"
         }
       },
+      "provingIdentityProblemWithBankBuildingSocietyDetails": {
+        "title": "A problem with your bank or building society details",
+        "header": "A problem with your bank or building society details",
+        "section1": {
+          "header": "What problem were you having with your bank or building society details?",
+          "radio1": "Entering your name",
+          "radio2": "Entering your bank or building society account details",
+          "errorMessage": "Select which problem you were having with your bank or building society details"
+        },
+        "section2": {
+          "label": "Anything else you need to tell us?",
+          "hint": "For example, if you want to add more detail"
+        }
+      },
       "provingIdentityNeedToUpdatePersonalInformation": {
         "title": "You need to update your personal information",
         "header": "You need to update your personal information",


### PR DESCRIPTION
## What
Create new form “A problem with your bank or building society details” (with English / Welsh variants and appropriate error states) and link to previous user selection
<!-- Describe what you have changed and why -->

## How to review
Go to http://localhost:3000/contact-us-questions?theme=proving_identity&subtheme=proving_identity_problem_with_bank_building_society_details&referer=yourreferrer

And play with the new form

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.
![aut-2843-screenshot-en](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/055e4d0c-3f76-4946-bd06-0689a67e7ad1)
![aut-2843-screenshot-cy](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/e1b09b61-8311-4938-8102-5211b014a990)
![aut-2843-screenshot-error-en](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/1b7d0fb0-dab4-43db-81d9-949b09fc2159)

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
