### PR TITLE
AUT-2883: Align sandpit frontend switches and lockout config with build

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -1,20 +1,31 @@
-environment                   = "authdev1"
-common_state_bucket           = "di-auth-development-tfstate"
-aws_region                    = "eu-west-2"
-account_management_fqdn       = "acc-mgmt-fg.authdev1.sandpit.auth.ida.digital.cabinet-office.gov.uk"
-oidc_api_fqdn                 = "oidc.authdev1.sandpit.account.gov.uk"
-frontend_fqdn                 = "signin.authdev1.sandpit.account.gov.uk"
-frontend_api_fqdn             = "auth.authdev1.sandpit.account.gov.uk"
-service_domain                = "authdev1.sandpit.account.gov.uk"
-zone_id                       = "Z062000928I8D7S9X1OVA"
-session_expiry                = 300000
-gtm_id                        = ""
-support_account_recovery      = "1"
-support_authorize_controller  = "1"
-support_2fa_b4_password_reset = "1"
-support_check_email_fraud     = "1"
-language_toggle_enabled       = "1"
-no_photo_id_contact_forms     = "1"
+environment             = "authdev1"
+common_state_bucket     = "di-auth-development-tfstate"
+aws_region              = "eu-west-2"
+account_management_fqdn = "acc-mgmt-fg.authdev1.sandpit.auth.ida.digital.cabinet-office.gov.uk"
+oidc_api_fqdn           = "oidc.authdev1.sandpit.account.gov.uk"
+frontend_fqdn           = "signin.authdev1.sandpit.account.gov.uk"
+frontend_api_fqdn       = "auth.authdev1.sandpit.account.gov.uk"
+service_domain          = "authdev1.sandpit.account.gov.uk"
+zone_id                 = "Z062000928I8D7S9X1OVA"
+session_expiry          = 300000
+gtm_id                  = ""
+
+support_account_recovery                            = "1"
+support_authorize_controller                        = "1"
+support_account_interventions                       = "1"
+support_reauthentication                            = "1"
+support_2fa_b4_password_reset                       = "1"
+support_2hr_lockout                                 = "1"
+support_check_email_fraud                           = "1"
+password_reset_code_entered_wrong_blocked_minutes   = "1"
+account_recovery_code_entered_wrong_blocked_minutes = "1"
+code_request_blocked_minutes                        = "1"
+email_entered_wrong_blocked_minutes                 = "1"
+code_entered_wrong_blocked_minutes                  = "1"
+reduced_code_block_duration_minutes                 = "0.5"
+url_for_support_links                               = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+language_toggle_enabled                             = "1"
+no_photo_id_contact_forms                           = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024
@@ -30,8 +41,6 @@ cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 
 alb_idle_timeout = 30
-
-url_for_support_links = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENB3csRUIdoaTHNn079Jl7JpiXzxF\n0p2ZIddCErxtIhGMTTqtbQZJCPesSKUVE/DQbpIko3mLoisuFgmQfFouCw==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -1,20 +1,31 @@
-environment                   = "authdev2"
-common_state_bucket           = "di-auth-development-tfstate"
-aws_region                    = "eu-west-2"
-account_management_fqdn       = "acc-mgmt-fg.authdev2.sandpit.auth.ida.digital.cabinet-office.gov.uk"
-oidc_api_fqdn                 = "oidc.authdev2.sandpit.account.gov.uk"
-frontend_fqdn                 = "signin.authdev2.sandpit.account.gov.uk"
-frontend_api_fqdn             = "auth.authdev2.sandpit.account.gov.uk"
-service_domain                = "authdev2.sandpit.account.gov.uk"
-zone_id                       = "Z062000928I8D7S9X1OVA"
-session_expiry                = 300000
-gtm_id                        = ""
-support_account_recovery      = "1"
-support_authorize_controller  = "1"
-support_2fa_b4_password_reset = "1"
-support_check_email_fraud     = "1"
-language_toggle_enabled       = "1"
-no_photo_id_contact_forms     = "1"
+environment             = "authdev2"
+common_state_bucket     = "di-auth-development-tfstate"
+aws_region              = "eu-west-2"
+account_management_fqdn = "acc-mgmt-fg.authdev2.sandpit.auth.ida.digital.cabinet-office.gov.uk"
+oidc_api_fqdn           = "oidc.authdev2.sandpit.account.gov.uk"
+frontend_fqdn           = "signin.authdev2.sandpit.account.gov.uk"
+frontend_api_fqdn       = "auth.authdev2.sandpit.account.gov.uk"
+service_domain          = "authdev2.sandpit.account.gov.uk"
+zone_id                 = "Z062000928I8D7S9X1OVA"
+session_expiry          = 300000
+gtm_id                  = ""
+
+support_account_recovery                            = "1"
+support_authorize_controller                        = "1"
+support_account_interventions                       = "1"
+support_reauthentication                            = "1"
+support_2fa_b4_password_reset                       = "1"
+support_2hr_lockout                                 = "1"
+support_check_email_fraud                           = "1"
+password_reset_code_entered_wrong_blocked_minutes   = "1"
+account_recovery_code_entered_wrong_blocked_minutes = "1"
+code_request_blocked_minutes                        = "1"
+email_entered_wrong_blocked_minutes                 = "1"
+code_entered_wrong_blocked_minutes                  = "1"
+reduced_code_block_duration_minutes                 = "0.5"
+url_for_support_links                               = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+language_toggle_enabled                             = "1"
+no_photo_id_contact_forms                           = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024
@@ -30,8 +41,6 @@ cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 
 alb_idle_timeout = 30
