### PR TITLE
AUT-3057: move privacy links into create your account journey step 1 and update Privacy notice paragraph

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -671,6 +671,10 @@
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_six.item_seven' | translate }}</li>
     </ul>
 
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.who_we_share_with.paragraph_experian' | translate }}
+    </p>
+
     <h3 class="govuk-heading-s">
         {{ 'pages.privacy.sections.who_we_share_with.sub_header_four' | translate }}
     </h3>

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -52,14 +52,6 @@
   text: 'pages.createPassword.securePasswordDetails.text' | translate
 }) }}
 
-<h2 class="govuk-heading-s">{{'pages.createPassword.termsOfUse.heading' | translate}}</h2>
-
-<p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph1' | translate}}</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li><a href="{{'pages.createPassword.termsOfUse.bullet1LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet1LinkText'| translate}}</a>{{'pages.createPassword.termsOfUse.bullet1Text'| translate}}</li>
-    <li><a href="{{'pages.createPassword.termsOfUse.bullet2LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet2LinkText'| translate}}</a></li>
-  </ul>
-
 {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -32,6 +32,14 @@
     } if (errors['email'])})
 }}
 
+<h2 class="govuk-heading-s">{{'pages.createPassword.termsOfUse.heading' | translate}}</h2>
+
+<p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph1' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li><a href="{{'pages.createPassword.termsOfUse.bullet1LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet1LinkText'| translate}}</a>{{'pages.createPassword.termsOfUse.bullet1Text'| translate}}</li>
+  <li><a href="{{'pages.createPassword.termsOfUse.bullet2LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet2LinkText'| translate}}</a></li>
+</ul>
+
 {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1467,24 +1467,25 @@
           },
           "paragraph_ten": "Ym mhob achos rydym ond yn darparu’r isafswm o wybodaeth sydd ei angen i gyflawni’r gwiriadau.",
           "sub_header_three": "Rhannu eich gwybodaeth er mwyn diogelu rhag twyll",
-          "paragraph_eleven": "Er mwyn diogelu rhag trosedd a thwyll, weithiau efallai y bydd angen i ni rannu gwybodaeth gyda:",
+          "paragraph_eleven": "Er mwyn amddiffyn rhag trosedd a thwyll, weithiau mae angen i ni rannu gwybodaeth gyda:",
           "list_five": {
             "item_one": "adrannau’r llywodraeth sy’n rhedeg y gwasanaethau rydych yn cael mynediad iddynt drwy eich GOV.UK One Login",
             "item_two": "sefydliadau eraill yn y sector cyhoeddus, fel y Swyddfa Gartref",
             "item_three": "asiantaethau gorfodi’r gyfraith",
-            "item_four": "asiantaethau gwirio credyd",
+            "item_four": "Experian (asiantaeth gwirio credyd)",
             "item_five": "proseswyr data sy’n darparu gwasanaethau monitro perthnasol"
           },
-          "paragraph_twelve": "Mae’r wybodaeth y gallem ei rannu yn cynnwys:",
+          "paragraph_twelve": "Mae’r wybodaeth a rannwn yn cynnwys:",
           "list_six": {
-            "item_one": "rhifau ffôn",
-            "item_two": "cyfeiriadau e-bost",
-            "item_three": "cyfeiriadau IP a lleoliadau daearegol",
-            "item_four": "dynodwyr cyfrif unigryw",
-            "item_five": "gwybodaeth am y dyfeisiau sy’n cael eu defnyddio",
-            "item_six": "manylion dogfen hunaniaeth, gan gynnwys enw a dyddiad geni",
-            "item_seven": "hanes cyfeiriad"
+            "item_one": "cyfeiriadau IP a lleoliadau daearegol",
+            "item_two": "dynodwyr cyfrif unigryw",
+            "item_three": "gwybodaeth am y dyfeisiau sy’n cael eu defnyddio",
+            "item_four": "manylion dogfen hunaniaeth, gan gynnwys enw a dyddiad geni",
+            "item_five": "hanes cyfeiriad",
+            "item_six": "rhifau ffôn",
+            "item_seven": "cyfeiriadau e-bost"
           },
