### PR TITLE
AUT-2797: Remove terms that trigger iOS bug from labels

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Reformatting of deploy-authdevs.sh
 4cf011b283c9b95e4733d4463d0f5352379ad8cb
+
+# Reformatting of setup-authenticator-app/index.njk
+6d381db8202a53dc65b653bed679bdcc9cf130c6

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
@@ -139,7 +139,7 @@ describe("Integration:: check your email security codes", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($("#code-error").text()).to.contains("Enter the code");
       })
       .expect(400, done);
   });
@@ -156,7 +156,7 @@ describe("Integration:: check your email security codes", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -174,7 +174,7 @@ describe("Integration:: check your email security codes", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -193,7 +193,7 @@ describe("Integration:: check your email security codes", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -235,7 +235,7 @@ describe("Integration:: check your email security codes", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
       .expect(400, done);

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -83,7 +83,7 @@ describe("Integration:: check your email", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($("#code-error").text()).to.contains("Enter the code");
       })
       .expect(400, done);
   });
@@ -100,7 +100,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -118,7 +118,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -136,7 +136,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -177,7 +177,7 @@ describe("Integration:: check your email", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
       .expect(400, done);

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -86,7 +86,7 @@ describe("Integration:: check your phone", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($("#code-error").text()).to.contains("Enter the code");
       })
       .expect(400, done);
   });
@@ -103,7 +103,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -121,7 +121,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -139,7 +139,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -183,7 +183,7 @@ describe("Integration:: check your phone", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
       .expect(400, done);

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -113,7 +113,7 @@ describe("Integration:: enter authenticator app code", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($("#code-error").text()).to.contains("Enter the code");
       })
       .expect(400, done);
   });
@@ -130,7 +130,7 @@ describe("Integration:: enter authenticator app code", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -148,7 +148,7 @@ describe("Integration:: enter authenticator app code", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -166,7 +166,7 @@ describe("Integration:: enter authenticator app code", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -226,7 +226,7 @@ describe("Integration:: enter authenticator app code", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "The security code you entered is not correct, check your authenticator app and try again"
+          "The code you entered is not correct, check your authenticator app and try again"
         );
       })
       .expect(400, done);

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -131,7 +131,7 @@ describe("Integration:: enter mfa", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the security code");
+        expect($("#code-error").text()).to.contains("Enter the code");
       })
       .expect(400, done);
   });
