### PR TITLE
BAU: Use eslint and prettier from node_modules

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,21 +12,26 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     name: Run pre-commit
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: 🏗️ Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
-
       - name: 🏗️ Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+
+      - name: 🏗️ Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.20.3"
+          cache: "yarn"
+          cache-dependency-path: "yarn.lock"
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,18 +35,11 @@ repos:
         types_or:
           - javascript
           - ts
-        entry: eslint --fix
-        additional_dependencies:
-          - eslint@^8.57.0
-          - eslint-config-prettier@^9.1.0
-          - eslint-plugin-no-only-tests@^3.1.0
-          - eslint-plugin-prettier@^4.0.0
+        entry: yarn run eslint --fix
         pass_filenames: true
       - id: prettier
         name: Run prettier
         language: node
         types: [text]
-        entry: prettier --write --ignore-unknown
-        additional_dependencies:
-          - prettier@^3.3.2
+        entry: yarn run prettier --write --ignore-unknown
         pass_filenames: true


### PR DESCRIPTION
## What

Rather than managing dependencies twice, just use the local node_modules for pre-commit depdencies. This will require a `yarn install` before running it for the first time - This has been added to the `pre-commit.yml` workflow

Additionally, don't run pre-commit for dependabot PRs.

## How to review

- Code review