+          "paragraph_experian":"Rydym yn defnyddio Experian i wirio eich cyfeiriad e-bost a rhif ffôn pan fyddwch yn creu eich GOV.UK One Login ac os byddwch yn newid eich cyfeiriad e-bost neu rif ffôn.",
           "sub_header_four": "Rhannu eich gwybodaeth gyda’n cyflenwyr",
           "paragraph_thirteen": "Rydym yn gweithio gyda chyflenwyr technoleg, er enghraifft rydym yn defnyddio darparwr cynnal allanol a darparwr canolfan gyswllt. Rydym ond yn rhoi mynediad i`n cyflenwyr i`ch gwybodaeth os ydynt ei hangen i ddarparu eu gwasanaeth. Mae ein cyflenwyr yn gweithredu fel proseswyr data ac maent yn ddarostyngedig i gontractau gyda ni sy`n eu cyfyngu i brosesu eich data personol ond at ddiben darparu eu gwasanaethau yn unol â`n cyfarwyddiadau."
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1467,24 +1467,25 @@
           },
           "paragraph_ten": "In all cases we only provide the minimum information needed to perform the checks.",
           "sub_header_three": "Sharing your information to protect against fraud",
-          "paragraph_eleven": "To protect against crime and fraud, we might sometimes need to share information with:",
+          "paragraph_eleven": "To protect against crime and fraud, we sometimes need to share information with:",
           "list_five": {
             "item_one": "government departments that run the services you access though your GOV.UK One Login",
             "item_two": "other public sector organisations, such as the Home Office",
             "item_three": "law enforcement agencies",
-            "item_four": "credit reference agencies",
+            "item_four": "Experian (a credit reference agency)",
             "item_five": "data processors who provide relevant monitoring services"
           },
-          "paragraph_twelve": "The information we might share includes:",
+          "paragraph_twelve": "The information we share includes:",
           "list_six": {
-            "item_one": "phone numbers",
-            "item_two": "email addresses",
-            "item_three": "IP addresses and geolocations",
-            "item_four": "unique account identifiers",
-            "item_five": "information about the devices being used",
-            "item_six": "identity document details, including name and date of birth",
-            "item_seven": "address history"
+            "item_one": "IP addresses and geolocations",
+            "item_two": "unique account identifiers",
+            "item_three": "information about the devices being used",
+            "item_four": "identity document details, including name and date of birth",
+            "item_five": "address history",
+            "item_six": "phone numbers",
+            "item_seven": "email addresses"
           },
+          "paragraph_experian":"We use Experian to check your email address and phone number when you create a GOV.UK One Login and if you change your email address or phone number.",
           "sub_header_four": "Sharing your information with our suppliers",
           "paragraph_thirteen": "We work with technology suppliers, for example we use an external hosting provider and a contact centre provider. We only give our suppliers access to your information if they need it to provide their service. Our suppliers act as data processors and are subject to contracts with us which restrict them to only processing your personal data for the sole purpose of providing their services in accordance with our instructions."
         },


### PR DESCRIPTION
## What
- Updating the privacy notice (see AUT-3022)
- Moving the “Agree to the [GOV.UK](http://gov.uk/) One Login terms of use” message from the Create Password screen to the Enter your email address screen (see AUT-3023)
- 
<!-- Describe what you have changed and why -->

## How to review
- Start the create account journey and check if you have the  “Agree to the [GOV.UK](http://gov.uk/) One Login terms of use” message when you have to enter your email address.
- Continue the create journey until you have to enter a new password. Check if you don't have the  “Agree to the [GOV.UK](http://gov.uk/) One Login terms of use” message.

- Go to /privacy-notice and check if the paragraph is correctly updated (see AUT-3022)
<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

## Related PRs

**### AUT-3022 screenshots:**

![updated-pn-paragraph-en](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/8a6d81cb-970a-4ab7-a2b8-e94b0c494907)
![updated-pn-paragraph-cy](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/450cf4b7-b379-4ddf-8512-8045ad43c9b6)

**### AUT-3023 screenshots:**
![en-move-paragraph](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/812d196b-6d65-4913-8c1e-a284b932caae)
![cy-move-paragraph](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/ceda86f9-0b60-4b68-86bd-e1147d82c4cb)
![cy-move-paragraph-2](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/2b9da03d-e375-4ba6-b130-b6bb1cc43647)
![en-move-paragraph-2](https://github.com/govuk-one-login/authentication-frontend/assets/148222801/05f60cfd-49f0-4699-8c0a-c2038095ea9c)

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