@@ -149,7 +149,7 @@ describe("Integration:: enter mfa", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -168,7 +168,7 @@ describe("Integration:: enter mfa", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -187,7 +187,7 @@ describe("Integration:: enter mfa", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
       })
       .expect(400, done);
@@ -230,7 +230,7 @@ describe("Integration:: enter mfa", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          " The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          " The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
       .expect(400, done);

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -315,7 +315,9 @@ describe("Integration::enter phone number", () => {
         phoneNumber: "07738394991",
       })
       .expect((res) => {
-        res.text.includes("You asked to resend the code too many times");
+        res.text.includes(
+          "You asked to resend the security code too many times"
+        );
       })
       .expect((res) => {
         res.text.includes("You will not be able to continue for 2 hours.");

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -315,9 +315,7 @@ describe("Integration::enter phone number", () => {
         phoneNumber: "07738394991",
       })
       .expect((res) => {
-        res.text.includes(
-          "You asked to resend the security code too many times"
-        );
+        res.text.includes("You asked to resend the code too many times");
       })
       .expect((res) => {
         res.text.includes("You will not be able to continue for 2 hours.");

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -136,7 +136,7 @@ describe("Integration::reset password check email ", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "The security code you entered is not correct"
+          "The code you entered is not correct"
         );
       })
       .expect(400, done);

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -11,78 +11,78 @@
 
 {% block content %}
 
-  {% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-  {% set noAuthAppInsetTextHtml %}
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph1' | translate}}</p>
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph2' | translate}}</p>
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph3' | translate}}</p>
-  {% endset %}
+    {% set noAuthAppInsetTextHtml %}
+        <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph1' | translate }}</p>
+        <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph2' | translate }}</p>
+        <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph3' | translate }}</p>
+    {% endset %}
 
-  {% set cannotScanInsetTextHtml %}
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph1' | translate}}</p>
-  <p class="govuk-body" id="secret-key">
-    <span class="govuk-!-display-block">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph2' | translate}}</span>
-    {{ displaySecretKey(secretKeyFragmentArray) }}
-  </p>
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph3' | translate}}</p>
-  {% endset %}
+    {% set cannotScanInsetTextHtml %}
+        <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.cannotScanDetails.paragraph1' | translate }}</p>
+        <p class="govuk-body" id="secret-key">
+            <span class="govuk-!-display-block">{{ 'pages.setupAuthenticatorApp.cannotScanDetails.paragraph2' | translate }}</span>
+            {{ displaySecretKey(secretKeyFragmentArray) }}
+        </p>
+        <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.cannotScanDetails.paragraph3' | translate }}</p>
+    {% endset %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.setupAuthenticatorApp.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.setupAuthenticatorApp.header' | translate }}</h1>
 
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step1' | translate }}</p>
-  {{ govukDetails({
+    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step1' | translate }}</p>
+    {{ govukDetails({
         summaryText: 'pages.setupAuthenticatorApp.noAuthAppDetails.summaryText' | translate,
         html: noAuthAppInsetTextHtml
-  }) }}
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step2' | translate }}</p>
-
-  <p class="govuk-body">
-    <img id="qr-code" src="{{qrCode}}" alt="QR Code Image">
-  </p>
-
-  {{ govukDetails({
-    summaryText: 'pages.setupAuthenticatorApp.cannotScanDetails.summaryText' | translate,
-    html: cannotScanInsetTextHtml
-  }) }}
-
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step3' | translate }}</p>
-  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step4' | translate }}</p>
-
-  <form id="form-tracking" method="post" novalidate="novalidate">
-
-    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-    <input type="hidden" name="_secretKey" value="{{secretKey}}"/>
-
-    {{ govukInput({
-  label: {
-  text: 'pages.setupAuthenticatorApp.code.label' | translate
-  },
-  hint: {
-      text: 'pages.setupAuthenticatorApp.code.hintText' | translate
-  },
-  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-  id: "code",
-  name: "code",
-  inputmode: "numeric",
-  spellcheck: false,
-  autocomplete: "one-time-code",
-  errorMessage: {
-  text: errors['code'].text
-  } if (errors['code'])})
-  }}
-
-    {{ govukButton({
-  "text": "general.continue.label" | translate,
-  "type": "Submit",
-  "preventDoubleClick": true
-  }) }}
+    }) }}
+    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step2' | translate }}</p>
 
     <p class="govuk-body">
-      <a href="/get-security-codes" class="govuk-link" rel="noreferrer">{{'pages.setupAuthenticatorApp.changeMfaChoiceLinkText' | translate }}</a>
+        <img id="qr-code" src="{{ qrCode }}" alt="QR Code Image">
     </p>
 
-  </form>
+    {{ govukDetails({
+        summaryText: 'pages.setupAuthenticatorApp.cannotScanDetails.summaryText' | translate,
+        html: cannotScanInsetTextHtml
+    }) }}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step3' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step4' | translate }}</p>
+
+    <form id="form-tracking" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="_secretKey" value="{{ secretKey }}" />
+
+        {{ govukInput({
+            label: {
+                text: 'pages.setupAuthenticatorApp.code.label' | translate
+            },
+            hint: {
+                text: 'pages.setupAuthenticatorApp.code.hintText' | translate
+            },
+            classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+            id: "code",
+            name: "code",
+            inputmode: "numeric",
+            spellcheck: false,
+            autocomplete: "one-time-code",
+            errorMessage: {
+                text: errors['code'].text
+            } if (errors['code'])}) }}
+
+        {{ govukButton({
+            "text": "general.continue.label" | translate,
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
+
+        <p class="govuk-body">
+            <a href="/get-security-codes" class="govuk-link"
+               rel="noreferrer">{{ 'pages.setupAuthenticatorApp.changeMfaChoiceLinkText' | translate }}</a>
+        </p>
+
+    </form>
+
+    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true }) }}
 {% endblock %}

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -47,7 +47,6 @@
     }) }}
 
     <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step3' | translate }}</p>
-    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step4' | translate }}</p>
 
     <form id="form-tracking" method="post" novalidate="novalidate">
 

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -88,7 +88,7 @@ describe("Integration::setup-authenticator-app", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code shown in your authenticator app"
+          "Enter the code shown in your authenticator app"
         );
         expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
