### PR TITLE
AUT-2904: Privacy notice updates for Dynatrace

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -445,6 +445,24 @@
         {{ 'pages.privacy.sections.if_you_agree_to_analytics.paragraph_four' | translate }}
     </p>
 
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.if_you_agree_to_analytics.dynatrace.paragraph_one' | translate }}
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.privacy.sections.if_you_agree_to_analytics.dynatrace.list.item_one' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.if_you_agree_to_analytics.dynatrace.list.item_two' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.if_you_agree_to_analytics.dynatrace.list.item_three' | translate }}</li>
+    </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.if_you_agree_to_analytics.dynatrace.paragraph_two' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.if_you_agree_to_analytics.dynatrace.paragraph_three' | translate }}
+    </p>
+
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.why_we_need_your_information.header' | translate }}
     </h2>
@@ -727,6 +745,10 @@
         <li>{{ 'pages.privacy.sections.how_long_we_keep_your_information.list_one.item_one' | translate }}</li>
         <li>{{ 'pages.privacy.sections.how_long_we_keep_your_information.list_one.item_two' | translate }}</li>
     </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.how_long_we_keep_your_information.paragraph_eleven' | translate }}
+    </p>
 
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.childrens_privacy_protection.header' | translate }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1347,7 +1347,17 @@
           },
           "paragraph_two": "Mae’r wybodaeth a gesglir yn cael ei hystyried yn ddata personol oherwydd bod Google Analytics yn neilltuo dynodwr unigryw i bob ymwelydd. Fodd bynnag, nid yw hyn yn ein galluogi ni na Google i bennu eich hunaniaeth yn y byd go iawn. Ni fyddwn hefyd yn cyfuno gwybodaeth dadansoddi â’r data a ddarperir gennych wrth ddilysu eich GOV.UK One Login neu brofi eich hunaniaeth neu unrhyw ddata arall y gallwn ei ddal er mwyn pennu eich hunaniaeth yn y byd go iawn.",
           "paragraph_three": "Rydym hefyd yn defnyddio Firebase Crashlytics i gasglu gwybodaeth am broblemau y gallech eu profi pan fyddwch yn defnyddio’r ap Gwirio ID GOV.UK, fel yr ap yn chwalu.",
