### PR TITLE
Bump ws from 8.14.2 to 8.17.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6653,9 +6653,9 @@ write-file-atomic@^3.0.0:
     typedarray-to-buffer "^3.1.5"
 
 ws@^8.13.0:
-  version "8.14.2"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz"
-  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## What

A clone of [a change Dependabot made but is failing to rebase](https://github.com/govuk-one-login/authentication-frontend/pull/1693). This deals with a ["ws affected by a DoS when handling a request with many HTTP headers"](https://github.com/govuk-one-login/authentication-frontend/security/dependabot/35) security vulnerability.

Bumps [ws](https://github.com/websockets/ws) from 8.14.2 to 8.17.1.
- [Release notes](https://github.com/websockets/ws/releases)
- [Commits](websockets/ws@8.14.2...8.17.1)

---
updated-dependencies:
- dependency-name: ws dependency-type: indirect ...

## How to review

1. See changes match the Dependabot change https://github.com/govuk-one-login/authentication-frontend/pull/1693


## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1693