### PR TITLE
Revert "AUT-2881: change identity document attribute"

### DIFF
--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -165,7 +165,7 @@ export function contactUsServiceSmartAgent(
 
     customAttributes["sa-useragent"] = contactForm.optionalData.userAgent;
 
-    customAttributes["sa-tag-identity-document"] = prepareIdentityDocumentTitle(
+    customAttributes["sa-identity-document"] = prepareIdentityDocumentTitle(
       contactForm.identityDocumentUsed
     );
 

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -61,7 +61,7 @@ export interface SmartAgentCustomAttributes {
   "sa-tag-telephone-number"?: string;
   "sa-tag-primary-intent-user-selection"?: string;
   "sa-useragent"?: string;
-  "sa-tag-identity-document"?: string;
+  "sa-identity-document"?: string;
   "sa-webformrefer"?: string;
   "sa-security-code-sent-method"?: string;
   "sa-tag-secondary-reason-user-selection"?: string;


### PR DESCRIPTION
Reverts govuk-one-login/authentication-frontend#1656

After a meeting (14/06/24 - 11.30am) with Christopher Sly (HGS - Digital Solutions), it seems his request was not the solution.
So now we have to revert this change.