### PR TITLE
Aut-2844 : add new contact form problem with national insurance number

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -181,6 +181,8 @@ export const CONTACT_US_THEMES = {
   PROVING_IDENTITY_NEED_TO_UPDATE_PERSONAL_INFORMATION:
     "proving_identity_need_to_update_personal_information",
   PROVING_IDENTITY_SOMETHING_ELSE: "proving_identity_something_else",
+  PROVING_IDENTITY_PROBLEM_WITH_NATIONAL_INSURANCE_NUMBER:
+    "proving_identity_problem_with_national_insurance_number",
 };
 
 export const CONTACT_US_FIELD_MAX_LENGTH = 1200;

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -71,6 +71,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.provingIdentityNeedToUpdatePersonalInformation.title",
   [CONTACT_US_THEMES.PROVING_IDENTITY_SOMETHING_ELSE]:
     "pages.contactUsQuestions.provingIdentitySomethingElse.title",
+  [CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_NATIONAL_INSURANCE_NUMBER]:
+    "pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
@@ -469,6 +471,8 @@ export function contactUsQuestionsFormPostToSmartAgent(
         moreDetailDescription: req.body.moreDetailDescription,
         serviceTryingToUse: req.body.serviceTryingToUse,
         countryPhoneNumberFrom: req.body.countryPhoneNumberFrom,
+        problemWithNationalInsuranceNumber:
+          req.body.problemWithNationalInsuranceNumber,
       },
       themes: { theme: req.body.theme, subtheme: req.body.subtheme },
       subject: "GOV.UK One Login",
@@ -824,6 +828,12 @@ export function getQuestionsFromFormTypeForMessageBody(
         { lng: "en" }
       ),
     },
+    provingIdentityProblemWithNationalInsuranceNumber: {
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
+    },
   };
 
   return formTypeToQuestions[formType];
@@ -991,6 +1001,10 @@ export function getQuestionFromThemes(
     ),
     proving_identity_something_else: req.t(
       "pages.contactUsQuestions.provingIdentitySomethingElse.title",
+      { lng: "en" }
+    ),
+    proving_identity_problem_with_national_insurance_number: req.t(
+      "pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.title",
       { lng: "en" }
     ),
   };

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -137,6 +137,34 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value, lng: req.i18n.lng }
         );
       }),
