### PR TITLE
[Do not merge before go-live date] AUT-2682: Update Accessibility Statement for webchat

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # Reformatting of setup-authenticator-app/index.njk
 6d381db8202a53dc65b653bed679bdcc9cf130c6
+
+# Reformatting of footer/accessibility-statement.njk
+55fcf27b9b0df344e23cabfb10f297149e84498d

--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -17,120 +17,120 @@
     </p>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section1.header' | translate }}
+        {{ 'pages.accessibilityStatement.usingOneLogin.header' | translate }}
     </h2>
 
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section1.paragraph1.text1' | translate }}
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.usingOneLogin.paragraph1.text1' | translate }}
         <a href="https://www.gov.uk/government/organisations/government-digital-service"
-           class="govuk-link">{{ 'pages.accessibilityStatement.section1.paragraph1.linkText' | translate }}</a>{{ 'pages.accessibilityStatement.section1.paragraph1.text2' | translate }}
+           class="govuk-link">{{ 'pages.accessibilityStatement.usingOneLogin.paragraph1.linkText' | translate }}</a>{{ 'pages.accessibilityStatement.usingOneLogin.paragraph1.text2' | translate }}
     </p>
     <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint1' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint2' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint3' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint4' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.usingOneLogin.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.usingOneLogin.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.usingOneLogin.bulletPoint3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.usingOneLogin.bulletPoint4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.usingOneLogin.bulletPoint5' | translate }}</li>
     </ul>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section1.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.usingOneLogin.paragraph2' | translate }}</p>
     <p class="govuk-body">
         <a href="https://mcmw.abilitynet.org.uk/"
-           class="govuk-link">{{ 'pages.accessibilityStatement.section1.linkText' | translate }}</a>
-        {{ 'pages.accessibilityStatement.section1.paragraph3' | translate }}
+           class="govuk-link">{{ 'pages.accessibilityStatement.usingOneLogin.linkText' | translate }}</a>
+        {{ 'pages.accessibilityStatement.usingOneLogin.paragraph3' | translate }}
     </p>
 
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section2.header' | translate }}
+        {{ 'pages.accessibilityStatement.accessibilityOfOneLogin.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section2.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.paragraph1' | translate }}</p>
     <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint1' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint2' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint3' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint4' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint5' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint6' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint7' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint8' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint9' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint10' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint11' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint12' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint13' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint10' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint11' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint12' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint13' | translate }}</li>
     </ul>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section2.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.paragraph2' | translate }}</p>
 
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section3.header' | translate }}
+        {{ 'pages.accessibilityStatement.whatToDo.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section3.paragraph1' | translate }}
-        <a href="/support" class="govuk-link">{{ 'pages.accessibilityStatement.section3.linkText' | translate }}</a>.
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.whatToDo.paragraph1' | translate }}
+        <a href="/support" class="govuk-link">{{ 'pages.accessibilityStatement.whatToDo.linkText' | translate }}</a>.
     </p>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section4.header' | translate }}
+        {{ 'pages.accessibilityStatement.howToReport.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section4.paragraph1' | translate }}
-        <a href="/support" class="govuk-link">{{ 'pages.accessibilityStatement.section4.linkText' | translate }}</a>.
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.howToReport.paragraph1' | translate }}
+        <a href="/support" class="govuk-link">{{ 'pages.accessibilityStatement.howToReport.linkText' | translate }}</a>.
     </p>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section5.header' | translate }}
+        {{ 'pages.accessibilityStatement.enforcement.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section5.paragraph1' | translate }}</p>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section5.paragraph2' | translate }}
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.enforcement.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.enforcement.paragraph2' | translate }}
         <a href="https://www.equalityadvisoryservice.com/"
-           class="govuk-link">{{ 'pages.accessibilityStatement.section5.linkText' | translate }}</a>.
+           class="govuk-link">{{ 'pages.accessibilityStatement.enforcement.linkText' | translate }}</a>.
     </p>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section6.header' | translate }}
+        {{ 'pages.accessibilityStatement.technicalInformation.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section6.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.technicalInformation.paragraph1' | translate }}</p>
 
     <h3 class="govuk-heading-s">
-        {{ 'pages.accessibilityStatement.section6.subHeader' | translate }}
+        {{ 'pages.accessibilityStatement.technicalInformation.subHeader' | translate }}
     </h3>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section6.paragraph2.text1' | translate }}
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.technicalInformation.paragraph2.text1' | translate }}
         <a href="https://www.w3.org/TR/WCAG21/"
-           class="govuk-link">{{ 'pages.accessibilityStatement.section6.paragraph2.linkText' | translate }}</a>
-        {{ 'pages.accessibilityStatement.section6.paragraph2.text2' | translate }}
+           class="govuk-link">{{ 'pages.accessibilityStatement.technicalInformation.paragraph2.linkText' | translate }}</a>
+        {{ 'pages.accessibilityStatement.technicalInformation.paragraph2.text2' | translate }}
     </p>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section7.header' | translate }}
+        {{ 'pages.accessibilityStatement.nonAccessibleContent.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section7.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.nonAccessibleContent.paragraph1' | translate }}</p>
 
     <h3 class="govuk-heading-s">
-        {{ 'pages.accessibilityStatement.section7.subHeader' | translate }}
+        {{ 'pages.accessibilityStatement.nonAccessibleContent.subHeader' | translate }}
     </h3>
     <ol class="govuk-list govuk-list--number">
-        <li>{{ 'pages.accessibilityStatement.section7.listItem1' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem2' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem3' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem4' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem5' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem6' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem7' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem8' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem9' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem10' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem11' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.section7.listItem12' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem10' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem11' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem12' | translate }}</li>
     </ol>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section8.header' | translate }}
+        {{ 'pages.accessibilityStatement.whatWereDoing.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section8.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.whatWereDoing.paragraph1' | translate }}</p>
 
     <h2 class="govuk-heading-m">
-        {{ 'pages.accessibilityStatement.section9.header' | translate }}
+        {{ 'pages.accessibilityStatement.preparation.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section9.paragraph1' | translate }}</p>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.section9.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph2' | translate }}</p>
 
     {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false }) }}
 

--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -4,127 +4,134 @@
 
 {% block content %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{'pages.accessibilityStatement.header' | translate}}
-</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+        {{ 'pages.accessibilityStatement.header' | translate }}
+    </h1>
 
-<p class="govuk-body">{{'pages.accessibilityStatement.content.paragraph1' | translate}}
-  <a href="https://www.gov.uk/help/accessibility" class="govuk-link">{{'pages.accessibilityStatement.content.linkText' | translate}}</a>.
-</p>
-<p class="govuk-body">{{'pages.accessibilityStatement.content.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.content.paragraph1' | translate }}
+        <a href="https://www.gov.uk/help/accessibility"
+           class="govuk-link">{{ 'pages.accessibilityStatement.content.linkText' | translate }}</a>.
+    </p>
+    <p class="govuk-body">
+        {{ 'pages.accessibilityStatement.content.paragraph2' | translate }}
+    </p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section1.header' | translate}}
-</h2>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section1.header' | translate }}
+    </h2>
 
-<p class="govuk-body">{{'pages.accessibilityStatement.section1.paragraph1.text1' | translate}}
-  <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-link">{{'pages.accessibilityStatement.section1.paragraph1.linkText' | translate}}</a>{{'pages.accessibilityStatement.section1.paragraph1.text2' | translate}}
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>{{'pages.accessibilityStatement.section1.bulletPoint1' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section1.bulletPoint2' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section1.bulletPoint3' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section1.bulletPoint4' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section1.bulletPoint5' | translate}}</li>
-</ul>
-<p class="govuk-body">{{'pages.accessibilityStatement.section1.paragraph2' | translate}}</p>
-<p class="govuk-body">
-  <a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">{{'pages.accessibilityStatement.section1.linkText' | translate}}</a>
-  {{'pages.accessibilityStatement.section1.paragraph3' | translate}}
-</p>
-
-
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section2.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section2.paragraph1' | translate}}</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint1' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint2' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint3' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint4' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint5' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint6' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint7' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint8' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint9' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint10' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint11' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint12' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint13' | translate}}</li>
-</ul>
-<p class="govuk-body">{{'pages.accessibilityStatement.section2.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section1.paragraph1.text1' | translate }}
+        <a href="https://www.gov.uk/government/organisations/government-digital-service"
+           class="govuk-link">{{ 'pages.accessibilityStatement.section1.paragraph1.linkText' | translate }}</a>{{ 'pages.accessibilityStatement.section1.paragraph1.text2' | translate }}
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section1.bulletPoint5' | translate }}</li>
+    </ul>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section1.paragraph2' | translate }}</p>
+    <p class="govuk-body">
+        <a href="https://mcmw.abilitynet.org.uk/"
+           class="govuk-link">{{ 'pages.accessibilityStatement.section1.linkText' | translate }}</a>
+        {{ 'pages.accessibilityStatement.section1.paragraph3' | translate }}
+    </p>
 
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section3.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section3.paragraph1' | translate}}
-  <a href="/support" class="govuk-link">{{'pages.accessibilityStatement.section3.linkText' | translate}}</a>.
-</p>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section2.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section2.paragraph1' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint10' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint11' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint12' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section2.bulletPoint13' | translate }}</li>
+    </ul>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section2.paragraph2' | translate }}</p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section4.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section4.paragraph1' | translate}}
-  <a href="/support" class="govuk-link">{{'pages.accessibilityStatement.section4.linkText' | translate}}</a>.
-</p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section5.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section5.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.accessibilityStatement.section5.paragraph2' | translate}}
-  <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">{{'pages.accessibilityStatement.section5.linkText' | translate}}</a>.
-</p>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section3.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section3.paragraph1' | translate }}
+        <a href="/support" class="govuk-link">{{ 'pages.accessibilityStatement.section3.linkText' | translate }}</a>.
+    </p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section6.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section6.paragraph1' | translate}}</p>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section4.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section4.paragraph1' | translate }}
+        <a href="/support" class="govuk-link">{{ 'pages.accessibilityStatement.section4.linkText' | translate }}</a>.
+    </p>
 
