### PR TITLE
BAU: add metadata that codepipeline understands

### DIFF
--- a/.github/workflows/build-deploy-frontend-dev.yml
+++ b/.github/workflows/build-deploy-frontend-dev.yml
@@ -12,6 +12,102 @@ on:
   workflow_dispatch:
 
 jobs:
+  pr-data:
+    name: Get data for merged PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      data: ${{ steps.get_pr_data.outputs.result }}
+    steps:
+      - name: Get PR data
+        uses: actions/github-script@v7
+        id: get_pr_data
+        with:
+          script: |
+            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
+                repository(owner: $owner, name: $name) {
+                  object(oid: $oid) {
+                    ... on Commit {
+                      oid
+                      message
+                      associatedPullRequests(first: 1) {
+                        nodes {
+                          number
+                          title
+                          merged
+                          mergedAt
+                          mergeCommit {
+                            oid
+                          }
+                        }
+                      }
+                    }
+                  }
+                  owner {
+                    login
+                  }
+                  name
+                  nameWithOwner
+                }
+              }`
+            const variables = {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                oid: context.sha,
+                shortSha: context.sha.slice(0, 7),
+            }
+
+            const result = await github.graphql(query, variables).then((response) => {
+                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
+                const res = {
+                    pr_number: null,
+                    pr_title: null,
+                    pr_merged_at: null,
+                    pr_merge_commit_sha: null,
+
+                    commit_message: firstLineOfCommitMessage,
+
+                    repo_full_name: response.repository.nameWithOwner,
+                    repo_owner: response.repository.owner.login,
+                    repo_name: response.repository.name,
+
+                    repository: response.repository.nameWithOwner,
+                    commitsha: context.sha,
+                    commitmessage: firstLineOfCommitMessage,
+                }
+                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
+
+                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
+                    const prData = response.repository.object.associatedPullRequests.nodes[0];
+                    res.pr_number = prData.number.toString();
+                    res.pr_title = prData.title;
+                    res.pr_merged_at = prData.mergedAt;
+                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
+                    res.commitmessage = prData.title;
+
+                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
+                }
+
+                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
+                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
+                }
+
+                return res;
+            }).catch((error) => {
+                throw error;
+            });
+
+            for (const key in result) {
+                if (result[key] == null) {
+                    result[key] = "";
+                }
+            }
+
+            console.log(result);
+            return result;
+
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -19,51 +115,53 @@ jobs:
       id-token: write
       contents: read
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Assume AWS DEPLOYER role in tooling acct
-      uses: aws-actions/configure-aws-credentials@v1-node16
-      with:
-        role-to-assume: ${{ env.DEPLOYER_ROLE }}
-        aws-region: ${{ env.AWS_REGION }}
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
-    - name: Login to GDS Dev Dynatrace Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: khw46367.live.dynatrace.com
-        username: khw46367
-        password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
-    - name: Build, tag, and push frontend
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ${{ env.DEV_TOOLING_ECR_FRONTEND_REPO }}
-        IMAGE_TAG: ${{ github.sha }}
-      run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-    - name: Build, tag, and push basic-auth-sidecar
-      working-directory: basic-auth-sidecar
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ${{ env.DEV_BASIC_SIDECAR_ECR_REPO }}
-        IMAGE_TAG: ${{ github.sha }}
-      run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-    - name: Build, tag, and push service down page
-      working-directory: service-down-page-config
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ${{ env.DEV_SERVICE_DOWN_ECR_REPO }}
-        IMAGE_TAG: ${{ github.sha }}
-      run: |
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-        
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Assume AWS DEPLOYER role in tooling acct
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ env.DEPLOYER_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to GDS Dev Dynatrace Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: khw46367.live.dynatrace.com
+          username: khw46367
+          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      - name: Build, tag, and push frontend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ env.DEV_TOOLING_ECR_FRONTEND_REPO }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: Build, tag, and push basic-auth-sidecar
+        working-directory: basic-auth-sidecar
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ env.DEV_BASIC_SIDECAR_ECR_REPO }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      - name: Build, tag, and push service down page
+        working-directory: service-down-page-config
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ env.DEV_SERVICE_DOWN_ECR_REPO }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
   deploy:
-    needs: build
+    needs:
+      - build
+      - pr-data
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -87,6 +185,6 @@ jobs:
             --bucket ${{ env.DEV_ARTIFACT_BUCKET }} \
             --key frontend.zip \
             --body frontend.zip \
-            --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG"`
+            --metadata '${{ toJson(fromJson(needs.pr-data.outputs.data)) }}'`
           VERSION=`echo $S3_RESPONSE | jq .VersionId -r`
           echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -15,10 +15,107 @@ on:
       - completed
 
 jobs:
+  pr-data:
+    name: Get data for merged PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      data: ${{ steps.get_pr_data.outputs.result }}
+    steps:
+      - name: Get PR data
+        uses: actions/github-script@v7
+        id: get_pr_data
+        with:
+          script: |
+            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
+                repository(owner: $owner, name: $name) {
+                  object(oid: $oid) {
+                    ... on Commit {
+                      oid
+                      message
+                      associatedPullRequests(first: 1) {
+                        nodes {
+                          number
+                          title
+                          merged
+                          mergedAt
+                          mergeCommit {
+                            oid
+                          }
+                        }
+                      }
+                    }
+                  }
+                  owner {
+                    login
+                  }
+                  name
+                  nameWithOwner
+                }
+              }`
+            const variables = {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                oid: context.sha,
+                shortSha: context.sha.slice(0, 7),
+            }
+
+            const result = await github.graphql(query, variables).then((response) => {
+                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
+                const res = {
+                    pr_number: null,
+                    pr_title: null,
+                    pr_merged_at: null,
+                    pr_merge_commit_sha: null,
+
+                    commit_message: firstLineOfCommitMessage,
+
+                    repo_full_name: response.repository.nameWithOwner,
+                    repo_owner: response.repository.owner.login,
+                    repo_name: response.repository.name,
+
+                    repository: response.repository.nameWithOwner,
+                    commitsha: context.sha,
+                    commitmessage: firstLineOfCommitMessage,
+                }
+                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
+
+                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
+                    const prData = response.repository.object.associatedPullRequests.nodes[0];
+                    res.pr_number = prData.number.toString();
+                    res.pr_title = prData.title;
+                    res.pr_merged_at = prData.mergedAt;
+                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
+                    res.commitmessage = prData.title;
+
+                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
+                }
+
+                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
+                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
+                }
+
+                return res;
+            }).catch((error) => {
+                throw error;
+            });
+
+            for (const key in result) {
+                if (result[key] == null) {
+                    result[key] = "";
+                }
+            }
+
+            console.log(result);
+            return result;
+
   deploy:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: pr-data
     permissions:
       id-token: write
       contents: read
@@ -40,6 +137,6 @@ jobs:
             --bucket ${{ secrets.ARTIFACT_BUCKET }} \
             --key frontend.zip \
             --body frontend.zip \
-            --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG"`
+            --metadata '${{ toJson(fromJson(needs.pr-data.outputs.data)) }}'`
           VERSION=`echo $S3_RESPONSE | jq .VersionId -r`
           echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ keys/
 ci/terraform/.terraform
 src/assets/javascript/all.js
 ci/terraform/*.plan
+.infracost


### PR DESCRIPTION
## What

As-per https://ordinaryexperts.com/blog/2019/04/27/better-codepipeline-metadata

This extra metadata is shown in the codepipeline UI and will allow better identification of where the artifact has come from.

<img width="665" alt="image" src="https://github.com/govuk-one-login/authentication-frontend/assets/3595020/bcfc8499-db13-488d-9125-554c0031e757">

## How to review

- Code review
- Deploy to dev from this branch (`./scripts/trigger-gha-current-branch.sh`) and confirm that the resulting pipeline run has the sensible metadata

Unfortunately the pr merge one is untestable without merging a pr. I guess 'trust me'?

## Related PRs

- govuk-one-login/authentication-api#4851
