### PR TITLE
AUT-2789: Log user out when they enter their password incorrectly max…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -169,7 +169,7 @@ async function createApp(): Promise<express.Application> {
   app.use(setLocalVarsMiddleware);
   app.use(setGTM);
 
-  i18next
+  await i18next
     .use(Backend)
     .use(i18nextMiddleware.LanguageDetector)
     .init(

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
@@ -94,9 +94,9 @@ describe("Integration:: check your email security codes", () => {
     app = await require("../../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL || "";
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -67,9 +67,9 @@ describe("Integration:: enter mfa", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL || "";
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.ENTER_MFA)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -49,9 +49,9 @@ describe("Integration::reset password check email ", () => {
 
     nock(baseApi).post("/reset-password-request").once().reply(204);
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -46,9 +46,9 @@ describe("Integration::reset password check email ", () => {
 
     nock(baseApi).post("/reset-password-request").once().reply(204);
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -44,9 +44,9 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
     process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app)
+    await request(app)
       .get(ENDPOINT)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -44,9 +44,9 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL;
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app)
+    await request(app)
       .get(ENDPOINT)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -44,6 +44,13 @@ export class InvalidBase64Error extends Error {
   }
 }
 
+export class ReauthJourneyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReauthJourneyError";
+  }
+}
+
 export class QueryParamsError extends Error {
   constructor(message: string) {
     super(message);


### PR DESCRIPTION
… allowed times.

Modifying the integration tests so they wait for the initial call to the app executed in the before method to complete.  This call is needed so the tests can use the csrf token and the correct cookies so it must complete before any of the tests are executed.

## What

<!-- Describe what you have changed and why -->
Some of the integration tests have been updated so they work correctly by enforcing a wait on the initial call to the service to obtain the tokens required in the subsequent tests.

The changes to support the reauth journey are dependent on matching changes in the backend that signal the user should be logged out rather than locked out if they fail to enter their password correctly more than 5 times.

When the back end signal the user has failed to provide their password correctly after 5 attempts the frontend checks if the journey is a reauth journey and then logs the user out by making a call to orchestration with the new path parameter  `error` set to `login_required`. 

## How to review
1. Review backend changes for context.
2. Code review
3. Deploy to environment (or run locally) and walk through the reauth flow while entering an invalid password.

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
