### PR TITLE
AUT-2726: Enable language toggle in integration and production

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -11,6 +11,7 @@ support_authorize_controller  = "1"
 support_2fa_b4_password_reset = "1"
 support_2hr_lockout           = "1"
 support_reauthentication      = "1"
+language_toggle_enabled       = "1"
 
 code_request_blocked_minutes                        = "120"
 account_recovery_code_entered_wrong_blocked_minutes = "120"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -19,6 +19,7 @@ code_entered_wrong_blocked_minutes                  = "120"
 email_entered_wrong_blocked_minutes                 = "120"
 password_reset_code_entered_wrong_blocked_minutes   = "120"
 reduced_code_block_duration_minutes                 = "15"
+language_toggle_enabled                             = "1"
 
 url_for_support_links = "https://home.account.gov.uk/contact-gov-uk-one-login"
 


### PR DESCRIPTION
## What

Enables language toggle in integration and production

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.


## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1515 introduced the language toggle dependency and references the UCD sign off that was provided by central UCD
- https://github.com/govuk-one-login/authentication-frontend/pull/1613 updated the package dependency and describes how the toggle can be tested locally
