### PR TITLE
AUT-2924: Prod enable Service down page

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,6 +1,7 @@
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
+service_down_page   = true
 
 #cloudfront enabled flag 
 cloudfront_auth_frontend_enabled = true


### PR DESCRIPTION
## What

AUT-2924 Prod enable Service down page


Note : This PR Just deploy the Service Down Page  as Dormant for use , It **DOES NOT**  actually switch on the page

To Switch the Page We need to Follow a Manual Step to Temporarily shutter the Service documented on Team manual 

## Why 

We have migrated service down page from concur pipeline to AWS code pipeline 

## How to review

1. Code Review