-<h3 class="govuk-heading-s">
-  {{'pages.accessibilityStatement.section6.subHeader' | translate}}
-</h3>
-<p class="govuk-body">{{'pages.accessibilityStatement.section6.paragraph2.text1' | translate}}
-  <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">{{'pages.accessibilityStatement.section6.paragraph2.linkText' | translate}}</a>
-  {{'pages.accessibilityStatement.section6.paragraph2.text2' | translate}}
-</p>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section5.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section5.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section5.paragraph2' | translate }}
+        <a href="https://www.equalityadvisoryservice.com/"
+           class="govuk-link">{{ 'pages.accessibilityStatement.section5.linkText' | translate }}</a>.
+    </p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section7.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section7.paragraph1' | translate}}</p>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section6.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section6.paragraph1' | translate }}</p>
 
-<h3 class="govuk-heading-s">
-  {{'pages.accessibilityStatement.section7.subHeader' | translate}}
-</h3>
-<ol class="govuk-list govuk-list--number">
-    <li>{{'pages.accessibilityStatement.section7.listItem1' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem2' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem3' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem4' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem5' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem6' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem7' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem8' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem9' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem10' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem11' | translate}}</li>
-    <li>{{'pages.accessibilityStatement.section7.listItem12' | translate}}</li>
-</ol>
+    <h3 class="govuk-heading-s">
+        {{ 'pages.accessibilityStatement.section6.subHeader' | translate }}
+    </h3>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section6.paragraph2.text1' | translate }}
+        <a href="https://www.w3.org/TR/WCAG21/"
+           class="govuk-link">{{ 'pages.accessibilityStatement.section6.paragraph2.linkText' | translate }}</a>
+        {{ 'pages.accessibilityStatement.section6.paragraph2.text2' | translate }}
+    </p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section8.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section8.paragraph1' | translate}}</p>
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section7.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section7.paragraph1' | translate }}</p>
 
-<h2 class="govuk-heading-m">
-  {{'pages.accessibilityStatement.section9.header' | translate}}
-</h2>
-<p class="govuk-body">{{'pages.accessibilityStatement.section9.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.accessibilityStatement.section9.paragraph2' | translate}}</p>
+    <h3 class="govuk-heading-s">
+        {{ 'pages.accessibilityStatement.section7.subHeader' | translate }}
+    </h3>
+    <ol class="govuk-list govuk-list--number">
+        <li>{{ 'pages.accessibilityStatement.section7.listItem1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem10' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem11' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.section7.listItem12' | translate }}</li>
+    </ol>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section8.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section8.paragraph1' | translate }}</p>
+
+    <h2 class="govuk-heading-m">
+        {{ 'pages.accessibilityStatement.section9.header' | translate }}
+    </h2>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section9.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.section9.paragraph2' | translate }}</p>
+
+    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false }) }}
 
 {% endblock %}

--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -13,7 +13,10 @@
            class="govuk-link">{{ 'pages.accessibilityStatement.content.linkText' | translate }}</a>.
     </p>
     <p class="govuk-body">
-        {{ 'pages.accessibilityStatement.content.paragraph2' | translate }}
+        {{ 'pages.accessibilityStatement.content.paragraph2.text1' | translate }}
+        <a href="{{ 'pages.accessibilityStatement.content.paragraph2.signInLink.href' | translate }}" class="govuk-link">{{ 'pages.accessibilityStatement.content.paragraph2.signInLink.text' | translate }}</a>
+        {{ 'pages.accessibilityStatement.content.paragraph2.text2' | translate }}
+        <a href="{{ 'pages.accessibilityStatement.content.paragraph2.accountLink.href' | translate }}" class="govuk-link">{{ 'pages.accessibilityStatement.content.paragraph2.accountLink.text' | translate }}</a>.
     </p>
 
     <h2 class="govuk-heading-m">
@@ -38,28 +41,65 @@
         {{ 'pages.accessibilityStatement.usingOneLogin.paragraph3' | translate }}
     </p>
 
-
     <h2 class="govuk-heading-m">
         {{ 'pages.accessibilityStatement.accessibilityOfOneLogin.header' | translate }}
     </h2>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.paragraph1' | translate }}</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint1' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint2' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint3' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint4' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint5' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint6' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint7' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint8' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint9' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint10' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint11' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint12' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.bulletPoint13' | translate }}</li>
-    </ul>
-    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.paragraph2' | translate }}</p>
 
+    <h3 class="govuk-heading-s">
+        {{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.header' | translate }}
+    </h3>
+
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.paragraph1' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint10' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint11' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint12' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.bulletPoint13' | translate }}</li>
+    </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.paragraph2.text1' | translate }}
+        <a href="{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.paragraph2.link.href' | translate }}" class="govuk-link">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.service.paragraph2.link.text' | translate }}</a>.
+    </p>
+
+    <h3 class="govuk-heading-s" id="webchat-accessibility">
+        {{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.header' | translate }}
+    </h3>
+
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.paragraph1' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint1' | translate }}
+            <ul class="govuk-list govuk-list--bullet">
+                <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.subBulletPoint1' | translate }}</li>
+                <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.subBulletPoint2' | translate }}</li>
+            </ul>
+        </li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.bulletPoint10' | translate }}</li>
+    </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.paragraph2.text1' | translate }}
+        <a href="{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.paragraph2.link.href' | translate }}" class="govuk-link">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.webchat.paragraph2.link.text' | translate }}</a>.
+    </p>
+
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.accessibilityOfOneLogin.updatesParagraph' | translate }}</p>
 
     <h2 class="govuk-heading-m">
         {{ 'pages.accessibilityStatement.whatToDo.header' | translate }}
@@ -103,23 +143,45 @@
     </h2>
     <p class="govuk-body">{{ 'pages.accessibilityStatement.nonAccessibleContent.paragraph1' | translate }}</p>
 
-    <h3 class="govuk-heading-s">
-        {{ 'pages.accessibilityStatement.nonAccessibleContent.subHeader' | translate }}
+    <h3 class="govuk-heading-s" id="non-compliance-service">
+        {{ 'pages.accessibilityStatement.nonAccessibleContent.service.header' | translate }}
     </h3>
     <ol class="govuk-list govuk-list--number">
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem1' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem2' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem3' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem4' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem5' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem6' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem7' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem8' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem9' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem10' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem11' | translate }}</li>
-        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.listItem12' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem7' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem8' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem9' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem10' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem11' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.service.listItem12' | translate }}</li>
     </ol>
+
+    <h3 class="govuk-heading-s" id="non-compliance-webchat">
+        {{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.header' | translate }}
+    </h3>
+
+    <ol class="govuk-list govuk-list--number">
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem3' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem4' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem5' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem6' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.listItem7' | translate }}</li>
+    </ol>
+
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.paragraph1' | translate }}</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.accessibilityStatement.nonAccessibleContent.webchat.bulletPoint3' | translate }}</li>
+    </ul>
 
     <h2 class="govuk-heading-m">
         {{ 'pages.accessibilityStatement.whatWereDoing.header' | translate }}
@@ -131,6 +193,7 @@
     </h2>
     <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph1' | translate }}</p>
     <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph3' | translate }}</p>
 
     {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false }) }}
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -836,7 +836,7 @@
         "linkText": "datganiad hygyrchedd ar wahân ar gyfer prif wefan GOV.UK",
         "paragraph2": "Mae’r dudalen hon ond yn cynnwys gwybodaeth am GOV.UK One Login, sydd ar gael yn www.signin.account.gov.uk."
       },