-
-url_for_support_links = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUm\nBhnWynwAkE/YZlskX+N7VmwIjupla7O6hczlIOqkmPdQ1ayDqI8yY2QOiw==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,23 +1,32 @@
-environment                   = "sandpit"
-common_state_bucket           = "digital-identity-dev-tfstate"
-aws_region                    = "eu-west-2"
-account_management_fqdn       = "acc-mgmt-fg.sandpit.auth.ida.digital.cabinet-office.gov.uk"
-oidc_api_fqdn                 = "oidc.sandpit.account.gov.uk"
-frontend_fqdn                 = "signin.sandpit.account.gov.uk"
-frontend_fqdn_origin          = "origin.signin.sandpit.account.gov.uk"
-frontend_api_fqdn             = "auth.sandpit.account.gov.uk"
-service_domain                = "sandpit.account.gov.uk"
-zone_id                       = "Z1031735QZMC84WYW1TP"
-session_expiry                = 300000
-gtm_id                        = ""
-support_account_recovery      = "1"
-support_authorize_controller  = "1"
-support_account_interventions = "1"
-support_2fa_b4_password_reset = "1"
-support_check_email_fraud     = "1"
-language_toggle_enabled       = "1"
-no_photo_id_contact_forms     = "0"
+environment             = "sandpit"
+common_state_bucket     = "digital-identity-dev-tfstate"
+aws_region              = "eu-west-2"
+account_management_fqdn = "acc-mgmt-fg.sandpit.auth.ida.digital.cabinet-office.gov.uk"
+oidc_api_fqdn           = "oidc.sandpit.account.gov.uk"
+frontend_fqdn           = "signin.sandpit.account.gov.uk"
+frontend_fqdn_origin    = "origin.signin.sandpit.account.gov.uk"
+frontend_api_fqdn       = "auth.sandpit.account.gov.uk"
+service_domain          = "sandpit.account.gov.uk"
+zone_id                 = "Z1031735QZMC84WYW1TP"
+session_expiry          = 300000
+gtm_id                  = ""
 
+support_account_recovery                            = "1"
+support_authorize_controller                        = "1"
+support_account_interventions                       = "1"
+support_reauthentication                            = "1"
+support_2fa_b4_password_reset                       = "1"
+support_2hr_lockout                                 = "1"
+support_check_email_fraud                           = "1"
+password_reset_code_entered_wrong_blocked_minutes   = "1"
+account_recovery_code_entered_wrong_blocked_minutes = "1"
+code_request_blocked_minutes                        = "1"
+email_entered_wrong_blocked_minutes                 = "1"
+code_entered_wrong_blocked_minutes                  = "1"
+reduced_code_block_duration_minutes                 = "0.5"
+url_for_support_links                               = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+language_toggle_enabled                             = "1"
+no_photo_id_contact_forms                           = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024
@@ -33,8 +42,6 @@ cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 
 alb_idle_timeout = 30
-
-url_for_support_links = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"


### PR DESCRIPTION

## What

Align sandpit frontend switches and lockout config with build.

Removes unexpected behaviour when testing due to 2hr lockout being switched off.

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/4607/