### PR TITLE
BAU: Improve deploy-frontend + upgrade action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,16 @@
 version: 2
 updates:
-  - package-ecosystem: 'npm'
-    directory: '/'
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: daily
       time: "03:00"
     target-branch: main
     labels:
-    - dependabot
+      - dependabot
     ignore:
       - dependency-name: "node"
-        versions: ["17.x","19.x","20.x"]
+        versions: ["17.x", "19.x", "20.x"]
     open-pull-requests-limit: 100
     commit-message:
       prefix: BAU
@@ -21,7 +21,15 @@ updates:
       time: "03:00"
     target-branch: main
     labels:
-    - dependabot
+      - dependabot
     open-pull-requests-limit: 100
+    commit-message:
+      prefix: BAU
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    target-branch: main
     commit-message:
       prefix: BAU

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -6,9 +6,6 @@ env:
 # Deploy role & Artificate buckets are Logical id  GitHubActionsRole & GitHubArtifactSourceBucket Value from Build Pipeline
 
 on:
-  push:
-    branches:
-      - main
   workflow_run:
     workflows: ["Build frontend"]
     types:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -118,10 +118,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: ${{ secrets.DEPLOY_ROLE }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## What

Bit of a kitchen sink PR.

deploy-frontend had a `push` trigger. This made no sense because nothing happened on push, only when it was triggered by the completion of the build workflow.

I've removed this trigger

Also, we hadn't updated the actions for a while - node16 is deprecated, so i've bumped actions relating to it.

Also, dependabot will now inform us of action upgrades.

## How to review

Code review