### PR TITLE
AUT-2729: Fix text wrapping issue on home page

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -17,7 +17,7 @@
 {% block content %}
     {% include "common/errors/errorSummary.njk" %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate | striptags | safe }} </h1>
 
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph1' | translate }}</p>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -164,7 +164,7 @@
     "signInOrCreate": {
       "mandatory": {
         "title": "Creu eich GOV.UK One Login neu fewngofnodi",
-        "header": "Creu eich GOV.UK One Login neu fewngofnodi"
+        "header": "Creu eich GOV.UK One&nbsp;Login neu fewngofnodi"
       },
       "optional": {
         "title": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -164,7 +164,7 @@
     "signInOrCreate": {
       "mandatory": {
         "title": "Create your GOV.UK One Login or sign in",
-        "header": "Create your GOV.UK One Login or sign in"
+        "header": "Create your GOV.UK One&nbsp;Login or sign&nbsp;in"
       },
       "optional": {
         "title": "Create a GOV.UK One Login or sign in to save your progress",


### PR DESCRIPTION
## What

Add a non-breaking space between the words "sign" and "in".  This pr is a 1 to 1 copy of [this PR](https://github.com/govuk-one-login/authentication-frontend/pull/1564), that was reverted.

##Why

Fixes an issue raised by UCD where the word "in" had been appearing on a line alone following a recent content change. This has been fixed by introducing non-breaking space HTML entities to ensure the words in 'sign in' and 'One Login' do not split across lines as text wraps across different screen sizes.

## How to review

1. Code Review

