### PR TITLE
AUT-1723: Fix the order of the realip config

### DIFF
--- a/basic-auth-sidecar/default.conf
+++ b/basic-auth-sidecar/default.conf
@@ -7,9 +7,9 @@ server {
 
       satisfy any;
 
+      include /etc/nginx/trusted-proxies.conf;
       real_ip_header X-Forwarded-For;
       real_ip_recursive on;
-      include /etc/nginx/trusted-proxies.conf;
 
       include /etc/nginx/allow-list.conf;
       deny all;


### PR DESCRIPTION
## What

Apparently, the order of the realip config is important. It seems that the trusted proxy config must come before the other directives.

## How to review

Code review 👀