-          "paragraph_four": "Yn y ddau achos, mae Google yn gweithredu fel ein prosesydd data ac nid ydym yn caniatáu i Google ddefnyddio na rhannu’r data hwn at eu dibenion eu hunain."
+          "paragraph_four": "Yn y ddau achos, mae Google yn gweithredu fel ein prosesydd data ac nid ydym yn caniatáu i Google ddefnyddio na rhannu’r data hwn at eu dibenion eu hunain.",
+          "dynatrace": {
+            "paragraph_one": "Rydym yn defnyddio Dynatrace i gasglu gwybodaeth am broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login. Er enghraifft:",
+            "list": {
+              "item_one": "pa mor gyflym mae tudalennau’n llwytho",
+              "item_two": "os byddwch yn gweld unrhyw negeseuon gwall",
+              "item_three": "gwybodaeth dechnegol gan gynnwys eich cyfeiriad IP a dynodwr unigryw"
+            },
+            "paragraph_two": "Nid yw’r wybodaeth a gasglwn yn ein galluogi ni na Dynatrace i benderfynu ar eich hunaniaeth yn y byd go iawn. Ni fyddwn yn cyfuno gwybodaeth ddadansoddi gydag unrhyw ddata arall i bennu eich hunaniaeth yn y byd go iawn.",
+            "paragraph_three": "Mae Dynatrace yn gweithredu fel ein prosesydd data ac nid ydym yn caniatáu iddynt ddefnyddio neu rannu’r data hwn at eu dibenion eu hunain."
+          }
         },
         "why_we_need_your_information": {
           "header": "Pam rydym angen eich gwybodaeth",
@@ -1364,7 +1374,7 @@
             "item_four": "darparu gwasanaeth(au) y llywodraeth rydych yn cael mynediad iddynt drwy GOV.UK One Login gyda gwybodaeth am ganlyniad eich gwiriad hunaniaeth",
             "item_five": "eich darparu gyda chofnod o sut mae eich GOV.UK One Login wedi cael ei ddefnyddio, er enghraifft, pan gafodd ei fewngofnodi iddo ddiwethaf a pha wasanaethau mae wedi cael ei ddefnyddio gyda",
             "item_six": "cysylltu â chi am unrhyw ymyrraeth arfaethedig, problemau neu newidiadau a allai effeithio ar eich GOV.UK One Login (gan ddefnyddio eich cyfeiriad e-bost)",
-            "item_seven": "gwella`r gwasanaeth trwy ddeall sut rydych yn ei ddefnyddio ac unrhyw broblemau rydych yn eu profi, er enghraifft defnyddio Google Analytics, Firebase Crashlytics ac arolwg adborth y ganolfan gyswllt",
+            "item_seven": "gwella’r gwasanaeth drwy ddeall sut rydych yn ei ddefnyddio ac unrhyw broblemau rydych yn eu profi, er enghraifft defnyddio Google Analytics, Firebase Crashlytics, Dynatrace, ac arolwg adborth y ganolfan gyswllt",
             "item_eight": "monitro cyfraddau cyflwyno gwiriadau hunaniaeth lwyddiannus ac aflwyddiannus a chynhyrchu adroddiadau dienw am GOV.UK One Login i’n helpu i ddeall ble gallwn ni wneud gwelliannau",
             "item_nine": "helpu i ddarganfod a thrwsio materion technegol neu ddadfygio",
             "item_ten": "cynorthwyo mewn filio a chymodi ar gyfer y gwasanaethau gwirio hunaniaeth trydydd parti rydym yn eu defnyddio",
@@ -1378,7 +1388,7 @@
           "sub_header_two": "Consent (UK GDPR Article (6)(1)(a))",
           "paragraph_two": "Rydym yn cael eich caniatâd i brosesu eich data personol ar gyfer y dibenion canlynol:",
           "list_one": {
-            "item_one": "casglu a dadansoddi gwybodaeth am sut rydych yn defnyddio eich GOV.UK One Login gan ddefnyddio cwcis Google Analytics",
+            "item_one": "casglu a dadansoddi gwybodaeth am sut rydych yn defnyddio’ch GOV.UK One Login gan ddefnyddio Google Analytics a Chwcis Dynatrace",
             "item_two": "casglu a phrosesu eich ymatebion i`n harolwg am yr help a gawsoch"
           },
           "paragraph_three": "Lle byddwn yn dibynnu ar ganiatâd byddwn yn esbonio mor glir a chryno â phosibl sut bydd eich data’n cael ei brosesu fel eich bod yn deall beth rydych yn cydsynio iddo. Os byddwch yn newid eich meddwl yn ddiweddarach, gallwch dynnu eich caniatâd yn ôl ar unrhyw adeg. Bydd sut gallwch wneud hyn yn dibynnu ar beth rdym yn prosesu eich data ar ei gyfer. Er enghraifft, gallwch:",
@@ -1503,7 +1513,8 @@
           "list_one": {
             "item_one": "cwestiynau KBV rydym yn yn eu cyrchu gan asiantaethau gwirio credyd neu eich atebion i’r cwestiynau hynny",
             "item_two": "fideo hunlun rydych yn ei gymryd fel rhan o brofi eich hunaniaeth drwy ddefnyddio’r ap Gwirio Hunaniaeth GOV.UK"
-          }
+          },
+          "paragraph_eleven": "Os gwnaethoch roi caniatâd i ddadansoddi, bydd Dynatrace yn storio gwybodaeth am sut y gwnaethoch ddefnyddio GOV.UK One Login am 35 diwrnod."
         },
         "childrens_privacy_protection": {
           "header": "Diogelu preifatrwydd plant",
@@ -1512,7 +1523,7 @@
         "where_information_processed_stored": {
           "header": "Lle mae eich gwybodaeth yn cael ei brosesu a’i storio",
           "paragraph_one": "Mae’r holl ddata personol sy’n cael ei brosesu’n uniongyrchol ar gyfer gweinyddu’ch GOV.UK One Login ac ar gyfer gwirio hunaniaeth yn cael ei storio yn y DU neu yn yr Ardal Economaidd Ewropeaidd (AEE). Mae’r AEE wedi cael ei asesu gan Swyddfa’r Comisiynydd Gwybodaeth fel un sydd ag amddiffyniadau cyfreithiol digonol ar gyfer preifatrwydd data yn unol â’r rhai yn y DU.",
-          "paragraph_two": "Gall data a gesglir gan Google Analytics gael ei drosglwyddo y tu allan i’r Ardal Economaidd Ewropeaidd (AEE) ar gyfer prosesu a gall rhai o’n cyflenwyr ddarparu cymorth technegol o’r tu allan i’r AEE. Yn y ddau achos, rydym yn sicrhau bod eich gwybodaeth wedi’i diogelu’n dda, er enghraifft drwy gynnwys cymalau ychwanegol yn ein contractau gyda chyflenwyr."
+          "paragraph_two": "Gellir trosglwyddo data a gesglir gan Google Analytics neu Dynatrace y tu allan i’r Ardal Economaidd Ewropeaidd (AEE) i’w brosesu a gall rhai o’n cyflenwyr ddarparu cymorth technegol o’r tu allan i’r AEE."
         },
         "how_we_protect_your_information": {
           "header": "Sut rydym yn diogelu eich gwybodaeth bersonol a’i gadw’n ddiogel",
@@ -1605,7 +1616,7 @@
           "header": "Newidiadau i’r hysbysiad hwn",
           "paragraph_one": "Efallai y byddwn yn newid yr hysbysiad preifatrwydd hwn. Yn yr achos hynny, bydd dyddiad ’diweddaru olaf’ y ddogfen hon hefyd yn newid. Bydd unrhyw newidiadau i’r hysbysiad preifatrwydd hwn yn berthnasol i chi a’ch gwybodaeth ar unwaith.",
           "paragraph_two": "Os yw’r newidiadau hyn yn effeithio ar sut mae eich gwybodaeth bersonol yn cael ei phrosesu, bydd GDS yn rhoi gwybod i chi.",
-          "paragraph_three": "Diweddarwyd diwethaf: 30 Hydref 2023"
+          "paragraph_three": "Diweddarwyd diwethaf: 28 Mehefin 2024"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1347,7 +1347,17 @@
           },
           "paragraph_two": "The information collected is classed as personal data because Google Analytics assigns a unique identifier to each visitor. This does not however enable us or Google to determine your real world identity. We will also not combine analytics information with the data you provide when authenticating your GOV.UK One Login or proving your identity or any other data that we may hold in order to determine your real world identity.",
           "paragraph_three": "We also use Firebase Crashlytics to collect information about problems you may experience when you use the GOV.UK ID Check app, such as the app crashing.",
-          "paragraph_four": "In both cases, Google acts as our data processor and we do not permit Google to use or share this data for their own purposes."
+          "paragraph_four": "In both cases, Google acts as our data processor and we do not permit Google to use or share this data for their own purposes.",
+          "dynatrace": {
+            "paragraph_one": "We use Dynatrace to collect information about problems you may experience when using GOV.UK One Login. For example:",
+            "list": {
+              "item_one": "how quickly pages load",
+              "item_two": "if you see any error messages",
+              "item_three": "technical information including your IP address and a unique identifier"
+            },
+            "paragraph_two": "The information we collect does not enable us or Dynatrace to determine your real world identity. We will not combine analytics information with any other data to determine your real world identity.",
+            "paragraph_three": "Dynatrace acts as our data processor and we do not permit them to use or share this data for their own purposes."
+          }
         },
         "why_we_need_your_information": {
           "header": "Why we need your information",
@@ -1364,7 +1374,7 @@
             "item_four": "provide the government service(s) that you access through GOV.UK One Login with information about the outcome of your identity check",
             "item_five": "provide you with a record of how your GOV.UK One Login has been used, for example, when it was last signed in to and what services it has been used with",
             "item_six": "contact you about any planned interruptions, problems or changes that may affect your GOV.UK One Login (using your email address)",
-            "item_seven": "improve the service by understanding how you use it and any problems you experience, for example using Google Analytics, Firebase Crashlytics and the contact centre feedback survey",
+            "item_seven": "improve the service by understanding how you use it and any problems you experience, for example using Google Analytics, Firebase Crashlytics, Dynatrace, and the contact centre feedback survey",
             "item_eight": "monitor the rates of successful and unsuccessful identity checking submissions and produce anonymised reports about GOV.UK One Login to help us understand where we can make improvements",
             "item_nine": "help diagnose and fix technical or debugging issues",
             "item_ten": "assist in billing and reconciliation for the third party identity checking services we use",
@@ -1378,7 +1388,7 @@
           "sub_header_two": "Consent (UK GDPR Article (6)(1)(a))",
           "paragraph_two": "We obtain your consent to process your personal data for the following purposes:",
           "list_one": {
-            "item_one": "collecting and analysing information about how you use your GOV.UK One Login using Google Analytics cookies",
+            "item_one": "collecting and analysing information about how you use your GOV.UK One Login using Google Analytics and Dynatrace cookies",
             "item_two": "collecting and processing your responses to our survey about the help you received"
           },
           "paragraph_three": "Where we rely on consent we will explain as clearly and concisely as possible how your data will be processed so you understand what you are consenting to. If you later change your mind, you can withdraw your consent at any time. How you can do this will depend on what we are processing your data for. For example, you can:",
@@ -1503,7 +1513,8 @@
           "list_one": {
             "item_one": "KBV questions we source from credit reference agencies or your answers to those questions",
             "item_two": "selfie video you take as part of proving your identity using the GOV.UK Identity Check app"
-          }
+          },
+          "paragraph_eleven": "If you consented to analytics, Dynatrace will store information about how you used GOV.UK One Login for 35 days."
         },
         "childrens_privacy_protection": {
           "header": "Children’s privacy protection",
@@ -1512,7 +1523,7 @@
         "where_information_processed_stored": {
           "header": "Where your information is processed and stored",
           "paragraph_one": "All personal data processed directly for the administration of your GOV.UK One Login and for identity checking is stored in the UK or in the European Economic Area (EEA). The EEA has been assessed by the UK Government as having adequate legal protections for data privacy in line with those in the UK.",
-          "paragraph_two": "Data collected by Google Analytics may be transferred outside the European Economic Area (EEA) for processing and some of our suppliers may provide technical support from outside of the EEA. In both cases, we ensure your information is just as well protected, for example by including extra clauses in our contracts with suppliers."
+          "paragraph_two": "Data collected by Google Analytics or Dynatrace may be transferred outside the European Economic Area (EEA) for processing and some of our suppliers may provide technical support from outside of the EEA. In both cases, we ensure your information is just as well protected, for example by including extra clauses in our contracts with suppliers."
         },
         "how_we_protect_your_information": {
           "header": "How we protect your personal information and keep it secure",
@@ -1605,7 +1616,7 @@
           "header": "Changes to this notice",
           "paragraph_one": "We may change this privacy notice. In that case, the ‘last updated’ date of this document will also change. Any changes to this privacy notice will apply to you and your information immediately.",
           "paragraph_two": "If these changes affect how your personal information is processed, GDS will let you know.",
-          "paragraph_three": "Last updated: 30 October 2023"
+          "paragraph_three": "Last updated: 28 June 2024"
         }
       }
     },


### PR DESCRIPTION
## What

Updates the privacy notice for updates to Dynatrace

### Screenshots

To capture these screenshots within a single image it was necessary to remove the CSS that sets normal page and column widths. This was done in browser developer tools only. 

<details>
    <summary>Privacy notice - English</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/0ec0ff71-231b-4323-b5dd-1533f1358b70)

</details>

<details>
    <summary>Privacy notice - Welsh</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/09385974-c4d7-4300-b657-a3e2b18f05b4)

</details>

## How to review

Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1784 Updates the cookies policy
