### PR TITLE
BAU: Remove duplicated name in ECS task definition

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -73,10 +73,6 @@ locals {
         value = var.gtm_id
       },
       {
-        name  = "ANALYTICS_COOKIE_DOMAIN"
-        value = local.service_domain
-      },
-      {
         name  = "REDIS_KEY"
         value = local.redis_key
       },


### PR DESCRIPTION
## What

Removes duplication of `ANALYTICS_COOKIE_DOMAIN` within the ECS Task Definition, retaining the variant that makes use of the `var.analytics_cookie_domain` that exists specifically for the purpose of setting a common cookie domain (regardless of the specific subdomain that might be used).

SRE colleagues have explained that the duplicated name is forcing new deployments and reduced capacity as a consequence. 

## How to review

1. Code Review

## Related PRs

The newer variant was introduced in https://github.com/govuk-one-login/authentication-frontend/pull/1633


