### PR TITLE
BAU:fix Sonarcloud "Expected the Promise rejection reason to be an Er…

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -190,7 +190,7 @@ export async function getNextPathAndUpdateJourney(
   await new Promise<void>((resolve, reject) => {
     req.session.save((error) => {
       if (error) {
-        reject(error);
+        reject(new Error(error));
         req.log.error(
           "Session could not be saved after setting the user journey."
         );


### PR DESCRIPTION
…ror."

Using an instance of the Error class allows you to provide more meaningful information about the error. The Error class and its subclasses provide properties such as message and stack that can be used to convey useful details.

## What

Fix [this](https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&types=CODE_SMELL&id=govuk-one-login_authentication-frontend&open=AY8Ub9V0CJ2aVgC8DLNx&tab=code) Sonarcloud issue.

## How to review

1. Code Review