@@ -107,7 +107,7 @@ describe("Integration::setup-authenticator-app", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
         expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
@@ -126,7 +126,7 @@ describe("Integration::setup-authenticator-app", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains(
-          "Enter the security code using only 6 digits"
+          "Enter the code using only 6 digits"
         );
         expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -301,13 +301,13 @@
       "paragraph4": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
       "paragraph5": "Bydd y cod yn dod i ben ar ôl 15 munud.",
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd"
         }
       },
       "details": {
@@ -409,13 +409,13 @@
         "paragraph3": "Bydd y cod yn dod i ben ar ôl awr."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd"
         }
       },
       "details": {
@@ -436,13 +436,13 @@
         "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd"
         }
       },
       "details": {
@@ -532,13 +532,13 @@
         "paragraph1": "os nad yw’r cod yn gweithio neu mae wedi dod i ben, neu ni dderbynioch un."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd"
         }
       },
       "details": {
@@ -570,13 +570,13 @@
         "paragraph1": "os nad yw’r cod yn gweithio neu mae wedi dod i ben, neu ni dderbynioch un."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd"
         }
       },
       "details": {
@@ -643,13 +643,13 @@
         "paragraph1": "Mae’r e-bost yn cynnwys cod diogelwch 6 digid. Ar ôl i chi roi eich cod, byddwch yn gallu newid sut i gael codau diogelwch pan fyddwch yn mewngofnodi.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
         "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud.",
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod 6 digid",
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
+          "required": "Rhowch y cod",
+          "maxLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "minLength": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi eto neu ofyn am god newydd"
         }
       },
       "details": {
@@ -2289,14 +2289,14 @@
         "paragraph3": "Mae rhai apiau dilysydd yn galw’r allwedd gyfrinachol yn ‘cod’."
       },
       "step3": "3. Bydd yr ap dilysydd yn dangos cod diogelwch.",
-      "step4": "4. Rhowch y cod diogelwch.",
+      "step4": "4. Rhowch y cod.",
       "code": {
-        "label": "Cod diogelwch",
+        "label": "Cod",
         "hintText": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
-          "required": "Rhowch y cod diogelwch a ddangosir yn eich ap dilysydd",
-          "invalidCode": "Nid yw’r cod diogelwch a roddwyd gennych yn gywir, gwiriwch eich ap dilyswr a cheisiwch eto",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig"
+          "required": "Rhowch y cod a dangosir yn eich ap dilysydd",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, gwiriwch eich ap dilysydd a rhowch gynnig arall",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid"
         }
       },
       "continueButtonText": "Parhau",
@@ -2307,9 +2307,9 @@
       "header": "Rhowch y cod diogelwch 6 digid a ddangosir yn eich ap dilysydd",
       "code": {
         "validationError": {
-          "required": "Rhowch y cod diogelwch",
-          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "invalidCode": "Nid yw’r cod diogelwch a roddwyd gennych yn gywir, gwiriwch eich ap dilyswr a cheisiwch eto"
+          "required": "Rhowch y cod",
+          "invalidFormat": "Rhowch y cod gan ddefnyddio dim ond 6 digid",
+          "invalidCode": "Nid yw’r cod a roddwyd gennych yn gywir, gwiriwch eich ap dilysydd a rhowch gynnig arall"
         }
       },
       "details": {
@@ -2328,7 +2328,7 @@
           "paragraph2End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login"
         },
         "code": {
-          "label": "Rhowch y cod diogelwch",
+          "label": "Rhowch y cod",
           "labelSummary": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd"
         }
       },
@@ -2341,7 +2341,7 @@
           "paragraph1End": "a ddefnyddiwyd gennych i greu eich GOV.UK One Login"
         },
         "code":{
-          "label": "Rhowch y cod diogelwch 6 digid"
+          "label": "Rhowch y cod 6 digid"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2289,9 +2289,8 @@
         "paragraph3": "Mae rhai apiau dilysydd yn galw’r allwedd gyfrinachol yn ‘cod’."
       },
       "step3": "3. Bydd yr ap dilysydd yn dangos cod diogelwch.",
