### PR TITLE
INCIDEN-827 Restore cookie preferences form

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -275,3 +275,5 @@ export const CONTACT_US_REFERER_ALLOWLIST = [
   "passwordUpdatedEmail",
   "changeCodesConfirmEmail",
 ];
+
+export const ANALYTICS_COOKIES = ["_ga", "_gid"];

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -4,7 +4,9 @@ import { sanitize } from "../../../utils/strings";
 import {
   COOKIES_PREFERENCES_SET,
   COOKIE_CONSENT,
+  ANALYTICS_COOKIES,
 } from "../../../app.constants";
+import { getDomainForCookiesSetByGoogleAnalytics } from "../../../config";
 
 const cookieService = cookieConsentService();
 
@@ -25,6 +27,22 @@ export function cookiesPost(req: Request, res: Response): void {
   const consentCookieValue = cookieService.createConsentCookieValue(
     consentValue === "true" ? COOKIE_CONSENT.ACCEPT : COOKIE_CONSENT.REJECT
   );
+
+  if (consentValue === "false") {
+    const options = {
+      domain: getDomainForCookiesSetByGoogleAnalytics(),
+    };
+
+    ANALYTICS_COOKIES.forEach((key) => {
+      res.clearCookie(key, options);
+    });
+
+    Object.keys(req.cookies).forEach((key) => {
+      if (key.startsWith("_ga")) {
+        res.clearCookie(key, options);
+      }
+    });
+  }
 
   res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
     expires: consentCookieValue.expires,

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -342,7 +342,7 @@
   ]
 }) }}
 
-<form method="post" id="cookie-preferences-form" novalidate hidden="true">
+<form method="post" id="cookie-preferences-form" novalidate>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 {{ govukRadios({
   name: "cookie_preferences",

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,6 +119,10 @@ export function getAnalyticsCookieDomain(): string {
   return process.env.ANALYTICS_COOKIE_DOMAIN;
 }
 
+export function getDomainForCookiesSetByGoogleAnalytics(): string {
+  return getServiceDomain() === "localhost" ? "localhost" : ".account.gov.uk";
+}
+
 export function getServiceDomain(): string {
   return process.env.SERVICE_DOMAIN || "localhost";
 }


### PR DESCRIPTION
## What

Restores the ability for users to change their previously selected cookie preferences via the cookies page.

This has been achieved by:

1. Removing the hidden attribute from the form
2. Updating the controller to remove those analytics cookies with known keys and the dynamic analytics cookies (while the prefix shown on the cookies page shows the prefix as `_gat_UA-[number]` I've found that a `_ga_[alphanumeric code]` cookie is set when GA4 is enabled, so I have extended the test to remove all dynamic cookies that start with `_ga`)
3. Introducing a function in `config.ts` to ensure the correct domain is used when we call `res.clearCookie`. This is to accommodate the difference between domains used for GA cookies between localhost (which uses "localhost") and all other environments (which use ".account.gov.uk")

## How to review

1. Code Review
2. Running the branch locally, verify that the form shown on the cookies page reflects the user's preference when it is rendered (defaulting to not using measurement cookies if the user has not stated a preference)
3. Running the branch locally, verify that submitting the form sets the `cookie_preferences_set` to reflect their preference and that the measurement cookies are also set or deleted (the analytics cookies should be present when a user opts in and removed or not present when a user has opted out)
4. Deploy to a sandpit-like environment to verify steps 2. and 3. work as expected

## Related PRs

The pull request that removed the JavaScript necessary to show the form was https://github.com/govuk-one-login/authentication-frontend/pull/1522