### PR TITLE
AUT-2997: Update cookie policy and functionality for Dynatrace RUM

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # Reformatting of footer/accessibility-statement.njk
 55fcf27b9b0df344e23cabfb10f297149e84498d
+
+# Reformatting of cookies/index.njk
+60117fe4bf12bc9362b66cf932788362431a6abb

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -276,4 +276,16 @@ export const CONTACT_US_REFERER_ALLOWLIST = [
   "changeCodesConfirmEmail",
 ];
 
-export const ANALYTICS_COOKIES = ["_ga", "_gid"];
+const GA_COOKIES = ["_ga", "_gid"];
+
+const DYNATRACE_RUM_COOKIES = [
+  "dtCookie",
+  "dtLatC",
+  "dtPC",
+  "dtSa",
+  "dtValidationCookie",
+  "dtDisabled",
+  "rxVisitor",
+  "rxvt",
+];
+export const ANALYTICS_COOKIES = [...GA_COOKIES, ...DYNATRACE_RUM_COOKIES];

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -61,6 +61,14 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
     if (window.DI.analyticsGa4.cookie.hasConsentForAnalytics()) {
       cookies.initAnalytics();
     }
+
+    if(window.dtrum !== undefined) {
+      if(window.DI.analyticsGa4.cookie.hasConsentForAnalytics()) {
+        window.dtrum.enable()
+      } else {
+        window.dtrum.disable()
+      }
+    }
   }
 
   initFeedbackRadioButtons();

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -1,23 +1,23 @@
 function initFeedbackRadioButtons() {
   var feedbackRadioButtons = Array.prototype.slice.call(
-      document.querySelectorAll('input[name="feedbackContact"]')
-    );
-    var container = document.querySelector("#contact-details-container");
-    feedbackRadioButtons.forEach(function (element) {
-      element.addEventListener(
-        "click",
-        function (event) {
-          if (event.target.value === "true") {
-            container.classList.remove("govuk-!-display-none");
-          } else {
-            container.classList.add("govuk-!-display-none");
-            var elements = container.getElementsByTagName("input");
-            for (var i = 0; i < elements.length; i++) {
-              if (elements[i].type == "text") {
-                elements[i].value = "";
-              }
+    document.querySelectorAll('input[name="feedbackContact"]')
+  );
+  var container = document.querySelector("#contact-details-container");
+  feedbackRadioButtons.forEach(function (element) {
+    element.addEventListener(
+      "click",
+      function (event) {
+        if (event.target.value === "true") {
+          container.classList.remove("govuk-!-display-none");
+        } else {
+          container.classList.add("govuk-!-display-none");
+          var elements = container.getElementsByTagName("input");
+          for (var i = 0; i < elements.length; i++) {
+            if (elements[i].type == "text") {
+              elements[i].value = "";
             }
           }
+        }
       }.bind(this)
     );
   });
@@ -62,11 +62,11 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
       cookies.initAnalytics();
     }
 
-    if(window.dtrum !== undefined) {
-      if(window.DI.analyticsGa4.cookie.hasConsentForAnalytics()) {
-        window.dtrum.enable()
+    if (window.dtrum !== undefined) {
+      if (window.DI.analyticsGa4.cookie.hasConsentForAnalytics()) {
+        window.dtrum.enable();
       } else {
-        window.dtrum.disable()
+        window.dtrum.disable();
       }
     }
   }
@@ -85,4 +85,4 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
   }
 
   w.DI.analyticsUa.init = appInit;
-})(window); 
+})(window);

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -6,7 +6,7 @@ import {
   COOKIE_CONSENT,
   ANALYTICS_COOKIES,
 } from "../../../app.constants";
-import { getDomainForCookiesSetByGoogleAnalytics } from "../../../config";
+import { getGoogleAnalyticsAndDynatraceCookieDomain } from "../../../config";
 
 const cookieService = cookieConsentService();
 
@@ -29,7 +29,7 @@ export function cookiesPost(req: Request, res: Response): void {
 
   if (consentValue === "false") {
     const options = {
-      domain: getDomainForCookiesSetByGoogleAnalytics(),
+      domain: getGoogleAnalyticsAndDynatraceCookieDomain(),
     };
 
     ANALYTICS_COOKIES.forEach((key) => {

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -285,6 +285,9 @@
 
     {{ govukTable({
         firstCellIsHeader: false,
+        attributes: {
+            id: 'analytics-cookies'
+        },
         head: [
             {
                 text: 'pages.cookiePolicy.analytics.table.headers.col1' | translate,

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -8,373 +8,376 @@
 
 {% block content %}
 
-{% set html %}
-<h3 class="govuk-notification-banner__heading">
-  {{ 'pages.cookiePolicy.successBanner.header' | translate }}
-</h3>
-<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
-<a class="govuk-notification-banner__link" id="go-back-link" href="{{ originalReferer }}">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
-{% endset %}
+    {% set html %}
+        <h3 class="govuk-notification-banner__heading">
+            {{ 'pages.cookiePolicy.successBanner.header' | translate }}
+        </h3>
+        <p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+        <a class="govuk-notification-banner__link" id="go-back-link"
+           href="{{ originalReferer }}">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
+    {% endset %}
 
-{% if updated %}
-{{
-  govukNotificationBanner({
-  html: html,
-  type: 'success',
-  titleText: 'general.cookie.cookieBanner.cookieBannerTitleText' | translate,
-  attributes: {
-    "id": "save-success-banner"
-  }
-}) }}
-{% else %}
-{{ govukNotificationBanner({
-  html: html,
-  type: 'success',
-  titleText: 'general.cookie.cookieBanner.cookieBannerTitleText' | translate,
-  attributes: {
-    "id": "save-success-banner",
-    "hidden": true
-  }
-}) }}
-{% endif %}
+    {% if updated %}
+        {{ govukNotificationBanner({
+            html: html,
+            type: 'success',
+            titleText: 'general.cookie.cookieBanner.cookieBannerTitleText' | translate,
+            attributes: {
+                "id": "save-success-banner"
+            }
+        }) }}
+    {% else %}
+        {{ govukNotificationBanner({
+            html: html,
+            type: 'success',
+            titleText: 'general.cookie.cookieBanner.cookieBannerTitleText' | translate,
+            attributes: {
+                "id": "save-success-banner",
+                "hidden": true
+            }
+        }) }}
+    {% endif %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.cookiePolicy.header' | translate }}
-</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+        {{ 'pages.cookiePolicy.header' | translate }}
+    </h1>
 
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph1' | translate}}
-  <a href="{{'pages.cookiePolicy.info.govUkCookiesLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.cookiePolicy.info.govUkCookiesLinkText' | translate}}</a>{{'pages.cookiePolicy.info.paragraph2' | translate}}
-</p>
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph3' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph4' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph5' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph6' | translate}}
-  <a href="{{'pages.cookiePolicy.info.linkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.cookiePolicy.info.linkText' | translate}}</a>{{'pages.cookiePolicy.info.paragraph7' | translate}}
-</p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.info.paragraph1' | translate }}
+        <a href="{{ 'pages.cookiePolicy.info.govUkCookiesLinkHref' | translate }}" class="govuk-link"
+           rel="noreferrer noopener"
+           target="_blank">{{ 'pages.cookiePolicy.info.govUkCookiesLinkText' | translate }}</a>{{ 'pages.cookiePolicy.info.paragraph2' | translate }}
+    </p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.info.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.info.paragraph4' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.info.paragraph5' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.info.paragraph6' | translate }}
+        <a href="{{ 'pages.cookiePolicy.info.linkHref' | translate }}" class="govuk-link" rel="noreferrer noopener"
+           target="_blank">{{ 'pages.cookiePolicy.info.linkText' | translate }}</a>{{ 'pages.cookiePolicy.info.paragraph7' | translate }}
+    </p>
 
-<h2 class="govuk-heading-s">{{'pages.cookiePolicy.essential.header' | translate}}</h2>
+    <h2 class="govuk-heading-s">{{ 'pages.cookiePolicy.essential.header' | translate }}</h2>
 
-<p class="govuk-body">{{'pages.cookiePolicy.essential.info.paragraph1' | translate}}</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>{{'pages.cookiePolicy.essential.info.bulletPoint1' | translate}}</li>
-  <li>{{'pages.cookiePolicy.essential.info.bulletPoint2' | translate}}</li>
-  <li>{{'pages.cookiePolicy.essential.info.bulletPoint3' | translate}}</li>
-</ul>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.essential.info.paragraph1' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.cookiePolicy.essential.info.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.cookiePolicy.essential.info.bulletPoint2' | translate }}</li>
+        <li>{{ 'pages.cookiePolicy.essential.info.bulletPoint3' | translate }}</li>
+    </ul>
 
-{{ govukTable({
-  firstCellIsHeader: false,
-  head: [
-    {
-    text: 'pages.cookiePolicy.essential.info.table.headers.col1' | translate,
-    classes: 'govuk-body-s'
-    },
-    {
-    text: 'pages.cookiePolicy.essential.info.table.headers.col2' | translate,
-    classes: 'govuk-body-s'
-    }
-  ],
-  rows: [
-    [
-      {
-      text: "aps",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "_csrf",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "gs",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "di-persistent-session-id",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "am",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row5.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "lo",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row6.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "hmpo-wizard-sc",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row7.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "service_session",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row8.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "cri_passport_service_session",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row9.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "ipv_core_service_session",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row10.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "chl",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row11.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "re",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row12.col2' | translate,
-      classes: 'govuk-body-s'
-      }
-    ]
-  ]
-}) }}
+    {{ govukTable({
+        firstCellIsHeader: false,
+        head: [
+            {
+                text: 'pages.cookiePolicy.essential.info.table.headers.col1' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.essential.info.table.headers.col2' | translate,
+                classes: 'govuk-body-s'
+            }
+        ],
+        rows: [
+            [
+                {
+                    text: "aps",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row1.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "_csrf",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row2.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "gs",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "di-persistent-session-id",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "am",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row5.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "lo",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row6.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "hmpo-wizard-sc",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row7.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "service_session",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row8.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "cri_passport_service_session",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row9.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "ipv_core_service_session",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row10.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "chl",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row11.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "re",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row12.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ]
+        ]
+    }) }}
 
-<h3 class="govuk-heading-s">{{'pages.cookiePolicy.cookiesMessage.header' | translate}}</h3>
-<p class="govuk-body">{{'pages.cookiePolicy.cookiesMessage.paragraph1' | translate}}</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>{{'pages.cookiePolicy.cookiesMessage.bulletPoint1' | translate}}</li>
-  <li>{{'pages.cookiePolicy.cookiesMessage.bulletPoint2' | translate}}</li>
-</ul>
+    <h3 class="govuk-heading-s">{{ 'pages.cookiePolicy.cookiesMessage.header' | translate }}</h3>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.cookiesMessage.paragraph1' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.cookiePolicy.cookiesMessage.bulletPoint1' | translate }}</li>
+        <li>{{ 'pages.cookiePolicy.cookiesMessage.bulletPoint2' | translate }}</li>
+    </ul>
 
-{{ govukTable({
-  firstCellIsHeader: false,
-  head: [
-    {
-      text: 'pages.cookiePolicy.cookiesMessage.table.headers.col1' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.cookiesMessage.table.headers.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.cookiesMessage.table.headers.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-  ],
-  rows: [
-    [
-    {
-      text: "cookies_preferences_set",
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.cookiesMessage.table.rows.row1.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.cookiesMessage.table.rows.row1.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-    ]
-  ]
-}) }}
+    {{ govukTable({
+        firstCellIsHeader: false,
+        head: [
+            {
+                text: 'pages.cookiePolicy.cookiesMessage.table.headers.col1' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.cookiesMessage.table.headers.col2' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.cookiesMessage.table.headers.col3' | translate,
+                classes: 'govuk-body-s'
+            }
+        ],
+        rows: [
+            [
+                {
+                    text: "cookies_preferences_set",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.cookiesMessage.table.rows.row1.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.cookiesMessage.table.rows.row1.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ]
+        ]
+    }) }}
 
-<h2 class="govuk-heading-s">{{'pages.cookiePolicy.settingsCookies.header' | translate}}</h2>
-<p class="govuk-body">{{'pages.cookiePolicy.settingsCookies.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.settingsCookies.paragraph2' | translate}}</p>
+    <h2 class="govuk-heading-s">{{ 'pages.cookiePolicy.settingsCookies.header' | translate }}</h2>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.settingsCookies.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.settingsCookies.paragraph2' | translate }}</p>
 
-{{ govukTable({
-  firstCellIsHeader: false,
-  head: [
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.headers.col1' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.headers.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.headers.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-  ],
-  rows: [
-    [
-    {
-      text: "lng",
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-    ]
-  ]
-}) }}
+    {{ govukTable({
+        firstCellIsHeader: false,
+        head: [
+            {
+                text: 'pages.cookiePolicy.settingsCookies.table.headers.col1' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.settingsCookies.table.headers.col2' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.settingsCookies.table.headers.col3' | translate,
+                classes: 'govuk-body-s'
+            }
+        ],
+        rows: [
+            [
+                {
+                    text: "lng",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ]
+        ]
+    }) }}
 
-<h2 class="govuk-heading-s">{{'pages.cookiePolicy.analytics.header' | translate}}</h2>
-<p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph2' | translate}}</p>
+    <h2 class="govuk-heading-s">{{ 'pages.cookiePolicy.analytics.header' | translate }}</h2>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.analytics.info.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.cookiePolicy.analytics.info.paragraph2' | translate }}</p>
 
-{{ govukTable({
-  firstCellIsHeader: false,
-  head: [
-    {
-      text: 'pages.cookiePolicy.analytics.table.headers.col1' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.headers.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.headers.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-  ],
-  rows: [
-    [
-    {
-      text: "_ga",
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.rows.row1.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.rows.row1.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-    ],
-    [
-    {
-      text: "_gid",
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.rows.row2.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.rows.row2.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-    ],
-    [
-    {
-      text: "_gat_UA-[number]",
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.rows.row3.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.analytics.table.rows.row3.col3' | translate,
-      classes: 'govuk-body-s'
-    }
-    ]
-  ]
-}) }}
+    {{ govukTable({
+        firstCellIsHeader: false,
+        head: [
+            {
+                text: 'pages.cookiePolicy.analytics.table.headers.col1' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.analytics.table.headers.col2' | translate,
+                classes: 'govuk-body-s'
+            },
+            {
+                text: 'pages.cookiePolicy.analytics.table.headers.col3' | translate,
+                classes: 'govuk-body-s'
+            }
+        ],
+        rows: [
+            [
+                {
+                    text: "_ga",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.row1.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.row1.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "_gid",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.row2.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.row2.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "_gat_UA-[number]",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.row3.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.row3.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ]
+        ]
+    }) }}
 
-<form method="post" id="cookie-preferences-form" novalidate>
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-<input type="hidden" id="originalReferer" name="originalReferer" value="{{originalReferer}}"/>
-{{ govukRadios({
-  name: "cookie_preferences",
-  attributes: {
-    "id": "radio-cookie-preferences"
-  },
-  items: [
-    {
-      value: "true",
-      text: 'pages.cookiePolicy.settings.yesRadioButton' | translate,
-      id: "policy-cookies-accepted",
-      checked: analyticsConsent === true
-    },
-    {
-      value: "false",
-      text: 'pages.cookiePolicy.settings.noRadioButton' | translate,
-      id: "policy-cookies-rejected",
-      checked: analyticsConsent === false
-    }
-  ]
-}) }}
+    <form method="post" id="cookie-preferences-form" novalidate>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" id="originalReferer" name="originalReferer" value="{{ originalReferer }}" />
+        {{ govukRadios({
+            name: "cookie_preferences",
+            attributes: {
+                "id": "radio-cookie-preferences"
+            },
+            items: [
+                {
+                    value: "true",
+                    text: 'pages.cookiePolicy.settings.yesRadioButton' | translate,
+                    id: "policy-cookies-accepted",
+                    checked: analyticsConsent === true
+                },
+                {
+                    value: "false",
+                    text: 'pages.cookiePolicy.settings.noRadioButton' | translate,
+                    id: "policy-cookies-rejected",
+                    checked: analyticsConsent === false
+                }
+            ]
+        }) }}
 
-{{ govukButton({
-  "text": 'pages.cookiePolicy.settings.saveButton' | translate,
-  "type": "submit",
-  "preventDoubleClick": true,
-  attributes: {
-    "id": "save-cookie-settings"
-  }
-}) }}
+        {{ govukButton({
+            "text": 'pages.cookiePolicy.settings.saveButton' | translate,
+            "type": "submit",
+            "preventDoubleClick": true,
+            attributes: {
+                "id": "save-cookie-settings"
+            }
+        }) }}
 
-</form>
+    </form>
 
 {% endblock %}

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -306,11 +306,11 @@
                     classes: 'govuk-body-s'
                 },
                 {
-                    text: 'pages.cookiePolicy.analytics.table.rows.row1.col2' | translate,
+                    text: 'pages.cookiePolicy.analytics.table.rows._ga.col2' | translate,
                     classes: 'govuk-body-s'
                 },
                 {
-                    text: 'pages.cookiePolicy.analytics.table.rows.row1.col3' | translate,
+                    text: 'pages.cookiePolicy.analytics.table.rows._ga.col3' | translate,
                     classes: 'govuk-body-s'
                 }
             ],
@@ -320,11 +320,11 @@
                     classes: 'govuk-body-s'
                 },
                 {
-                    text: 'pages.cookiePolicy.analytics.table.rows.row2.col2' | translate,
+                    text: 'pages.cookiePolicy.analytics.table.rows._gid.col2' | translate,
                     classes: 'govuk-body-s'
                 },
                 {
-                    text: 'pages.cookiePolicy.analytics.table.rows.row2.col3' | translate,
+                    text: 'pages.cookiePolicy.analytics.table.rows._gid.col3' | translate,
                     classes: 'govuk-body-s'
                 }
             ],
@@ -334,11 +334,123 @@
                     classes: 'govuk-body-s'
                 },
                 {
-                    text: 'pages.cookiePolicy.analytics.table.rows.row3.col2' | translate,
+                    text: 'pages.cookiePolicy.analytics.table.rows._gat_UA.col2' | translate,
                     classes: 'govuk-body-s'
                 },
                 {
-                    text: 'pages.cookiePolicy.analytics.table.rows.row3.col3' | translate,
+                    text: 'pages.cookiePolicy.analytics.table.rows._gat_UA.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "dtCookie",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtCookie.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtCookie.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "dtLatC",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtLatC.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtLatC.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "dtPC",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtPC.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtPC.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "dtSa",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtSa.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtSa.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "dtValidationCookie",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtValidationCookie.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtValidationCookie.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "dtDisabled",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtDisabled.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.dtDisabled.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "rxVisitor",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.rxVisitor.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.rxVisitor.col3' | translate,
+                    classes: 'govuk-body-s'
+                }
+            ],
+            [
+                {
+                    text: "rxvt",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.rxvt.col2' | translate,
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.analytics.table.rows.rxvt.col3' | translate,
                     classes: 'govuk-body-s'
                 }
             ]

--- a/src/components/common/cookies/tests/cookies-controller-integration.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller-integration.test.ts
@@ -1,0 +1,63 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { expect } from "../../../../../test/utils/test-utils";
+import * as cheerio from "cheerio";
+import decache from "decache";
+import { PATH_NAMES, ANALYTICS_COOKIES } from "../../../../app.constants";
+
+describe("Integration:: cookies controller", () => {
+  let app: any;
+  let $: any;
+  const dynamicGACookieName = "_gat_UA-[number]";
+  const analyticsCookieNamesListedInCookieNotice: string[] = [];
+
+  before(async () => {
+    decache("../../../../app");
+
+    app = await require("../../../../app").createApp();
+
+    request(app)
+      .get(PATH_NAMES.COOKIES_POLICY)
+      .end((err, res) => {
+        $ = cheerio.load(res.text);
+        $("table#analytics-cookies tbody td:first-child").each(
+          (i: any, elem: any) => {
+            const cookieName = $(elem).text();
+            analyticsCookieNamesListedInCookieNotice.push(cookieName);
+          }
+        );
+      });
+  });
+
+  after(() => {
+    app = undefined;
+  });
+
+  describe("The cookies policy page", () => {
+    describe("table with an id of `analytics-cookies`", () => {
+      it("should exist, once", () => {
+        expect($("table#analytics-cookies").length).to.eq(1);
+      });
+      it(`should include the dynamic Google Analytics cookie name, ${dynamicGACookieName}`, () => {
+        expect(analyticsCookieNamesListedInCookieNotice).to.include(
+          dynamicGACookieName
+        );
+      });
+      it("should list all items in the ANALYTICS_COOKIES array", () => {
+        ANALYTICS_COOKIES.forEach((i) => {
+          expect(analyticsCookieNamesListedInCookieNotice).to.include(i);
+        });
+      });
+    });
+  });
+  describe("the ANALYTICS_COOKIES array", () => {
+    describe("when the dynamic Google Analytics cookie name is added", () => {
+      it("should include all measurement cookies listed the cookie policy page", () => {
+        expect(analyticsCookieNamesListedInCookieNotice).to.have.same.members([
+          ...ANALYTICS_COOKIES,
+          dynamicGACookieName,
+        ]);
+      });
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -119,7 +119,7 @@ export function getAnalyticsCookieDomain(): string {
   return process.env.ANALYTICS_COOKIE_DOMAIN;
 }
 
-export function getDomainForCookiesSetByGoogleAnalytics(): string {
+export function getGoogleAnalyticsAndDynatraceCookieDomain(): string {
   return getServiceDomain() === "localhost" ? "localhost" : ".account.gov.uk";
 }
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -792,7 +792,7 @@
       "analytics": {
         "header": "Cwcis sy’n mesur sut rydych yn defnyddio eich GOV.UK One Login",
         "info": {
-          "paragraph1": "Rydym yn defnyddio cwcis Google Analytics i gasglu gwybodaeth dienw am sut rydych yn defnyddio GOV.UK One Login, er enghraifft pa dudalennau rydych yn ymweld â hwy a beth rydych yn clicio arno.",
+          "paragraph1": "Rydym yn defnyddio cwcis Google Analytics a Dynatrace i gasglu gwybodaeth dienw am sut rydych yn defnyddio GOV.UK One Login, er enghraifft pa dudalennau rydych yn ymweld â hwy a beth rydych yn clicio arno.",
           "paragraph2": "Mae hyn yn ein helpu ni i ddeall sut allwn ni wella GOV.UK One Login."
         },
         "table": {
@@ -802,16 +802,48 @@
             "col3": "Dod i ben"
           },
           "rows": {
-            "row1": {
+            "_ga": {
               "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
               "col3": "2 flynedd"
             },
-            "row2": {
+            "_gid": {
               "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
               "col3": "24 awr"
             },
-            "row3": {
+            "_gat_UA": {
               "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
+              "col3": "Pan fyddwch yn cau eich porwr gwe"
+            },
+            "dtCookie": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "Pan fyddwch yn cau eich porwr gwe"
+            },
+            "dtLatC": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "Pan fyddwch yn cau eich porwr gwe"
+            },
+            "dtPC": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "Pan fyddwch yn cau eich porwr gwe"
+            },
+            "dtSa": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "Pan fyddwch yn cau eich porwr gwe"
+            },
+            "dtValidationCookie": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "Yn syth"
+            },
+            "dtDisabled": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "Pan fyddwch yn cau eich porwr gwe"
+            },
+            "rxVisitor": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
+              "col3": "2 flynedd"
+            },
+            "rxvt": {
+              "col2": "Ein helpu i ddeall unrhyw broblemau y gallech eu profi wrth ddefnyddio GOV.UK One Login",
               "col3": "Pan fyddwch yn cau eich porwr gwe"
             }
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -792,7 +792,7 @@
       "analytics": {
         "header": "Cookies that measure how you use GOV.UK One Login",
         "info": {
-          "paragraph1": "We use Google Analytics cookies to collect anonymised information about how you use your GOV.UK One Login, for example what pages you visit and what you click on.",
+          "paragraph1": "We use Google Analytics and Dynatrace cookies to collect anonymised information about how you use your GOV.UK One Login, for example what pages you visit and what you click on.",
           "paragraph2": "This helps us understand how we can improve GOV.UK One Login"
         },
         "table": {
@@ -802,16 +802,48 @@
             "col3": "Expires"
           },
           "rows": {
-            "row1": {
+            "_ga": {
               "col2": "Helps us count how many people visit GOV.UK One Login by checking if you’ve visited before",
               "col3": "2 years"
             },
-            "row2": {
+            "_gid": {
               "col2": "Helps us count how many people visit GOV.UK One Login by checking if you’ve visited before",
               "col3": "24 hours"
             },
-            "row3": {
+            "_gat_UA": {
               "col2": "Helps us count how many people visit GOV.UK One Login by checking if you’ve visited before",
+              "col3": "When you close your web browser"
+            },
+            "dtCookie": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "When you close your web browser"
+            },
+            "dtLatC": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "When you close your web browser"
+            },
+            "dtPC": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "When you close your web browser"
+            },
+            "dtSa": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "When you close your web browser"
+            },
+            "dtValidationCookie": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "Instantly"
+            },
+            "dtDisabled": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "When you close your web browser"
+            },
+            "rxVisitor": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
+              "col3": "2 years"
+            },
+            "rxvt": {
+              "col2": "Helps us understand any problems you may experience when using GOV.UK One Login",
               "col3": "When you close your web browser"
             }
           }


### PR DESCRIPTION
## What

This PR does three things:

1. Updates the GOV.UK One Login cookie policy to list cookies set by Dynatrace RUM
2. Adds these cookies to the array of cookie names to be cleared if a user opts out of cookies using the form shown on the cookie policy page
3. Introduces additional tests to reduce risk that measurement cookies are added to the privacy policy without being included in the list of cookies to be cleared when a user opts out using the form on the policy page.

### Screenshots

<details>

<summary>Cookie policy - English</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/ed0b143d-8364-44e8-a51c-4e376a3a2685)


</details>


<details>

<summary>Cookie policy - Welsh</summary>

![image](https://github.com/govuk-one-login/authentication-frontend/assets/16000203/b2a4d381-f607-4ecc-8530-eff2e8a7dd8f)

</details>

## How to review

Code Review commit by commit.

## Checklist

- [x] A UCD review has been performed
- [x] Performance analyst has been notified of the change.

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1704 Updates the privacy policy

