### PR TITLE
BAU: Add a forwarded_ip_config block to rate rule

### DIFF
--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -86,6 +86,11 @@ resource "aws_wafv2_web_acl" "frontend_alb_waf_regional_web_acl" {
       rate_based_statement {
         limit              = var.environment == "staging" ? 20000000 : 25000
         aggregate_key_type = "IP"
+
+        forwarded_ip_config {
+          header_name       = "X-Forwarded-For"
+          fallback_behavior = "MATCH"
+        }
         scope_down_statement {
           and_statement {
             statement {
@@ -154,6 +159,11 @@ resource "aws_wafv2_web_acl" "frontend_alb_waf_regional_web_acl" {
         limit                 = var.environment == "staging" ? 20000000 : var.rate_limited_endpoints_requests_per_period
         evaluation_window_sec = var.rate_limited_endpoints_rate_limit_period
         aggregate_key_type    = "IP"
+
+        forwarded_ip_config {
+          header_name       = "X-Forwarded-For"
+          fallback_behavior = "MATCH"
+        }
 
 
         scope_down_statement {


### PR DESCRIPTION
## What

This will allow the WAF to use the X-Forwarded-For header in the case that it's provided (request via cloudfront). It will fall back to using the 'true' client IP if the header is not provided (direct request).

## How to review

Code review