+    body("problemWithNationalInsuranceNumber")
+      .if(body("theme").equals("proving_identity"))
+      .if(
+        body("subtheme").equals(
+          "proving_identity_problem_with_national_insurance_number"
+        )
+      )
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.section1.errorMessage",
+          { value, lng: req.i18n.lng }
+        );
+      }),
+    body("problemWithNationalInsuranceNumber")
+      .if(body("theme").equals("proving_identity"))
+      .if(
+        body("subtheme").equals(
+          "proving_identity_problem_with_national_insurance_number"
+        )
+      )
+      .isLength({ max: CONTACT_US_FIELD_MAX_LENGTH })
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.optionalDescriptionErrorMessage.entryTooLongMessage",
+          { value, lng: req.i18n.lng }
+        );
+      }),
     body("contact")
       .notEmpty()
       .withMessage((value, { req }) => {

--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -197,6 +197,11 @@ export function contactUsServiceSmartAgent(
         contactForm.descriptions.issueDescription;
     }
 
+    if (contactForm.descriptions.problemWithNationalInsuranceNumber) {
+      customAttributes["sa-tag-national-insurance-number"] =
+        contactForm.descriptions.problemWithNationalInsuranceNumber;
+    }
+
     customAttributes["sa-tag-what-gov-service"] =
       contactForm.descriptions.serviceTryingToUse;
 

--- a/src/components/contact-us/questions/_proving-identity-problem-with-national-insurance-number.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-with-national-insurance-number.njk
@@ -1,0 +1,59 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+    {{ 'pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.header' | translate }}
+</h1>
+
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="theme" value="{{theme}}"/>
+    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
+    <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
+    <input type="hidden" name="formType" value="provingIdentityProblemWithNationalInsuranceNumber"/>
+    <input type="hidden" name="referer" value="{{referer}}"/>
+    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
+
+    <p class="govuk-body">{{ 'pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.paragraph4' | translate | safe}}</p>
+
+    {{ govukCharacterCount({
+        label: {
+            text: 'pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.section1.header' | translate,
+            classes: "govuk-label--s"
+        },
+        id: "problemWithNationalInsuranceNumber",
+        name: "problemWithNationalInsuranceNumber",
+        maxlength: contactUsFieldMaxLength,
+        value: problemWithNationalInsuranceNumber,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translate,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translate
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translate,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translate
+        },
+        errorMessage: {
+            text: errors['problemWithNationalInsuranceNumber'].text | translate | replace('[maximumCharacters]', contactUsFieldMaxLength.toLocaleString())
+        } if (errors['problemWithNationalInsuranceNumber'])
+    }) }}
+
+    {% include 'contact-us/questions/_service-trying-to-use.njk' %}
+
+    {{ govukWarningText({
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+        iconFallbackText: "Warning"
+    }) }}
+
+    {% include 'contact-us/questions/_reply_by_email.njk' %}
+
+    {{ govukButton({
+        "text": "general.sendMessage" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -135,4 +135,8 @@
         {% include 'contact-us/questions/_proving-identity-something-else.njk' %}
     {% endif %}
 
+    {% if (theme == 'proving_identity') and (subtheme == 'proving_identity_problem_with_national_insurance_number') %}
+        {% include 'contact-us/questions/_proving-identity-problem-with-national-insurance-number.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -380,7 +380,6 @@ describe("Integration:: contact us - public user", () => {
     });
   });
 
-
   describe("when a user had a problem with their phone number when creating an account", () => {
     const phoneNumberIssueData = (
       issueDescription: string,

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -362,6 +362,25 @@ describe("Integration:: contact us - public user", () => {
     });
   });
 
+  describe("when a user had a problem with their national insurance number", () => {
+    it("should return validation error when user has not described which problem they had", (done) => {
+      const data = {
+        _csrf: token,
+        theme: "proving_identity",
+        subtheme: "proving_identity_problem_with_national_insurance_number",
+        contact: "false",
+      };
+      expectValidationErrorOnPost(
+        "/contact-us-questions",
+        data,
+        "#problemWithNationalInsuranceNumber-error",
+        "What problem were you having with your National Insurance number?",
+        done
+      );
+    });
+  });
+
+
   describe("when a user had a problem with their phone number when creating an account", () => {
     const phoneNumberIssueData = (
       issueDescription: string,

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -45,6 +45,7 @@ export interface Descriptions {
   moreDetailDescription?: string;
   serviceTryingToUse?: string;
   countryPhoneNumberFrom?: string;
+  problemWithNationalInsuranceNumber?: string;
 }
 
 export interface Themes {
@@ -77,6 +78,7 @@ export interface SmartAgentCustomAttributes {
   "sa-tag-subtheme"?: string;
   "sa-app-error-code"?: string;
   "sa-security-mobile-country"?: string;
+  "sa-tag-national-insurance-number"?: string;
 }
 
 export interface SmartAgentTicket {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2171,8 +2171,21 @@
         "section2": {
           "errorMessage": "Rhowch beth ddigwyddodd"
         }
+      },
+      "provingIdentityProblemWithNationalInsuranceNumber": {
+        "title": "Problem gyda’ch rhif Yswiriant Gwladol",
+        "header": "Problem gyda’ch rhif Yswiriant Gwladol",
+        "paragraph1": "Mae eich rhif Yswiriant Gwladol yn cael ei wneud i fyny o  2 lythyren, 6 rhif a llythyren terfynol.",
+        "paragraph2": "Er enghraifft, QQ123456B.",
+        "paragraph3": "Gallwch ddod o hyd i’ch rhif Yswiriant Gwladol ar eich slip cyflog, P60 neu lythyr budd-dal.",
+        "paragraph4": "Gallwch ddarllen mwy am gael neu ddod o hyd i’ch rhif Yswiriant Gwladol yn <a href=\"https://www.gov.uk/rhif-yswiriant-gwladol-coll\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">www.gov.uk/rhif-yswiriant-gwladol-coll</a>",
+        "section1": {
+          "header": "Pa broblem oeddech chi’n ei chael gyda’ch rhif Yswiriant Gwladol?",
+          "errorMessage": "Pa broblem oeddech chi’n ei chael gyda’ch rhif Yswiriant Gwladol?"
+        }
       }
     },
+    
     "contactUsSubmitSuccess": {
       "title": "Mae eich neges wedi ei anfon",
       "header": "Mae eich neges wedi ei anfon",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2171,8 +2171,21 @@
         "section2": {
           "errorMessage": "Enter what happened"
         }
+      },
+      "provingIdentityProblemWithNationalInsuranceNumber": {
+        "title": "A problem with your National Insurance number",
+        "header": "A problem with your National Insurance number",
+        "paragraph1": "Your National Insurance number is made up of 2 letters, 6 numbers and a final letter.",
+        "paragraph2": "For example, QQ123456B.",
+        "paragraph3": "You can find your National Insurance number on your payslip, P60 or benefit letter.",
+        "paragraph4": "You can read more about getting or finding your National Insurance number at <a href=\"https://www.gov.uk/find-national-insurance-number\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">www.gov.uk/find-national-insurance-number</a>",
+        "section1": {
+          "header": "What problem were you having with your National Insurance number?",
+          "errorMessage": "What problem were you having with your National Insurance number?"
+        }
       }
     },
+    
     "contactUsSubmitSuccess": {
       "title": "Your message has been submitted",
       "header": "Your message has been submitted",


### PR DESCRIPTION
## What
Create new form “A problem with your national insurance number” (with English / Welsh variants and appropriate error states) and link to previous user selection
<!-- Describe what you have changed and why -->

## How to review
Go to http://localhost:3000/contact-us-questions?theme=proving_identity&subtheme=proving_identity_problem_with_national_insurance_number&lng=en&referer=

And play with the new form.
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.
![aut-2844-screenshot-error-en](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/85e27d7e-5f2a-4935-9168-52c4a58e79d4)
![aut-2844-screenshot-en](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/342c73e2-1b56-4efa-a010-cff7e80d8bd9)
![aut-2844-screenshot-cy](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/22ebd22b-3ce2-408b-bb73-cf2c86262e93)

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
