### PR TITLE
AUT-2760: Switch off the pre auth page in all environments

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -27,7 +27,6 @@ password_reset_code_entered_wrong_blocked_minutes   = "120"
 reduced_code_block_duration_minutes                 = "15"
 support_reauthentication                            = "1"
 language_toggle_enabled                             = "1"
-prove_identity_welcome_enabled                      = "0"
 no_photo_id_contact_forms                           = "1"
 
 url_for_support_links = "https://home.staging.account.gov.uk/contact-gov-uk-one-login"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -262,7 +262,7 @@ variable "support_check_email_fraud" {
 variable "prove_identity_welcome_enabled" {
   description = "Do not show the prove identity welcome screen when disabled"
   type        = string
-  default     = "1"
+  default     = "0"
 }
 
 variable "email_entered_wrong_blocked_minutes" {


### PR DESCRIPTION
## What

Switch off the pre auth page in all environments

## How to review

The change is already enabled in staging and has been tested there.

1. Code Review

## Checklist

- [ ] Performance analyst has been notified of the change.
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.


## Related PRs

https://github.com/govuk-one-login/authentication-smoke-tests/pull/559
https://github.com/govuk-one-login/authentication-frontend/pull/1657
https://github.com/govuk-one-login/authentication-frontend/pull/1643