-      "step4": "4. Rhowch y cod.",
       "code": {
-        "label": "Cod",
+        "label": "4. Rhowch y cod.",
         "hintText": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
           "required": "Rhowch y cod a dangosir yn eich ap dilysydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -301,13 +301,13 @@
       "paragraph4": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
       "paragraph5": "The code will expire after 15 minutes.",
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
       },
       "details": {
@@ -409,13 +409,13 @@
         "paragraph3": "The code will expire after one hour."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
       },
       "details": {
@@ -436,13 +436,13 @@
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
       },
       "details": {
@@ -532,13 +532,13 @@
         "paragraph1": "if the code does not work or has expired, or you did not receive one."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
       },
       "details": {
@@ -570,13 +570,13 @@
         "paragraph1": "if the code does not work or has expired, or you did not receive one."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
       },
       "details": {
@@ -643,13 +643,13 @@
         "paragraph1": "The email contains a 6 digit security code. After you enter the code, you’ll be able to change how you get security codes when you sign in.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
         "paragraph3": "The code will expire after 15 minutes.",
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the 6 digit code",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Enter the code",
+          "maxLength": "Enter the code using only 6 digits",
+          "minLength": "Enter the code using only 6 digits",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
       },
       "details": {
@@ -2289,14 +2289,14 @@
         "paragraph3": "Some authenticator apps call the secret key a ‘code’."
       },
       "step3": "3. The authenticator app will show a security code.",
-      "step4": "4. Enter the security code.",
+      "step4": "4. Enter the code.",
       "code": {
-        "label": "Security code",
+        "label": "Code",
         "hintText": "This is the 6-digit number shown in your authenticator app",
         "validationError": {
-          "required": "Enter the security code shown in your authenticator app",
-          "invalidCode": "The security code you entered is not correct, check your authenticator app and try again",
-          "invalidFormat": "Enter the security code using only 6 digits"
+          "required": "Enter the code shown in your authenticator app",
+          "invalidCode": "The code you entered is not correct, check your authenticator app and try again",
+          "invalidFormat": "Enter the code using only 6 digits"
         }
       },
       "continueButtonText": "Continue",
@@ -2307,9 +2307,9 @@
       "header": "Enter the 6 digit security code shown in your authenticator app",
       "code": {
         "validationError": {
-          "required": "Enter the security code",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, check your authenticator app and try again"
+          "required": "Enter the code",
+          "invalidFormat": "Enter the code using only 6 digits",
+          "invalidCode": "The code you entered is not correct, check your authenticator app and try again"
         }
       },
       "details": {
@@ -2328,7 +2328,7 @@
           "paragraph2End": "you used to create your GOV.UK One Login"
         },
         "code": {
-          "label": "Enter the security code",
+          "label": "Enter the code",
           "labelSummary": "This is the 6-digit number shown in your authenticator app"
         }
       },
@@ -2341,7 +2341,7 @@
           "paragraph1End": "you used to create your GOV.UK One Login"
         },
         "code":{
-          "label": "Enter the 6 digit security code"
+          "label": "Enter the 6 digit code"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2289,9 +2289,8 @@
         "paragraph3": "Some authenticator apps call the secret key a ‘code’."
       },
       "step3": "3. The authenticator app will show a security code.",
-      "step4": "4. Enter the code.",
       "code": {
-        "label": "Code",
+        "label": "4. Enter the code.",
         "hintText": "This is the 6-digit number shown in your authenticator app",
         "validationError": {
           "required": "Enter the code shown in your authenticator app",

--- a/src/locales/tests/locale.test.ts
+++ b/src/locales/tests/locale.test.ts
@@ -16,6 +16,24 @@ export function traverseObjectProperties(
   });
 }
 
