### PR TITLE
BAU: strip non-ascii characters from metadata

### DIFF
--- a/.github/workflows/build-deploy-frontend-dev.yml
+++ b/.github/workflows/build-deploy-frontend-dev.yml
@@ -103,6 +103,8 @@ jobs:
                 if (result[key] == null) {
                     result[key] = "";
                 }
+                # strip non-ascii characters from all values
+                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
             }
 
             console.log(result);

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -106,6 +106,8 @@ jobs:
                 if (result[key] == null) {
                     result[key] = "";
                 }
+                # strip non-ascii characters from all values
+                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
             }
 
             console.log(result);


### PR DESCRIPTION
## What

AWS can't handle non-ascii characters in S3 metadata, so strip them out

## How to review

- Code review
