### PR TITLE
INCIDENT-814: use waf acl created by cloudfront stack

### DIFF
--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -146,7 +146,7 @@ resource "aws_wafv2_web_acl" "frontend_alb_waf_regional_web_acl" {
     }
 
     action {
-      block {}
+      count {}
     }
 
     statement {
@@ -499,7 +499,7 @@ resource "aws_wafv2_web_acl" "frontend_alb_waf_regional_web_acl" {
 
 resource "aws_wafv2_web_acl_association" "alb_waf_association" {
   resource_arn = aws_lb.frontend_alb.arn
-  web_acl_arn  = aws_wafv2_web_acl.frontend_alb_waf_regional_web_acl.arn
+  web_acl_arn  = var.cloudfront_auth_dns_enabled ? aws_cloudformation_stack.cloudfront[0].outputs["CloakingOriginWebACLArn"] : aws_wafv2_web_acl.frontend_alb_waf_regional_web_acl.arn
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "frontend_alb_waf_logging_config" {


### PR DESCRIPTION
## What

The cloudfront cloudformation stack creates a WAF ACL that we can use for our ALB.

This PR makes the ALB use that stack.

## How to review

Code review