### PR TITLE
BAU: Allow dependabot to trigger SonarCloud analysis

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Run test coverage
         run: yarn test:coverage
       - name: SonarCloud Scan
-        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: sonarsource/sonarcloud-github-action@v2.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

We have GitHub PR checks toat wait for SonarCloud reports, but they are not triggered for dependabot PRs.

## How to review

- See the removal of the dependabot condition