+export function testForSecurityCodeInLabel(key: string, value: string): void {
+  if (key.search(/label/) !== -1) {
+    expect(value.toLowerCase()).to.not.contain(
+      "security code",
+      `Label '${value}' contains 'security code'`
+    );
+  }
+}
+
+export function testForCodDiogelwchInLabel(key: string, value: string): void {
+  if (key.search(/label/) !== -1) {
+    expect(value.toLowerCase()).to.not.contain(
+      "cod diogelwch",
+      `Label '${value}' contains 'cod diogelwch'`
+    );
+  }
+}
+
 export function testExpectation(key: string, value: string): void {
   expect(value).to.not.contain(
     "'",
@@ -58,5 +76,15 @@ describe("locale file structure", () => {
 
   it("should be that locale files have the same keys in the same position", () => {
     expect(englishTranslationFileKeys).to.eql(welshTranslationFileKeys);
+  });
+});
+
+describe("form labels", () => {
+  it("should not contain the phrase 'security code' in English translations", () => {
+    traverseObjectProperties(englishTranslations, testForSecurityCodeInLabel);
+  });
+
+  it("should not contain the phrase 'cod diogelwch' in Welsh translations", () => {
+    traverseObjectProperties(welshTranslations, testForCodDiogelwchInLabel);
   });
 });


### PR DESCRIPTION
## What

A bug in Safari on iOS causes users to be prompted to 'Scan card' when specific input fields receive focus. Device testing has revealed this impacts only those fields containing the term 'security code'. It seems this is causing browser autocomplete heuristics to interpret the field purpose as being for a CVV code.

This PR:

* removes the term 'security code' from all form labels and introduces tests to ensure it is not reintroduced
* updates error messages to be consistent with the new labels
* introduces a change requested by UCD to combine an instruction with the associated form label (avoiding redundant messaging). 

### Forms that have been updated

The term "security code" has been removed from field labels and error messages in:

* The **set up an authenticator app** page
* The **check your phone** page presented during account creation, sign in and password reset journeys
* The **check your email** page presented to users during account creation, password reset and change 2FA method journeys

### Example screenshots

These examples have details elements in an expanded state only for their initial render state (the content of these will be identical in error states).

<details>

<summary>Set up an authenticator app (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/5d4196d6-f090-4177-a48d-eb4aef73f6f6)


</details>


<details>

<summary>Set up an authenticator app (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/f04c5654-2be7-4608-8ff8-ffac6500bcae)


</details>

<details>

<summary>Set up an authenticator app - required error state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/c75840b1-db9e-4766-8a03-5f9e16ab1940)


</details>

<details>

<summary>Set up an authenticator app - required error state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/4a1af442-b26e-4790-b0d1-15c848a32862)

</details>

<details>

<summary>Set up an authenticator app - incorrect code state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/71c99ea4-02e2-4ab8-b8af-4d0eef49414a)


</details>

<details>

<summary>Set up an authenticator app -  incorrect code state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1046ce16-eea9-416d-a50f-cb083dd5c03d)


</details>

<details>

<summary>Set up an authenticator app - incorrect length or format state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1cd410c3-e511-4325-922d-aaa602cbe3db)


</details>

<details>

<summary>Set up an authenticator app -  incorrect length or format state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1eb7e981-c201-4016-acdf-ac04a640e93b)

</details>

<details>

<summary>Check your phone (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/90e6bac2-5dcf-4729-b843-e54d3b5580a0)

</details>

<details>

<summary>Check your phone (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/39af46dd-8855-4e80-ba37-f629595f29b9)

</details>

<details>

<summary>Check your phone - required error state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/f8cf87d3-4f89-404d-adaf-9cc5f0aecdad)

</details>

<details>

<summary>Check your phone - required error state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/fbe0afeb-e11a-4e24-b9ce-a485ffdca9a3)



</details>

<details>

<summary>Check your phone - incorrect length or format state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/576aca3b-76ba-4013-af8e-4a9562889e14)


</details>

<details>

<summary>Check your phone - incorrect length or format state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/23cac101-b3b0-4cf2-a575-2f3d44561e19)

</details>

<details>

<summary>Check your phone - incorrect code state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/2fdf182f-6331-4028-ba8e-a9f53e9e5510)


</details>

<details>

<summary>Check your phone - incorrect code state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/7062e3d8-866a-4650-b9f7-35721f9552ca)

</details>

<details>

<summary>Check your email (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/fd7df75e-2a2b-4bb0-acd3-7881122d5071)


</details>

<details>

<summary>Check your email (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/cda12076-8528-40c9-89ae-61cc1bd303cb)


</details>

<details>

<summary>Check your email - required error state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/1f0fdf15-2fa2-4903-a173-bdaa2420f5b8)


</details>

<details>

<summary>Check your email - required error state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/01d3fa0c-be31-4930-b94e-c197c4beca3c)



</details>

<details>

<summary>Check your email - incorrect length or format state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/7ae4d288-a674-4701-a00a-fcf794de491d)


</details>

<details>

<summary>Check your email - incorrect length or format state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/c81361cc-5ad7-4585-9b0b-4d2435ca569e)


</details>

<details>

<summary>Check your email - incorrect code state (English)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/13886b0c-d5d8-4812-a214-75cdc6750708)


</details>

<details>

<summary>Check your email - incorrect code state (Welsh)</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/d7623009-1bef-4084-b176-91c1a16d9632)


</details>


## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.