-      "section1": {
+      "usingOneLogin": {
         "header": "Defnyddio GOV.UK One Login",
         "paragraph1": {
           "text1": "Mae GOV.UK One Login yn cael eu rhedeg gan y ",
@@ -853,7 +853,7 @@
         "linkHref": "https://mcmw.abilitynet.org.uk/",
         "paragraph3": "gyngor ar sut i wneud eich dyfais yn haws i’w defnyddio os oes gennych anabledd."
       },
-      "section2": {
+      "accessibilityOfOneLogin": {
         "header": "Pa mor hygyrch yw GOV.UK One Login ",
         "paragraph1": "Nid yw’r rhannau canlynol o GOV.UK One Login yn gwbl hygyrch:",
         "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu GOV.UK One Login",
@@ -871,23 +871,23 @@
         "bulletPoint13": "nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni",
         "paragraph2": "Byddwn yn diweddaru’r dudalen hon pan fydd y materion wedi cael eu datrys neu gyda gwybodaeth ynghylch pryd rydym yn bwriadu eu datrys."
       },
-      "section3": {
+      "whatToDo": {
         "header": "Beth i’w wneud os ydych yn cael trafferth defnyddio GOV.UK One Login",
         "paragraph1": "Os ydych yn cael trafferth defnyddio GOV.UK One Login, ",
         "linkText": "cysylltwch â ni"
       },
-      "section4": {
+      "howToReport": {
         "header": "Rhoi gwybod am broblemau hygyrchedd gyda GOV.UK One Login",
         "paragraph1": "Rydym bob amser yn ceisio gwella hygyrchedd GOV.UK One Login. Os byddwch yn dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu’n credu nad ydym yn cwrdd â gofynion hygyrchedd, ",
         "linkText": "cysylltwch â ni"
       },
-      "section5": {
+      "enforcement": {
         "header": "Gweithdrefn orfodi",
         "paragraph1": "Mae’r Comisiwn Cydraddoldeb a Hawliau Dynol (EHRC) yn gyfrifol am orfodi Rheoliadau Hygyrchedd Cyrff Sector Cyhoeddus (Gwefannau a Chymwysiadau Symudol) (Rhif 2) 2018 (y ‘rheoliadau hygyrchedd’).",
         "paragraph2": "Os nad ydych yn hapus â sut rydym yn ymateb i’ch cwyn, ",
         "linkText": "cysylltwch â’r Gwasanaeth Cynghori a Chymorth Cydraddoldeb (EASS)"
       },
-      "section6": {
+      "technicalInformation": {
         "header": "Gwybodaeth dechnegol am hygyrchedd GOV.UK One Login",
         "paragraph1": "Mae Gwasanaeth Digidol y Llywodraeth wedi ymrwymo i wneud GOV.UK One Login yn hygyrch, yn unol â Rheoliadau Cyrff y Sector Cyhoeddus (Gwefannau a Cheisiadau Symudol) (Rhif 2) Hygyrchedd 2018.",
         "subHeader": "Statws cydymffurfio",
@@ -897,7 +897,7 @@
           "text2": " oherwydd y diffyg cydymffurfiaeth a restrir isod."
         }
       },
-      "section7": {
+      "nonAccessibleContent": {
         "header": "Cynnwys anhygyrch",
         "paragraph1": "Nid yw’r cynnwys a restrir isod yn hygyrch am y rhesymau canlynol.",
         "subHeader": "Diffyg cydymffurfio â’r rheoliadau hygyrchedd",
@@ -914,11 +914,11 @@
         "listItem11": "Nid yw botymau sy’n dangos animeiddiadau ’spinner’ yn cadw at eich gosodiadau cynnig llai. Mae hyn yn methu maen prawf llwyddiant 2.2.2 (Saib, Stop, Cuddio) WCAG 2.2.",
         "listItem12": "Nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2."
       },
-      "section8": {
+      "whatWereDoing": {
         "header": "Beth rydym yn ei wneud i wella hygyrchedd",
         "paragraph1": "Byddwn yn diweddaru’r dudalen hon pan fydd materion wedi cael eu datrys, pryd byddwn yn disgwyl iddynt gael eu datrys neu pan fydd problemau newydd yn cael eu nodi."
       },
-      "section9": {
+      "preparation": {
         "header": "Paratoi’r datganiad hygyrchedd hwn",
         "paragraph1": "Paratowyd y datganiad hwn ar 4 Tachwedd 2020. Cafodd ei adolygu ddiwethaf ar 28 Chwefror 2024.",
         "paragraph2": "Cafodd GOV.UK One Login ei brofi ddiwethaf ym mis Hydref a Tachwedd 2023. Cynhaliwyd y prawf gan dîm hygyrchedd GOV.UK One Login, a gynhyrchodd archwiliad o’r daith yn Rhagfyr 2023. Asesodd dîm hygyrchedd GOV.UK One Login y gwasanaeth GOV.UK One Login yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe WCAG 2.2 wrth baratoi ar gyfer y canllawiau sy’n cael eu gorfodi yn Hydref 2024."

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -471,9 +471,9 @@
         "link": "roi cynnig arall",
         "paragraph2End": " gyda chod newydd."
       },
-      "2hLockout":{
-        "signInJourney":{
-          "info":{
+      "2hLockout": {
+        "signInJourney": {
+          "info": {
             "paragraph1": "Ni fyddwch yn gallu mewngofnodi am 2 awr.",
             "paragraph2": "Beth allwch chi ei wneud",
             "paragraph3": "Arhoswch am 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto.",
@@ -512,13 +512,13 @@
         "link": "gael cod newydd",
         "paragraph2End": " ar ôl 15 munud."
       },
-      "info":{
-        "paragraph1":"Mae hyn oherwydd eich bod wedi gofyn i ail-anfon y cod diogelwch gormod o weithiau y tro diwethaf i chi geisio mewngofnodi.",
+      "info": {
+        "paragraph1": "Mae hyn oherwydd eich bod wedi gofyn i ail-anfon y cod diogelwch gormod o weithiau y tro diwethaf i chi geisio mewngofnodi.",
         "paragraph1_create": "Mae hyn oherwydd eich bod wedi gofyn i ail-anfon y cod diogelwch gormod o weithiau.",
-        "subHeading":"Beth allwch chi ei wneud",
-        "paragraph2":"Arhoswch am 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto.",
-        "paragraph3":"Os ydych angen ei ddefnyddio yn gynt, gallwch fynd yn ôl i’r gwasanaeth a chwilio am ffyrdd eraill i barhau"
-     }
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph2": "Arhoswch am 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto.",
+        "paragraph3": "Os ydych angen ei ddefnyddio yn gynt, gallwch fynd yn ôl i’r gwasanaeth a chwilio am ffyrdd eraill i barhau"
+      }
     },
     "enterMfa": {
       "title": "Gwiriwch eich ffôn",
@@ -601,7 +601,7 @@
       "header": "Cael cod diogelwch",
       "continue": "Cael cod diogelwch",
       "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
-      "paragraph1":"Gallwch ofyn am 5 cod diogelwch. Os byddwch yn gofyn am fwy na 5, byddwch yn cael eich cloi allan am 2 awr.",
+      "paragraph1": "Gallwch ofyn am 5 cod diogelwch. Os byddwch yn gofyn am fwy na 5, byddwch yn cael eich cloi allan am 2 awr.",
       "phoneNumber": {
         "default": "Byddwn yn anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login",
         "isResendCodeRequest": "Byddwn yn anfon cod i’ch rhif ffôn sy’n gorffen gyda "
@@ -834,7 +834,18 @@
       "content": {
         "paragraph1": "Mae GOV.UK One Login yn rhan o wefan ehangach GOV.UK. Mae ",
         "linkText": "datganiad hygyrchedd ar wahân ar gyfer prif wefan GOV.UK",
-        "paragraph2": "Mae’r dudalen hon ond yn cynnwys gwybodaeth am GOV.UK One Login, sydd ar gael yn www.signin.account.gov.uk."
+        "paragraph2": {
+          "text1": "Mae’r dudalen hon yn cynnwys gwybodaeth am y gwasanaeth GOV.UK One Login, sydd ar gael yn ",
+          "signInLink": {
+            "href": "https://www.signin.account.gov.uk",
+            "text": "www.signin.account.gov.uk"
+          },
+          "text2": " a’r gwesgwrs cymorth i ddefnyddwyr sydd ar gael yn ",
+          "accountLink": {
+            "href": "https://home.account.gov.uk/contact-gov-uk-one-login",
+            "text": "home.account.gov.uk/contact-gov-uk-one-login"
+          }
+        }
       },
       "usingOneLogin": {
         "header": "Defnyddio GOV.UK One Login",
@@ -855,25 +866,58 @@
       },
       "accessibilityOfOneLogin": {
         "header": "Pa mor hygyrch yw GOV.UK One Login ",
-        "paragraph1": "Nid yw’r rhannau canlynol o GOV.UK One Login yn gwbl hygyrch:",
-        "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu GOV.UK One Login",
-        "bulletPoint2": "nid yw’n bosib i ddarllenydd sgrin wybod pryd mae’r e-byst rydym yn eu hanfon mewn iaith ar wahân i’r Saesneg",
-        "bulletPoint3": "mae un dudalen yn ail-lwytho yn awtomatig ar ôl terfyn amser penodol, ac nid yw’n bosibl i stopio neu oedi hyn",
-        "bulletPoint4": "mae’r ddolen allgofnodi pennawd yn achosi bar sgrolio llorweddol ar chwyddiadau mawr iawn ar ddyfeisiau symudol",
-        "bulletPoint5": "nid yw bob amser yn bosibl defnyddio opsiynau awtomatig eich porwr i roi gwybodaeth",
-        "bulletPoint6": "nid yw’r dolenni yn y troedyn yr un peth ar bob tudalen",
-        "bulletPoint7": "mae dolen wag yn y pennawd am ran fer o’r daith",
-        "bulletPoint8": "nid yw rhai tudalennau’n nodi’n gywir yr iaith y maent yn cael eu cyhoeddi ynddi",
-        "bulletPoint9": "nid yw teitlau rhai tudalennau yn dechrau gyda ’gwall’ os nad ydych wedi rhoi’r wybodaeth sydd ei hangen yn y ffurf cywir",
-        "bulletPoint10": "mae rhai dolenni yn y pennawd a’r troedyn y gallech ddisgwyl eu hagor mewn tab newydd yn agor yn yr un tab",
-        "bulletPoint11": "mae rhai meysydd ffurflen yn cyfyngu ar faint o nodau y gellir eu rhoi ynddynt, a all ei gwneud hi’n anodd rhoi gwybodaeth wrth ddefnyddio technolegau cynorthwyol",
-        "bulletPoint12": "nid yw botymau sy’n dangos animeiddiadau ’spinner’ yn cadw at eich gosodiadau cynnig llai",
-        "bulletPoint13": "nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni",
-        "paragraph2": "Byddwn yn diweddaru’r dudalen hon pan fydd y materion wedi cael eu datrys neu gyda gwybodaeth ynghylch pryd rydym yn bwriadu eu datrys."
+        "service": {
+          "header": "Materion hygyrchedd ar y gwasanaeth GOV.UK One Login",
+          "paragraph1": "Nid yw’r rhannau canlynol o wefan GOV.UK One Login yn gwbl hygyrch:",
+          "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu GOV.UK One Login",
+          "bulletPoint2": "nid yw’n bosib i ddarllenydd sgrin wybod pryd mae’r e-byst rydym yn eu hanfon mewn iaith ar wahân i’r Saesneg",
+          "bulletPoint3": "mae un dudalen yn ail-lwytho yn awtomatig ar ôl terfyn amser penodol, ac nid yw’n bosibl i stopio neu oedi hyn",
+          "bulletPoint4": "mae’r ddolen allgofnodi pennawd yn achosi bar sgrolio llorweddol ar chwyddiadau mawr iawn ar ddyfeisiau symudol",
+          "bulletPoint5": "nid yw bob amser yn bosibl defnyddio opsiynau awtomatig eich porwr i roi gwybodaeth",
+          "bulletPoint6": "nid yw’r dolenni yn y troedyn yr un peth ar bob tudalen",
+          "bulletPoint7": "mae dolen wag yn y pennawd am ran fer o’r daith",
+          "bulletPoint8": "nid yw rhai tudalennau’n nodi’n gywir yr iaith y maent yn cael eu cyhoeddi ynddi",
+          "bulletPoint9": "nid yw teitlau rhai tudalennau yn dechrau gyda ‘gwall’ os nad ydych wedi rhoi’r wybodaeth sydd ei hangen yn y ffurf cywir",
+          "bulletPoint10": "mae rhai dolenni yn y pennawd a’r troedyn y gallech ddisgwyl eu hagor mewn tab newydd yn agor yn yr un tab",
+          "bulletPoint11": "mae rhai meysydd ffurflen yn cyfyngu ar faint o nodau y gellir eu rhoi ynddynt, a all ei gwneud hi’n anodd rhoi gwybodaeth wrth ddefnyddio technolegau cynorthwyol",
+          "bulletPoint12": "nid yw botymau sy’n dangos animeiddiadau ‘spinner’ yn cadw at eich gosodiadau cynnig llai",
+          "bulletPoint13": "nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni",
+          "paragraph2": {
+            "text1": "Ewch i’r ",
+            "link": {
+              "text": "manylion technegol materion hygyrchedd gwasanaeth GOV.UK One Login",
+              "href": "#non-compliance-service"
+            }
+          }
+        },
+        "webchat": {
+          "header": "Materion hygyrchedd ar gwesgwrs GOV.UK One Login",
+          "paragraph1": "Nid yw’r rhannau canlynol o’r gwe-sgwrs GOV.UK One Login yn gwbl hygyrch:",
+          "bulletPoint1": "efallai na fydd meddalwedd rheoli llais yn gallu labelu cynnwys gwesgwrs yn gywir:",
+          "subBulletPoint1": "os ydych yn defnyddio Safari, bydd angen i chi ddefnyddio’r swyddogaeth ‘show grid’ i ddefnyddio’r gwesgwrs",
+          "subBulletPoint2": "os ydych yn defnyddio Chrome efallai y bydd angen i chi ofyn i’r cyfrifiadur ‘guddio rhifau’ a ‘dangos rhifau’ eto i adnewyddu labelu’r cynnwys",
+          "bulletPoint2": "nid yw’n bosib newid iaith yng nghanol sesiwn sgwrsio – os gwnewch, byddwch yn colli eich hanes sgwrs",
+          "bulletPoint3": "nid yw’n bosib arbed eich sesiwn sgwrsio i gyfeirio ato yn ddiweddarach os byddwch yn gadael y dudalen gyswllt",
+          "bulletPoint4": "os ydych yn defnyddio bysellfwrdd allanol, efallai na fydd y ffocws yn cyrraedd adran cwestiwn ac ateb y gwesgwrs a gallai ddiflannu’n llwyr",
+          "bulletPoint5": "mae rhai porwyr yn symud ffocws y bysellfwrdd i ddechrau’r gwesgwrs pan ychwanegir cynnwys newydd",
+          "bulletPoint6": "os ydych yn defnyddio darllenydd sgrin, efallai y bydd yn anodd gwahaniaethu rhwng opsiynau ateb pan maent yn cael eu hychwanegu gyntaf at y gwesgwrs",
+          "bulletPoint7": "weithiau nid yw’r testun ateb yn ddigon disgrifiadol wrth ddarllen allan o gyd-destun yn y gwesgwrs",
+          "bulletPoint8": "mae’r label maes ffurflen yn cael ei ddileu dros dro pan fyddwch yn teipio ymateb - mae’r label maes yn cael ei ddisodli pan fyddwch yn anfon eich ymateb",
+          "bulletPoint9": "mae ffocws yn dychwelyd i’r eicon gwesgwrs ar ôl i’r gwesgwrs gael ei gau, hyd yn oed os byddwch yn cychwyn y gwesgwrs o’r ddolen yng nghynnwys y dudalen",
+          "bulletPoint10": "os ydych yn defnyddio darllenydd sgrin, ni fydd y gwesgwrs yn cadarnhau ei fod wedi’i gau",
+          "paragraph2": {
+            "text1": "Ewch i’r ",
+            "link": {
+              "text": "manylion technegol materion hygyrchedd gwesgwrs GOV.UK One Login",
+              "href": "#non-compliance-webchat"
+            }
+          }
+        },
+        "updatesParagraph": "Byddwn yn diweddaru’r dudalen hon pan fydd y materion wedi cael eu datrys neu gyda gwybodaeth ynghylch pryd rydym yn bwriadu eu datrys."
       },
       "whatToDo": {
-        "header": "Beth i’w wneud os ydych yn cael trafferth defnyddio GOV.UK One Login",
-        "paragraph1": "Os ydych yn cael trafferth defnyddio GOV.UK One Login, ",
+        "header": "Beth i’w wneud os ydych yn cael trafferth defnyddio GOV.UK One Login neu’r gwesgwrs",
+        "paragraph1": "Os ydych yn cael trafferth defnyddio unrhyw ran o GOV.UK One Login, ",
         "linkText": "cysylltwch â ni"
       },
       "howToReport": {
@@ -900,19 +944,35 @@
       "nonAccessibleContent": {
         "header": "Cynnwys anhygyrch",
         "paragraph1": "Nid yw’r cynnwys a restrir isod yn hygyrch am y rhesymau canlynol.",
-        "subHeader": "Diffyg cydymffurfio â’r rheoliadau hygyrchedd",
-        "listItem1": "Pan fyddwch yn creu GOV.UK One Login neu’n mewngofnodi, os nad ydych yn gwneud unrhyw beth am 60 munud, bydd y broses yn dod i ben (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn neu ddiffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant 2.2.1 (Amseru Addasadwy) WCAG 2.2.",
-        "listItem2": "Mae’r ddolen allgofnodi pennawd yn achosi bar sgrolio llorweddol ar chwyddiadau mawr iawn ar ddyfeisiau symudol. Os ydych chi’n defnyddio technolegau cynorthwyol efallai y byddwch yn cael hi’n anoddach i lywio tudalennau os ydych chi’n cynyddu’r lefel chwyddo. Mae hyn yn methu maen prawf llwyddiant 1.4.10 (Reflow) WCAG 2.2.",
-        "listItem3": "Nid yw bob amser yn bosibl defnyddio opsiynau awtomatig eich porwr i roi gwybodaeth. Mae hyn yn methu maen prawf llwyddiant 1.3.5 (Diben Mewnbwn Hunaniaeth) WCAG 2.2.",
-        "listItem4": "Os ydych chi’n defnyddio technolegau cynorthwyol, efallai y bydd yn cymryd mwy o amser i chi rhoi gwybodaeth. Mae hyn yn methu maen prawf llwyddiant 1.3.5 (Pwrpas Mewnbwn Hunaniaeth) WCAG 2.2.",
-        "listItem5": "Nid yw’r dolenni yn y troedyn yr un peth ar bob tudalen. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2.",
-        "listItem6": "Mae dolen wag yn y pennawd ar gyfer rhan fer o’r daith. Os ydych chi’n defnyddio technolegau cynorthwyol efallai eich bod chi’n ymwybodol o’r ddolen ond ni fyddwch yn gallu ei dewis. Mae hyn yn methu maen prawf llwyddiant 3.2.3 (Llywio Cyson) WCAG 2.2.",
-        "listItem7": "Nid yw rhai tudalennau’n nodi’n gywir yr iaith y maent yn cael eu cyhoeddi ynddi. Mae hyn yn golygu na fydd darllenwyr sgrin yn darllen cynnwys yn gywir. Mae hyn yn methu maen prawf llwyddiant 3.1.1 (Iaith y Dudalen) WCAG 2.2.",
-        "listItem8": "Nid yw teitlau rhai tudalennau yn dechrau gyda ’gwall’ os nad yw’r defnyddiwr wedi rhoi’r wybodaeth sydd ei hangen yn y ffurf cywir. Mae hyn yn golygu nad yw defnyddwyr darllenwyr sgrin yn gwybod ar unwaith bod problem. Mae hyn yn methu maen prawf llwyddiant 2.4.2 (Teitl y dudalen) WCAG 2.2.",
-        "listItem9": "Mae dolenni yn y pennawd a’r troedyn y gallech ddisgwyl eu hagor mewn tab newydd weithiau’n agor mewn tab newydd. Mae hyn yn methu Canllaw 3.2 (Rhagweladwy) WCAG 2.2.",
-        "listItem10": "Mae rhai meysydd ffurflen yn cyfyngu ar faint o nodau y gellir eu rhoi, a all ei gwneud hi’n anodd rhoi gwybodaeth os ydych chi’n defnyddio technolegau cynorthwyol. Mae hyn yn methu maen prawf llwyddiant 3.3.1 (Adnabod Gwallau) WCAG 2.2.",
-        "listItem11": "Nid yw botymau sy’n dangos animeiddiadau ’spinner’ yn cadw at eich gosodiadau cynnig llai. Mae hyn yn methu maen prawf llwyddiant 2.2.2 (Saib, Stop, Cuddio) WCAG 2.2.",
-        "listItem12": "Nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2."
+        "service": {
+          "header": "Diffyg cydymffurfiaeth â’r rheoliadau hygyrchedd ar gyfer y gwasanaeth GOV.UK One Login",
+          "listItem1": "Pan fyddwch yn creu GOV.UK One Login neu’n mewngofnodi, os nad ydych yn gwneud unrhyw beth am 60 munud, bydd y broses yn dod i ben (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn neu ddiffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant 2.2.1 (Amseru Addasadwy) WCAG 2.2.",
+          "listItem2": "Mae’r ddolen allgofnodi pennawd yn achosi bar sgrolio llorweddol ar chwyddiadau mawr iawn ar ddyfeisiau symudol. Os ydych chi’n defnyddio technolegau cynorthwyol efallai y byddwch yn cael hi’n anoddach i lywio tudalennau os ydych chi’n cynyddu’r lefel chwyddo. Mae hyn yn methu maen prawf llwyddiant 1.4.10 (Reflow) WCAG 2.2.",
+          "listItem3": "Nid yw bob amser yn bosibl defnyddio opsiynau awtomatig eich porwr i roi gwybodaeth. Mae hyn yn methu maen prawf llwyddiant 1.3.5 (Diben Mewnbwn Hunaniaeth) WCAG 2.2.",
+          "listItem4": "Os ydych chi’n defnyddio technolegau cynorthwyol, efallai y bydd yn cymryd mwy o amser i chi rhoi gwybodaeth. Mae hyn yn methu maen prawf llwyddiant 1.3.5 (Pwrpas Mewnbwn Hunaniaeth) WCAG 2.2.",
+          "listItem5": "Nid yw’r dolenni yn y troedyn yr un peth ar bob tudalen. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2.",
+          "listItem6": "Mae dolen wag yn y pennawd ar gyfer rhan fer o’r daith. Os ydych chi’n defnyddio technolegau cynorthwyol efallai eich bod chi’n ymwybodol o’r ddolen ond ni fyddwch yn gallu ei dewis. Mae hyn yn methu maen prawf llwyddiant 3.2.3 (Llywio Cyson) WCAG 2.2.",
+          "listItem7": "Nid yw rhai tudalennau’n nodi’n gywir yr iaith y maent yn cael eu cyhoeddi ynddi. Mae hyn yn golygu na fydd darllenwyr sgrin yn darllen cynnwys yn gywir. Mae hyn yn methu maen prawf llwyddiant 3.1.1 (Iaith y Dudalen) WCAG 2.2.",
+          "listItem8": "Nid yw teitlau rhai tudalennau yn dechrau gyda ‘gwall’ os nad yw’r defnyddiwr wedi rhoi’r wybodaeth sydd ei hangen yn y ffurf cywir. Mae hyn yn golygu nad yw defnyddwyr darllenwyr sgrin yn gwybod ar unwaith bod problem. Mae hyn yn methu maen prawf llwyddiant 2.4.2 (Teitl y dudalen) WCAG 2.2.",
+          "listItem9": "Mae dolenni yn y pennawd a’r troedyn y gallech ddisgwyl eu hagor mewn tab newydd weithiau’n agor yn yr un tab. Mae hyn yn methu WCAG 2.2 Guideline 3.2 (Predictable).",
+          "listItem10": "Mae rhai meysydd ffurflen yn cyfyngu ar faint o nodau y gellir eu rhoi, a all ei gwneud hi’n anodd rhoi gwybodaeth os ydych chi’n defnyddio technolegau cynorthwyol. Mae hyn yn methu maen prawf llwyddiant 3.3.1 (Adnabod Gwallau) WCAG 2.2.",
+          "listItem11": "Nid yw botymau sy’n dangos animeiddiadau ‘spinner’ yn cadw at eich gosodiadau cynnig llai. Mae hyn yn methu maen prawf llwyddiant 2.2.2 (Saib, Stop, Cuddio) WCAG 2.2.",
+          "listItem12": "Nid yw’r wybodaeth yng nghynnwys y faner cwci yr un peth ar bob tudalen y mae’n ymddangos arni. Mae hyn yn methu maen prawf llwyddiant 3.2.6 (Cymorth Cyson) WCAG 2.2."
+        },
+        "webchat": {
+          "header": "Diffyg cydymffurfiaeth â’r rheoliadau hygyrchedd ar gyfer gwesgwrs GOV.UK One Login",
+          "listItem1": "Efallai na fydd meddalwedd rheoli llais yn gallu labelu’r cynnwys gwesgwrs yn gywir. Mae hyn yn methu WCAG 2.2 success criterion 4.1.2 (Name, role, value).",
+          "listItem2": "Os ydych yn defnyddio bysellfwrdd allanol ar ddyfeisiau symudol, efallai na fydd ffocws y bysellfwrdd yn cyrraedd yr adran cwestiwn ac ateb a gallai ddiflannu’n llwyr. Mae hyn yn methu WCAG 2.2 success criterion 2.1.1 (Keyboard) a WCAG 2.2 success criterion 2.1.2 (No keyboard trap).",
+          "listItem3": "Mae rhai porwyr yn symud y ffocws allweddell sgwrsio i ddechrau’r sgwrs pan ychwanegir cynnwys sgwrsio newydd. Mae hyn yn methu WCAG 2.2 success criterion 2.4.3 (Focus order).",
+          "listItem4": "Os ydych yn defnyddio darllenydd sgrin, gall fod yn anodd gwahaniaethu rhwng y gwahanol opsiynau ateb cyflym a ddarperir gan y gwesgwrs. Mae hyn yn methu WCAG 2.2 success criterion 1.3.1 (Info and relationships).",
+          "listItem5": "Weithiau nid yw’r testun ateb mewn botymau yn ddigon disgrifiadol allan o gyd-destun. Mae hyn yn methu WCAG 2.2 success criterion 2.4.6 (Headings and labels).",
+          "listItem6": "Mae’r label maes yn cael ei dynnu o’r ffurflen pan fyddwch yn teipio eich ymateb eich hun i neges, ond mae’n cael ei ddisodli pan fyddwch pwyso dychwelyd. Mae hyn yn methu WCAG 2.2 success criterion 3.3.2 (Labels and instructions).",
+          "listItem7": "Mae ffocws yn dychwelyd i’r eicon gwesgwrs ar ôl i’r gwesgwrs gael ei gau, hyd yn oed os byddwch yn cychwyn y sgwrs we o’r ddolen yng nghynnwys y dudalen. Mae hyn yn methu WCAG 2.2 success criterion 2.4.3 (Focus order).",
+          "paragraph1": "Mae tri mater nad ydym yn credu sy’n cydymffurfio â rheoliadau hygyrchedd ond a allai fod yn rhwystredig i ddefnyddwyr:",
+          "bulletPoint1": "nid yw’n bosibl newid iaith yng nghanol sesiwn sgwrsio",
+          "bulletPoint2": "nid yw’n bosibl arbed eich sesiwn sgwrsio",
+          "bulletPoint3": "nid yw’r gwesgwrs yn cadarnhau ei fod wedi ei gau i ddefnyddwyr darllenydd sgrin"
+        }
       },
       "whatWereDoing": {
         "header": "Beth rydym yn ei wneud i wella hygyrchedd",
@@ -920,8 +980,9 @@
       },
       "preparation": {
         "header": "Paratoi’r datganiad hygyrchedd hwn",
-        "paragraph1": "Paratowyd y datganiad hwn ar 4 Tachwedd 2020. Cafodd ei adolygu ddiwethaf ar 28 Chwefror 2024.",
-        "paragraph2": "Cafodd GOV.UK One Login ei brofi ddiwethaf ym mis Hydref a Tachwedd 2023. Cynhaliwyd y prawf gan dîm hygyrchedd GOV.UK One Login, a gynhyrchodd archwiliad o’r daith yn Rhagfyr 2023. Asesodd dîm hygyrchedd GOV.UK One Login y gwasanaeth GOV.UK One Login yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe WCAG 2.2 wrth baratoi ar gyfer y canllawiau sy’n cael eu gorfodi yn Hydref 2024."
+        "paragraph1": "Paratowyd y datganiad hwn ar 4 Tachwedd 2020. Cafodd ei adolygu ddiwethaf ar 5 Mehefin 2024.",
+        "paragraph2": "Cafodd GOV.UK One Login ei brofi ddiwethaf ym mis Hydref a Tachwedd 2023. Cynhaliwyd y prawf gan dîm hygyrchedd GOV.UK One Login, a gynhyrchodd archwiliad o’r daith yn Rhagfyr 2023. Asesodd dîm hygyrchedd GOV.UK One Login y gwasanaeth GOV.UK One Login yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe (WCAG) 2.2 wrth baratoi ar gyfer y canllawiau sy’n cael eu gorfodi yn Hydref 2024.",
+        "paragraph3": "Profwyd y gwasanaeth gwesgwrs GOV.UK One Login ddiwethaf ym mis Ebrill 2024. Cynhaliwyd archwiliad cychwynnol gan dîm hygyrchedd GOV.UK One Login ym mis Hydref 2023. Cafodd y gwasanaeth ei archwilio gan y Ganolfan Hygyrchedd Digidol (DAC) ym mis Ionawr 2024. Asesodd archwiliad DAC y gwasanaeth gwe-sgwrs yn erbyn WCAG 2.1, ond mae pob methiant meini prawf llwyddiant hefyd yn berthnasol i WCAG 2.2."
       }
     },
     "termsAndConditions": {
@@ -1623,16 +1684,16 @@
       "title": "Rydych wedi rhoi’r cyfrinair anghywir i mewn ormod o weithiau",
       "header": "Rydych wedi rhoi’r cyfrinair anghywir i mewn ormod o weithiau",
       "paragraph_old": "Rydych chi wedi cael eich cloi allan o’ch GOV.UK One Login oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
-      "paragraph":"Ni fyddwch yn gallu mewngofnodi am 2 awr, oherwydd eich bod wedi rhoi’r cyfrinair anghywir fwy na 5 gwaith.",
+      "paragraph": "Ni fyddwch yn gallu mewngofnodi am 2 awr, oherwydd eich bod wedi rhoi’r cyfrinair anghywir fwy na 5 gwaith.",
       "subHeader_old": "Beth nesaf",
-      "subHeader":"Beth allwch chi ei wneud",
+      "subHeader": "Beth allwch chi ei wneud",
       "bulletPointSection": {
         "title": "Gallwch:",
         "first_old": "aros am 15 munud a ",
-        "first":"ailosod eich cyfrinair",
+        "first": "ailosod eich cyfrinair",
         "firstLink_old": "cheisio mewngofnodi eto",
         "second_old": "ailosod eich cyfrinair",
-        "second":"arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
+        "second": "arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
       }
     },
     "browserBackButtonError": {
@@ -1654,7 +1715,7 @@
           "errorMessage": "Rhaid i chi ddewis opsiwn i ddweud wrthym beth rydych angen help gyda"
         }
       },
-      "section2": { 
+      "section2": {
         "header": "Oriau Swyddfa",
         "paragraph1": "Dim ond yn ystod oriau swyddfa y gallwn ymateb i’ch ymholiadau cymorth. Ein horiau swyddfa yw 8:00am i 8:00pm, o ddydd Llun i ddydd Gwener.",
         "paragraph2": "Pan fyddwch yn cysylltu yn ystod oriau swyddfa, byddwn yn ceisio ateb o fewn 2 ddiwrnod gwaith."
@@ -2204,7 +2265,6 @@
         }
       }
     },
-    
     "contactUsSubmitSuccess": {
       "title": "Mae eich neges wedi ei anfon",
       "header": "Mae eich neges wedi ei anfon",
@@ -2339,7 +2399,7 @@
           "authenticatorApp": "ap dilysydd ",
           "paragraph1End": "a ddefnyddiwyd gennych i greu eich GOV.UK One Login"
         },
-        "code":{
+        "code": {
           "label": "Rhowch y cod 6 digid"
         }
       }
@@ -2376,14 +2436,14 @@
         "secondLink": "ailosod eich cyfrinair",
         "paragraph2End": "."
       },
-      "subHeader":"Beth allwch chi ei wneud",
+      "subHeader": "Beth allwch chi ei wneud",
       "bulletPointSection": {
         "title": "Gallwch:",
         "first_old": "aros am 15 munud a ",
-        "first":"ailosod eich cyfrinair",
+        "first": "ailosod eich cyfrinair",
         "firstLink_old": "cheisio mewngofnodi eto",
         "second_old": "ailosod eich cyfrinair",
-        "second":"arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
+        "second": "arhoswch 2 awr, yna ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK"
       }
     },
     "needToResetPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -471,9 +471,9 @@
         "link": "try again",
         "paragraph2End": " with a new code."
       },
-      "2hLockout":{
-        "signInJourney":{
-          "info":{
+      "2hLockout": {
+        "signInJourney": {
+          "info": {
             "paragraph1": "You will not be able to sign in for 2 hours.",
             "paragraph2": "What can you do",
             "paragraph3": "Wait for 2 hours, then go back to the service you were trying to use and start again.",
@@ -512,13 +512,13 @@
         "link": "get a new code",
         "paragraph2End": " after 15 minutes."
       },
-      "info":{
-        "paragraph1":"This is because you asked to resend the security code too many times the last time you tried to sign in.",
+      "info": {
+        "paragraph1": "This is because you asked to resend the security code too many times the last time you tried to sign in.",
         "paragraph1_create": "This is because you asked to resend the security code too many times.",
-        "subHeading":"What you can do",
-        "paragraph2":"Wait 2 hours, then go back to the service you were trying to use and start again.",
-        "paragraph3":"If you need to use it sooner, you can go back to the service and look for other ways to continue."
-     }
+        "subHeading": "What you can do",
+        "paragraph2": "Wait 2 hours, then go back to the service you were trying to use and start again.",
+        "paragraph3": "If you need to use it sooner, you can go back to the service and look for other ways to continue."
+      }
     },
     "enterMfa": {
       "title": "Check your phone",
@@ -834,7 +834,18 @@
       "content": {
         "paragraph1": "GOV.UK One Login is part of the wider GOV.UK website. There’s a separate ",
         "linkText": "accessibility statement for the main GOV.UK website",
-        "paragraph2": "This page only contains information about GOV.UK One Login, available at www.signin.account.gov.uk."
+        "paragraph2": {
+          "text1": "This page contains information about the GOV.UK One Login service, available at ",
+          "signInLink": {
+            "href": "https://www.signin.account.gov.uk",
+            "text": "www.signin.account.gov.uk"
+          },
+          "text2": " and the user support webchat available at ",
+          "accountLink": {
+            "href": "https://home.account.gov.uk/contact-gov-uk-one-login",
+            "text": "home.account.gov.uk/contact-gov-uk-one-login"
+          }
+        }
       },
       "usingOneLogin": {
         "header": "Using GOV.UK One Login",
@@ -855,25 +866,58 @@
       },
       "accessibilityOfOneLogin": {
         "header": "How accessible GOV.UK One Login is",
-        "paragraph1": "The following parts of GOV.UK One Login are not fully accessible:",
-        "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create a GOV.UK One Login",
-        "bulletPoint2": "it’s not possible for a screen reader to know when the emails we send are in a language other than English",
-        "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
-        "bulletPoint4": "the header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices",
-        "bulletPoint5": "it’s not always possible to use your browser’s autocomplete options to enter information",
-        "bulletPoint6": "the links in the footer are not the same on every page",
-        "bulletPoint7": "there is an empty link in the header for a short section of the journey",
-        "bulletPoint8": "some pages do not correctly identify the language they are published in",
-        "bulletPoint9": "some page titles do not start with ‘error’ if you have not entered the information that’s needed in the correct format",
-        "bulletPoint10": "some links in the header and footer that you may expect to open in a new tab open in the same tab",
-        "bulletPoint11": "some form fields limit how many characters can be entered in them, which can make it difficult to enter information when using assistive technologies",
-        "bulletPoint12": "buttons that show ‘spinner’ animations do not adhere to your reduced motion settings",
-        "bulletPoint13": "the information in the cookie banner content is not the same on all pages it appears on",
-        "paragraph2": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
+        "service": {
+          "header": "Accessibility issues on the GOV.UK One Login service",
+          "paragraph1": "The following parts of GOV.UK One Login website are not fully accessible:",
+          "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create a GOV.UK One Login",
+          "bulletPoint2": "it’s not possible for a screen reader to know when the emails we send are in a language other than English",
+          "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
+          "bulletPoint4": "the header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices",
+          "bulletPoint5": "it’s not always possible to use your browser’s autocomplete options to enter information",
+          "bulletPoint6": "the links in the footer are not the same on every page",
+          "bulletPoint7": "there is an empty link in the header for a short section of the journey",
+          "bulletPoint8": "some pages do not correctly identify the language they are published in",
+          "bulletPoint9": "some page titles do not start with ‘error’ if you have not entered the information that’s needed in the correct format",
+          "bulletPoint10": "some links in the header and footer that you may expect to open in a new tab open in the same tab",
+          "bulletPoint11": "some form fields limit how many characters can be entered in them, which can make it difficult to enter information when using assistive technologies",
+          "bulletPoint12": "buttons that show ‘spinner’ animations do not adhere to your reduced motion settings",
+          "bulletPoint13": "the information in the cookie banner content is not the same on all pages it appears on",
+          "paragraph2": {
+            "text1": "Go to the ",
+            "link": {
+              "text": "technical details of the GOV.UK One Login service accessibility issues",
+              "href": "#non-compliance-service"
+            }
+          }
+        },
+        "webchat": {
+          "header": "Accessibility issues on the GOV.UK One Login webchat",
+          "paragraph1": "The following parts of the GOV.UK One Login webchat are not fully accessible:",
+          "bulletPoint1": "voice control software may not be able to accurately label webchat content:",
+          "subBulletPoint1": "if you are using Safari you will need to use the ‘show grid’ functionality to use the webchat",
+          "subBulletPoint2": "if you are using Chrome you may need to ask the computer to ‘hide numbers’ and ‘show numbers’ again to refresh the labelling of the content",
+          "bulletPoint2": "it’s not possible to change language in the middle of a chat session – if you do, you will lose your chat history",
+          "bulletPoint3": "it’s not possible to save your chat session to refer to later if you leave the contact page",
+          "bulletPoint4": "if you are using an external keyboard, the focus may not reach the question and answer section of the webchat and could disappear completely",
+          "bulletPoint5": "some browsers move the keyboard focus to the start of the webchat when new content is added",
+          "bulletPoint6": "if you are using a screen reader, it may be difficult to distinguish between answer options when they are first added to the webchat",
+          "bulletPoint7": "sometimes the answer text is not descriptive enough when read out of context in the webchat",
+          "bulletPoint8": "the form field label is temporarily removed when you are typing a response – the field label is replaced when you send your response",
+          "bulletPoint9": "focus returns to the webchat icon after the webchat is closed, even if you start the webchat from the link in page content",
+          "bulletPoint10": "if you are using a screen reader, the webchat will not confirm it has been closed",
+          "paragraph2": {
+            "text1": "Go to the ",
+            "link": {
+              "text": "technical details of the GOV.UK One Login webchat accessibility issues",
+              "href": "#non-compliance-webchat"
+            }
+          }
+        },
+        "updatesParagraph": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
       },
       "whatToDo": {
-        "header": "What to do if you have difficulty using GOV.UK One Login",
-        "paragraph1": "If you have difficulty using GOV.UK One Login, ",
+        "header": "What to do if you have difficulty using GOV.UK One Login or the webchat",
+        "paragraph1": "If you have difficulty using any part of GOV.UK One Login, ",
         "linkText": "contact us"
       },
       "howToReport": {
@@ -900,19 +944,35 @@
       "nonAccessibleContent": {
         "header": "Non-accessible content",
         "paragraph1": "The content listed below is non-accessible for the following reasons.",
-        "subHeader": "Non compliance with the accessibility regulations",
-        "listItem1": "When you create a GOV.UK One Login or sign in, if you do not do anything for 60 minutes, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.2 success criterion 2.2.1 (Timing Adjustable).",
-        "listItem2": "The header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices. If you use assistive technologies you may find it harder to navigate pages if you increase the zoom level. This fails WCAG 2.2 success criterion 1.4.10 (Reflow).",
-        "listItem3": "It’s not always possible to use your browser’s autocomplete options to enter information. This fails WCAG 2.2 success criterion 1.3.5 (Identity Input Purpose).",
-        "listItem4": "If you use assistive technologies, it may take you longer to enter information. This fails WCAG 2.2 success criterion 1.3.5 (Identity Input Purpose).",
-        "listItem5": "The links in the footer are not the same on every page. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help).",
-        "listItem6": "There is an empty link in the header for a short section of the journey. If you use assistive technologies you may be aware of the link but will not be able to select it. This fails WCAG 2.2 success criterion 3.2.3 (Consistent Navigation).",
-        "listItem7": "Some pages do not correctly identify the language they are published in. This means screen readers will not read content correctly. This fails WCAG 2.2 success criterion 3.1.1 (Language of Page).",
-        "listItem8": "Some page titles do not start with ‘error’ if the user hasn’t entered the information that’s needed in the correct format. This means screen reader users do not immediately know there is a problem. This fails WCAG 2.2 success criterion 2.4.2 (Page Titled).",
-        "listItem9": "Links in the header and footer that you may expect to open in a new tab sometimes open in a new tab. This fails WCAG 2.2 Guideline 3.2 (Predictable).",
-        "listItem10": "Some form fields limit how many characters can be entered, which can make it difficult to enter information if you are using assistive technologies. This fails WCAG 2.2 success criterion 3.3.1 (Error Identification).",
-        "listItem11": "Buttons that show ‘spinner’ animations do not adhere to your reduced motion settings. This fails WCAG 2.2 success criterion 2.2.2 (Pause, Stop, Hide).",
-        "listItem12": "The information in the cookie banner content is not the same on all pages it appears on. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help)."
+        "service": {
+          "header": "Non compliance with the accessibility regulations for the GOV.UK One Login service",
+          "listItem1": "When you create a GOV.UK One Login or sign in, if you do not do anything for 60 minutes, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.2 success criterion 2.2.1 (Timing Adjustable).",
+          "listItem2": "The header sign-out link causes a horizontal scrollbar at very large magnifications on mobile devices. If you use assistive technologies you may find it harder to navigate pages if you increase the zoom level. This fails WCAG 2.2 success criterion 1.4.10 (Reflow).",
+          "listItem3": "It’s not always possible to use your browser’s autocomplete options to enter information. This fails WCAG 2.2 success criterion 1.3.5 (Identity Input Purpose).",
+          "listItem4": "If you use assistive technologies, it may take you longer to enter information. This fails WCAG 2.2 success criterion 1.3.5 (Identity Input Purpose).",
+          "listItem5": "The links in the footer are not the same on every page. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help).",
+          "listItem6": "There is an empty link in the header for a short section of the journey. If you use assistive technologies you may be aware of the link but will not be able to select it. This fails WCAG 2.2 success criterion 3.2.3 (Consistent Navigation).",
+          "listItem7": "Some pages do not correctly identify the language they are published in. This means screen readers will not read content correctly. This fails WCAG 2.2 success criterion 3.1.1 (Language of Page).",
+          "listItem8": "Some page titles do not start with ‘error’ if the user hasn’t entered the information that’s needed in the correct format. This means screen reader users do not immediately know there is a problem. This fails WCAG 2.2 success criterion 2.4.2 (Page Titled).",
+          "listItem9": "Links in the header and footer that you may expect to open in a new tab sometimes open in the same tab. This fails WCAG 2.2 Guideline 3.2 (Predictable).",
+          "listItem10": "Some form fields limit how many characters can be entered, which can make it difficult to enter information if you are using assistive technologies. This fails WCAG 2.2 success criterion 3.3.1 (Error Identification).",
+          "listItem11": "Buttons that show ‘spinner’ animations do not adhere to your reduced motion settings. This fails WCAG 2.2 success criterion 2.2.2 (Pause, Stop, Hide).",
+          "listItem12": "The information in the cookie banner content is not the same on all pages it appears on. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help)."
+        },
+        "webchat": {
+          "header": "Non compliance with the accessibility regulations for the GOV.UK One Login webchat",
+          "listItem1": "Voice control software may not be able to accurately label the webchat content. This fails WCAG 2.2 success criterion 4.1.2 (Name, role, value).",
+          "listItem2": "If you are using an external keyboard on mobile devices, the keyboard focus may not reach the question and answer section and could disappear completely. This fails WCAG 2.2 success criterion 2.1.1 (Keyboard) and WCAG 2.2 success criterion 2.1.2 (No keyboard trap).",
+          "listItem3": "Some browsers move the chat keyboard focus to the start of the chat when new chat content is added. This fails WCAG 2.2 success criterion 2.4.3 (Focus order).",
+          "listItem4": "If you are using a screen reader, it may be difficult to distinguish between the different quick answer options provided by the webchat. This fails WCAG 2.2 success criterion 1.3.1 (Info and relationships).",
+          "listItem5": "Sometimes the answer text in buttons is not descriptive enough out of context. This fails WCAG 2.2 success criterion 2.4.6 (Headings and labels).",
+          "listItem6": "The field label is removed from the form when you type your own response to a message, but is replaced when you press return. This fails WCAG 2.2 success criterion 3.3.2 (Labels and instructions).",
+          "listItem7": "Focus returns to the webchat icon after the webchat is closed, even if you start the webchat from the link in page content. This fails WCAG 2.2 success criterion 2.4.3 (Focus order).",
+          "paragraph1": "There are three issues that we do not believe are non-compliant with accessibility regulations but may be frustrating for users:",
+          "bulletPoint1": "it’s not possible to change language in the middle of a chat session",
+          "bulletPoint2": "it’s not possible to save your chat session",
+          "bulletPoint3": "the webchat does not confirm it has been closed to screen reader users"
+        }
       },
       "whatWereDoing": {
         "header": "What we’re doing to improve accessibility",
@@ -920,8 +980,9 @@
       },
       "preparation": {
         "header": "Preparation of this accessibility statement",
-        "paragraph1": "This statement was prepared on 4 November 2020. It was last reviewed on 28 February 2024.",
-        "paragraph2": "GOV.UK One Login was last tested in October and November 2023. The test was carried out by the GOV.UK One Login accessibility team who produced an audit of the journey in December 2023. The GOV.UK One Login accessibility team assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.2 in preparation for the guidelines being enforced in October 2024."
+        "paragraph1": "This statement was prepared on 4 November 2020. It was last reviewed on 5 June 2024.",
+        "paragraph2": "GOV.UK One Login was last tested in October and November 2023. The test was carried out by the GOV.UK One Login accessibility team who produced an audit of the journey in December 2023. The GOV.UK One Login accessibility team assessed GOV.UK One Login against the Web Content Accessibility Guidelines (WCAG) 2.2 in preparation for the guidelines being enforced in October 2024.",
+        "paragraph3": "The GOV.UK One Login webchat service was last tested in April 2024. An initial audit was carried out by the GOV.UK One Login accessibility team in October 2023. The service was audited by the Digital Accessibility Centre (DAC) in January 2024. The DAC audit assessed the webchat service against WCAG 2.1, but all success criteria failures also apply to WCAG 2.2."
       }
     },
     "termsAndConditions": {
@@ -2204,7 +2265,6 @@
         }
       }
     },
-    
     "contactUsSubmitSuccess": {
       "title": "Your message has been submitted",
       "header": "Your message has been submitted",
@@ -2339,7 +2399,7 @@
           "authenticatorApp": "authenticator app ",
           "paragraph1End": "you used to create your GOV.UK One Login"
         },
-        "code":{
+        "code": {
           "label": "Enter the 6 digit code"
         }
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -836,7 +836,7 @@
         "linkText": "accessibility statement for the main GOV.UK website",
         "paragraph2": "This page only contains information about GOV.UK One Login, available at www.signin.account.gov.uk."
       },
-      "section1": {
+      "usingOneLogin": {
         "header": "Using GOV.UK One Login",
         "paragraph1": {
           "text1": "GOV.UK One Login is run by the ",
@@ -853,7 +853,7 @@
         "linkHref": "https://mcmw.abilitynet.org.uk/",
         "paragraph3": "has advice on making your device easier to use if you have a disability."
       },
-      "section2": {
+      "accessibilityOfOneLogin": {
         "header": "How accessible GOV.UK One Login is",
         "paragraph1": "The following parts of GOV.UK One Login are not fully accessible:",
         "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create a GOV.UK One Login",
@@ -871,23 +871,23 @@
         "bulletPoint13": "the information in the cookie banner content is not the same on all pages it appears on",
         "paragraph2": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
       },
-      "section3": {
+      "whatToDo": {
         "header": "What to do if you have difficulty using GOV.UK One Login",
         "paragraph1": "If you have difficulty using GOV.UK One Login, ",
         "linkText": "contact us"
       },
-      "section4": {
+      "howToReport": {
         "header": "Report accessibility problems with GOV.UK One Login",
         "paragraph1": "We’re always looking to improve the accessibility of GOV.UK One Login. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, ",
         "linkText": "contact us"
       },
-      "section5": {
+      "enforcement": {
         "header": "Enforcement procedure",
         "paragraph1": "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).",
         "paragraph2": "If you’re not happy with how we respond to your complaint, ",
         "linkText": "contact the Equality Advisory and Support Service (EASS)"
       },
-      "section6": {
+      "technicalInformation": {
         "header": "Technical information about GOV.UK One Login’s accessibility",
         "paragraph1": "The Government Digital Service is committed to making GOV.UK One Login accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.",
         "subHeader": "Compliance status",
@@ -897,7 +897,7 @@
           "text2": " AA standard, due to the non-compliances listed below."
         }
       },
-      "section7": {
+      "nonAccessibleContent": {
         "header": "Non-accessible content",
         "paragraph1": "The content listed below is non-accessible for the following reasons.",
         "subHeader": "Non compliance with the accessibility regulations",
@@ -914,11 +914,11 @@
         "listItem11": "Buttons that show ‘spinner’ animations do not adhere to your reduced motion settings. This fails WCAG 2.2 success criterion 2.2.2 (Pause, Stop, Hide).",
         "listItem12": "The information in the cookie banner content is not the same on all pages it appears on. This fails WCAG 2.2 success criterion 3.2.6 (Consistent Help)."
       },
-      "section8": {
+      "whatWereDoing": {
         "header": "What we’re doing to improve accessibility",
         "paragraph1": "We’ll update this page when issues are fixed, when we expect them to be fixed or when new problems are identified."
       },
-      "section9": {
+      "preparation": {
         "header": "Preparation of this accessibility statement",
         "paragraph1": "This statement was prepared on 4 November 2020. It was last reviewed on 28 February 2024.",
         "paragraph2": "GOV.UK One Login was last tested in October and November 2023. The test was carried out by the GOV.UK One Login accessibility team who produced an audit of the journey in December 2023. The GOV.UK One Login accessibility team assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.2 in preparation for the guidelines being enforced in October 2024."


### PR DESCRIPTION
## What

This PR updates the GOV.UK One Login Accessibility Statement (in 5f87297f30070f45fab4421e5010a97df90c83f0) to:

- describe issues related to the introduction of a third-party webchat tool
- separate these issues from those related to the broader GOV.UK One Login service
- introduce three new anchors, two of which are linked to from the statement itself and a third is for incoming links from
  the webchat tool itself 

The PR also:

1. reformats the accessibility statement template (in https://github.com/govuk-one-login/authentication-frontend/pull/1679/commits/55fcf27b9b0df344e23cabfb10f297149e84498d) and excludes the commit from `git blame` (in https://github.com/govuk-one-login/authentication-frontend/pull/1679/commits/4e19bf50658b026fb9262606e7d7840eae369c58)
2. replaces positional section names (such as `section3` and `section4`) with more descriptive names (like `usingOneLogin`) so that sections can be introduced and removed more easily (in commit https://github.com/govuk-one-login/authentication-frontend/pull/1679/commits/05174af475bf80b903b91e8cb55e0166608cc87d)

### Screenshots

<details>
  <summary>Accessibility Statement - In English</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/8f0dfc37-8663-4fda-a706-f4305a5918c1)


</details>

<details>
  <summary>Accessibility Statement - In Welsh</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/a9fdbf59-e2ab-4b54-b693-585c3654b79d)



</details>

<details>
  <summary>Heading hierarchy</summary>

<img width="750" alt="Screenshot 2024-06-11 at 16 29 55" src="https://github.com/govuk-one-login/authentication-frontend/assets/16000203/38c4c0ba-a118-4a23-9658-0eac2f00e1c2">

</details>

## How to review

1. Code Review commit-by-commit

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.

