### PR TITLE
AUT-2776 contact us page spamming - Sanitize free text value into contact us forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.366.0",
+    "@govuk-one-login/frontend-analytics": "1.0.3",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "^0.0.3",
-    "@govuk-one-login/frontend-analytics": "1.0.3",
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-base32-enc-dec": "^12.0.1",
     "aws-sdk": "^2.1356.0",

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -1,11 +1,17 @@
-import { body, check } from "express-validator";
+import { CustomSanitizer, body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
+import xss from "xss";
 import {
   CONTACT_US_FIELD_MAX_LENGTH,
   CONTACT_US_THEMES,
   CONTACT_US_COUNTRY_MAX_LENGTH,
 } from "../../app.constants";
+const sanitizeFreeTextValue: CustomSanitizer = function sanitizeFreeTextValue(
+  value: string
+) {
+  return xss(value);
+};
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
@@ -242,6 +248,19 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value, lng: req.i18n.lng }
         );
       }),
+    //Free text Sanitizers
+    body("serviceTryingToUse").customSanitizer(sanitizeFreeTextValue),
+    body("problemWithNationalInsuranceNumber").customSanitizer(
+      sanitizeFreeTextValue
+    ),
+    body("moreDetailDescription").customSanitizer(sanitizeFreeTextValue),
+    body("optionalDescription").customSanitizer(sanitizeFreeTextValue),
+    body("additionalDescription").customSanitizer(sanitizeFreeTextValue),
+    body("problemWith").customSanitizer(sanitizeFreeTextValue),
+    body("issueDescription").customSanitizer(sanitizeFreeTextValue),
+    body("name").customSanitizer(sanitizeFreeTextValue),
+    body("country").customSanitizer(sanitizeFreeTextValue),
+    body("countryPhoneNumberFrom").customSanitizer(sanitizeFreeTextValue),
     validateBodyMiddleware("contact-us/questions/index.njk"),
   ];
 }


### PR DESCRIPTION
## What
Into Contact forms, Sanitize free text value and add contact form submission rate limit.

<!-- Describe what you have changed and why -->
- Add an xss filter on free text value from contact forms.

## How to review
1/ Go to any contact form page, fill a free text field with some js code inside (ex: `<script>alert("test")</script>`) and be sure the form is not submitted and error message is here.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
