### PR TITLE
AUT-2931: Move check email fraud block logic

### DIFF
--- a/src/components/check-your-email/tests/check-your-email-controller.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-controller.test.ts
@@ -13,10 +13,26 @@ import { PATH_NAMES } from "../../../app.constants";
 import { ERROR_CODES, getErrorPathByCode } from "../../common/constants";
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { CheckEmailFraudBlockInterface } from "../../check-email-fraud-block/types";
+import { commonVariables } from "../../../../test/helpers/common-test-variables";
+import { AccountInterventionsInterface } from "../../account-intervention/types";
 
 describe("check your email controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
+  const { email } = commonVariables;
+
+  const accountInterventionsFakeSuccessfulService: AccountInterventionsInterface =
+    {
+      accountInterventions: sinon.fake.returns({ success: true }),
+    } as unknown as AccountInterventionsInterface;
+
+  const checkEmailFraudFakeSuccessfulService: CheckEmailFraudBlockInterface = {
+    checkEmailFraudBlock: sinon.fake.returns({
+      success: true,
+      data: { email, isBlockedStatus: "Pending" },
+    }),
+  } as unknown as CheckEmailFraudBlockInterface;
 
   beforeEach(() => {
     req = createMockRequest(PATH_NAMES.CHECK_YOUR_EMAIL);
@@ -57,7 +73,11 @@ describe("check your email controller", () => {
       req.session.id = "123456-djjad";
       req.session.user.email = "test@test.com";
 
-      await checkYourEmailPost(fakeService)(req as Request, res as Response);
+      await checkYourEmailPost(
+        fakeService,
+        accountInterventionsFakeSuccessfulService,
+        checkEmailFraudFakeSuccessfulService
+      )(req as Request, res as Response);
 
       expect(fakeService.verifyCode).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(
@@ -74,7 +94,11 @@ describe("check your email controller", () => {
 
       req.session.user.isVerifyEmailCodeResendRequired = true;
 
-      await checkYourEmailPost(fakeService)(req as Request, res as Response);
+      await checkYourEmailPost(
+        fakeService,
+        accountInterventionsFakeSuccessfulService,
+        checkEmailFraudFakeSuccessfulService
+      )(req as Request, res as Response);
 
       expect(fakeService.verifyCode).to.have.not.been.called;
       expect(res.redirect).to.have.calledWith(
@@ -96,7 +120,11 @@ describe("check your email controller", () => {
       req.session.id = "123456-djjad";
       req.session.user.email = "test@test.com";
 
-      await checkYourEmailPost(fakeService)(req as Request, res as Response);
+      await checkYourEmailPost(
+        fakeService,
+        accountInterventionsFakeSuccessfulService,
+        checkEmailFraudFakeSuccessfulService
+      )(req as Request, res as Response);
 
       expect(fakeService.verifyCode).to.have.been.calledOnce;
       expect(res.render).to.have.been.calledWith("check-your-email/index.njk");

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -18,6 +18,7 @@ describe("Integration:: check your email", () => {
   let baseApi: string;
 
   before(async () => {
+    process.env.SUPPORT_CHECK_EMAIL_FRAUD = "1";
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -56,6 +57,7 @@ describe("Integration:: check your email", () => {
   after(() => {
     sinon.restore();
     app = undefined;
+    delete process.env.SUPPORT_CHECK_EMAIL_FRAUD;
   });
 
   it("should return verify email page", (done) => {
@@ -148,6 +150,14 @@ describe("Integration:: check your email", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
 
+    nock(baseApi)
+      .post(API_ENDPOINTS.CHECK_EMAIL_FRAUD_BLOCK)
+      .once()
+      .reply(HTTP_STATUS_CODES.OK, {
+        email: "test@test.com",
+        isBlockedStatus: "Pending",
+      });
+
     request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
@@ -165,6 +175,14 @@ describe("Integration:: check your email", () => {
       code: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
       success: false,
     });
+
+    nock(baseApi)
+      .post(API_ENDPOINTS.CHECK_EMAIL_FRAUD_BLOCK)
+      .once()
+      .reply(HTTP_STATUS_CODES.OK, {
+        email: "test@test.com",
+        isBlockedStatus: "Pending",
+      });
 
     request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
@@ -188,6 +206,14 @@ describe("Integration:: check your email", () => {
       code: ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES,
       success: false,
     });
+
+    nock(baseApi)
+      .post(API_ENDPOINTS.CHECK_EMAIL_FRAUD_BLOCK)
+      .once()
+      .reply(HTTP_STATUS_CODES.OK, {
+        email: "test@test.com",
+        isBlockedStatus: "Pending",
+      });
 
     request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -16,7 +16,6 @@ import { SendNotificationServiceInterface } from "../../common/send-notification
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
-import { CheckEmailFraudBlockInterface } from "../../check-email-fraud-block/types";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 
 describe("enter email controller", () => {
@@ -31,13 +30,6 @@ describe("enter email controller", () => {
       success: true,
     }),
   } as unknown as CheckReauthServiceInterface;
-
-  const checkEmailFraudFakeSuccessfulService: CheckEmailFraudBlockInterface = {
-    checkEmailFraudBlock: sinon.fake.returns({
-      success: true,
-      data: { email, isBlockedStatus: "Pending" },
-    }),
-  } as unknown as CheckEmailFraudBlockInterface;
 
   beforeEach(() => {
     res = mockResponse();
@@ -148,11 +140,10 @@ describe("enter email controller", () => {
         }),
       } as unknown as EnterEmailServiceInterface;
 
-      await enterEmailPost(
-        fakeService,
-        checkReauthSuccessfulFakeService,
-        checkEmailFraudFakeSuccessfulService
-      )(req as Request, res as Response);
+      await enterEmailPost(fakeService, checkReauthSuccessfulFakeService)(
+        req as Request,
+        res as Response
+      );
 
       expect(fakeService.userExists).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
@@ -166,11 +157,10 @@ describe("enter email controller", () => {
         }),
       } as unknown as EnterEmailServiceInterface;
 
-      await enterEmailPost(
-        fakeService,
-        checkReauthSuccessfulFakeService,
-        checkEmailFraudFakeSuccessfulService
-      )(req as Request, res as Response);
+      await enterEmailPost(fakeService, checkReauthSuccessfulFakeService)(
+        req as Request,
+        res as Response
+      );
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ACCOUNT_NOT_FOUND);
       expect(fakeService.userExists).to.have.been.calledOnce;
@@ -195,11 +185,10 @@ describe("enter email controller", () => {
         }),
       } as unknown as EnterEmailServiceInterface;
 
-      await enterEmailPost(
-        fakeService,
-        checkReauthSuccessfulFakeService,
-        checkEmailFraudFakeSuccessfulService
-      )(req as Request, res as Response);
+      await enterEmailPost(fakeService, checkReauthSuccessfulFakeService)(
+        req as Request,
+        res as Response
+      );
 
       const expectedLockTime = new Date(
         date.getTime() + lockTTlInSeconds * 1000
@@ -426,11 +415,10 @@ describe("enter email controller", () => {
         }),
       } as unknown as EnterEmailServiceInterface;
 
-      await enterEmailPost(
-        fakeService,
-        checkReauthSuccessfulFakeService,
-        checkEmailFraudFakeSuccessfulService
-      )(req as Request, res as Response);
+      await enterEmailPost(fakeService, checkReauthSuccessfulFakeService)(
+        req as Request,
+        res as Response
+      );
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
     });

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -21,7 +21,6 @@ describe("Integration::enter email", () => {
   let baseApi: string;
 
   before(async () => {
-    process.env.SUPPORT_CHECK_EMAIL_FRAUD = "1";
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -168,13 +167,6 @@ describe("Integration::enter email", () => {
         email: "test@test.com",
         doesUserExist: true,
       });
-    nock(baseApi)
-      .post(API_ENDPOINTS.CHECK_EMAIL_FRAUD_BLOCK)
-      .once()
-      .reply(HTTP_STATUS_CODES.OK, {
-        email: "test@test.com",
-        isBlockedStatus: "Pending",
-      });
 
     request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
@@ -193,13 +185,6 @@ describe("Integration::enter email", () => {
       email: "test@test.com",
       doesUserExist: false,
     });
-    nock(baseApi)
-      .post(API_ENDPOINTS.CHECK_EMAIL_FRAUD_BLOCK)
-      .once()
-      .reply(HTTP_STATUS_CODES.OK, {
-        email: "test@test.com",
-        isBlockedStatus: "Pending",
-      });
 
     request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
@@ -249,14 +234,6 @@ describe("Integration::enter email", () => {
       .reply(HTTP_STATUS_CODES.OK, {
         email: "test@test.com",
         doesUserExist: true,
-      });
-
-    nock(baseApi)
-      .post(API_ENDPOINTS.CHECK_EMAIL_FRAUD_BLOCK)
-      .once()
-      .reply(HTTP_STATUS_CODES.OK, {
-        email: "test@test.com",
-        isBlockedStatus: "Pending",
       });
 
     request(app)


### PR DESCRIPTION
## What

Prior to this commit, the call to the check email fraud block was imlemented in the enter-email-controller. This commit moves it over to the check-your-email-controller where it should be.

## How to review

1. Code Review


