### PR TITLE
AUT-1723: trust cloudfront cidrs in sidecar

### DIFF
--- a/.github/workflows/test-sidecar.yml
+++ b/.github/workflows/test-sidecar.yml
@@ -6,6 +6,9 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+    paths:
+      - basic-auth-sidecar/**
+      - test/basic-auth-sidecar/**
 
 jobs:
   run-tests:

--- a/ci/terraform/core.tf
+++ b/ci/terraform/core.tf
@@ -8,6 +8,12 @@ data "terraform_remote_state" "core" {
   }
 }
 
+
+data "aws_ip_ranges" "cloudfront_ips" {
+  regions  = ["global"]
+  services = ["cloudfront"]
+}
+
 locals {
   vpc_arn                                    = data.terraform_remote_state.core.outputs.vpc_arn
   vpc_id                                     = data.terraform_remote_state.core.outputs.vpc_id

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -5,6 +5,11 @@ locals {
   nginx_port       = 8080
   application_port = var.basic_auth_password == "" ? var.app_port : local.nginx_port
 
+  sidecar_trusted_proxies = concat(
+    local.private_subnet_cidr_blocks,
+    data.aws_ip_ranges.cloudfront_ips.cidr_blocks,
+  )
+
   frontend_container_definition = {
     name      = local.container_name
     image     = "${var.image_uri}:${var.image_tag}@${var.image_digest}"
@@ -255,7 +260,7 @@ locals {
       },
       {
         name  = "TRUSTED_PROXIES"
-        value = jsonencode(local.public_subnet_cidr_blocks)
+        value = jsonencode(local.sidecar_trusted_proxies)
       },
     ]
   }

--- a/ci/terraform/nonprod-common.tfvars
+++ b/ci/terraform/nonprod-common.tfvars
@@ -1,0 +1,7 @@
+service_down_page         = false
+service_down_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository"
+service_down_image_digest = "sha256:2376c76ae4ae05320319752df0bc6d69ef4836e9d66e5c78f941edf42c087f10"
+
+smartagent_api_key    = ""
+smartagent_api_url    = ""
+smartagent_webform_id = ""

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -37,7 +37,7 @@ frontend_auto_scaling_min_count  = 1
 frontend_auto_scaling_max_count  = 2
 ecs_desired_count                = 1
 
-#cloudfront enabled flag 
+#cloudfront enabled flag
 cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 


### PR DESCRIPTION
## What

As we now have a cloudfront distribution in front of the ALB, we need to add the cloudfront node CIDRs to the list of trusted proxies in the sidecar container. This will allow the sidecar to correctly identify the client IP address via X-Forwarded-For headers.

With cloudfront, the sidecar sees the following header:

`X-Forwarded-For: client_ip, cloudfront_ip`, eg:
```
X-Forwarded-For: 1.2.3.4, 15.158.48.119
```

As 15.158.48.119 was previously not in the list of trusted proxies, nginx treated it as the client IP address (as it is the rightmost IP that's not a trusted proxy). This resulted in the sidecar requesting basic auth. Now these IPs are marked correctly, it will work as expected again.

This behaviour is as-per `real_ip_recursive on;`:

> If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field.

## How to review

- Code review
- Test deploy to sandpit / authdevs, confirm that no infra changes occur
