### PR TITLE
Revert "AUT-1466: Show end of telephone number on MFA resend screen"

### DIFF
--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -6,9 +6,13 @@
 {% set showBack = true %}
 {% set hrefBack = 'enter-code' %}
 
-{% set phoneNumberMessage %}
-   {{ 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber | returnLastCharacters({limit: 3}) }}</span>
-{% endset %}
+{% if isResendCodeRequest %}
+    {% set phoneNumberMessage %}
+       {{ 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber }}</span>
+    {% endset %}
+{% else %}
+    {% set phoneNumberMessage = 'pages.resendMfaCode.phoneNumber.default' | translate | replace("[mobile]", phoneNumber) %}
+{% endif %}
 
 {% block content %}
     <form action="/resend-code" method="post" novalidate="novalidate">

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -32,6 +32,7 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
   } else {
     res.render("resend-mfa-code/index.njk", {
       phoneNumber: req.session.user.redactedPhoneNumber,
+      isResendCodeRequest: req.query?.isResendCodeRequest,
       support2hrLockout: support2hrLockout(),
     });
   }

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -61,18 +61,6 @@ describe("Integration:: resend mfa code", () => {
 
   it("should return resend mfa code page", (done) => {
     request(app).get(PATH_NAMES.RESEND_MFA_CODE).expect(200, done);
-
-    it("should include the last three digits of the user's telephone number", (done) => {
-      request(app)
-        .get(PATH_NAMES.RESEND_MFA_CODE)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($(".govuk-inset-text").text()).to.eq(
-            "We will send a code to your phone number ending with 867"
-          );
-        })
-        .expect(200, done);
-    });
   });
 
   it("should return error when csrf not present", (done) => {

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -60,5 +60,5 @@ export function returnLastCharactersOnly(
   value: string,
   options: { limit: number } = { limit: 4 }
 ): string {
-  return value?.length ? value.slice(-options.limit) : "";
+  return value.slice(-options.limit);
 }

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -252,8 +252,5 @@ describe("phone-number", () => {
         ).to.equal(i);
       });
     });
-    it("should return an empty string if passed empty string", () => {
-      expect(returnLastCharactersOnly("", { limit: 3 })).to.equal("");
-    });
   });
 });


### PR DESCRIPTION
Reverts govuk-one-login/authentication-frontend#1672 to see if it may be related to the acceptance test failure 

> Expected condition failed: waiting for title to contain "You asked to resend the security code too many times". Current title: "Check your phone - GOV.UK One Login"