### PR TITLE
Aut-2325: Add "What service were you trying to use?" question into signin phone number issue contact form

### DIFF
--- a/src/components/contact-us/questions/_sign_in_phone_number_issue.njk
+++ b/src/components/contact-us/questions/_sign_in_phone_number_issue.njk
@@ -78,6 +78,8 @@
     } if (errors['countryPhoneNumberFrom'])
 }) }}
 
+{% include 'contact-us/questions/_service-trying-to-use.njk' %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.signInPhoneNumberIssue.personalInformation.paragraph' | translate,
     iconFallbackText: "Warning"


### PR DESCRIPTION
## What
- Add the field "What service were you trying to use?" to the ‘Another problem with a phone number screen’ to allow users to tell us what service they were trying to use when they are loading the contact form signin phone number issue


<!-- Describe what you have changed and why -->

## How to review
- Go to /contact-us-questions?theme=account_creation&subtheme=sign_in_phone_number_issue&referer=
- Check if new field is here
-  Valid the form and be sure you're landing on the good page

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
<img width="812" alt="Screenshot 2024-07-04 140801" src="https://github.com/govuk-one-login/authentication-frontend/assets/148222801/a8d8ebae-23ba-4f66-b337-d85c367d1003">
<img width="407" alt="Screenshot 2024-07-04 140910" src="https://github.com/govuk-one-login/authentication-frontend/assets/148222801/264c92e7-2348-474a-a974-2690ed707b18">
