### PR TITLE
AUT-1784: Enable GA4 in production environment

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -41,6 +41,6 @@ orch_to_auth_audience           = "https://signin.account.gov.uk/"
 
 ua_disabled                          = "false"
 universal_analytics_gtm_container_id = "GTM-TT5HDKV"
-ga4_disabled                         = "true"
+ga4_disabled                         = "false"
 google_analytics_4_gtm_container_id  = "GTM-K4PBJH3"
 analytics_cookie_domain              = ".account.gov.uk"


### PR DESCRIPTION
## What

Enables GA4 in production

## How to review

1. Code Review


## Checklist

- [x] Performance analyst has been notified of the change.

## Related PRs

* https://github.com/govuk-one-login/authentication-frontend/pull/1671 - updated the environment variables
* https://github.com/govuk-one-login/authentication-frontend/pull/1633 set the GA4 and UA environment variables as initially requested
* https://github.com/govuk-one-login/authentication-frontend/pull/1522 introduced GA4