### PR TITLE
AUT-1723: use CloudFront-Viewer-Address header

### DIFF
--- a/basic-auth-sidecar/default.conf
+++ b/basic-auth-sidecar/default.conf
@@ -8,8 +8,7 @@ server {
       satisfy any;
 
       include /etc/nginx/trusted-proxies.conf;
-      real_ip_header X-Forwarded-For;
-      real_ip_recursive on;
+      real_ip_header CloudFront-Viewer-Address;
 
       include /etc/nginx/allow-list.conf;
       deny all;

--- a/ci/terraform/core.tf
+++ b/ci/terraform/core.tf
@@ -8,12 +8,6 @@ data "terraform_remote_state" "core" {
   }
 }
 
-
-data "aws_ip_ranges" "cloudfront_ips" {
-  regions  = ["global"]
-  services = ["cloudfront"]
-}
-
 locals {
   vpc_arn                                    = data.terraform_remote_state.core.outputs.vpc_arn
   vpc_id                                     = data.terraform_remote_state.core.outputs.vpc_id

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -5,11 +5,6 @@ locals {
   nginx_port       = 8080
   application_port = var.basic_auth_password == "" ? var.app_port : local.nginx_port
 
-  sidecar_trusted_proxies = concat(
-    local.private_subnet_cidr_blocks,
-    data.aws_ip_ranges.cloudfront_ips.cidr_blocks,
-  )
-
   frontend_container_definition = {
     name      = local.container_name
     image     = "${var.image_uri}:${var.image_tag}@${var.image_digest}"
@@ -260,7 +255,7 @@ locals {
       },
       {
         name  = "TRUSTED_PROXIES"
-        value = jsonencode(local.sidecar_trusted_proxies)
+        value = jsonencode(local.private_subnet_cidr_blocks)
       },
     ]
   }

--- a/test/basic-auth-sidecar/basic-auth-sidecar.test.ts
+++ b/test/basic-auth-sidecar/basic-auth-sidecar.test.ts
@@ -2,8 +2,6 @@ import chai from "chai";
 import chaiHttp from "chai-http";
 import { describe } from "mocha";
 
-const tar = require("tar-stream");
-
 const expect = chai.expect;
 
 chai.use(chaiHttp);
@@ -18,6 +16,13 @@ import {
 import { Environment } from "testcontainers/build/types";
 import path from "path";
 import debug from "debug";
+
+interface RequestData {
+  path: string;
+  auth?: { username: string; password: string };
+  forwardedAddress?: string;
+  method?: string;
+}
 
 describe("BasicAuthSidecar", function () {
   if (process.env.RUNNER_DEBUG === "1") {
@@ -89,17 +94,18 @@ describe("BasicAuthSidecar", function () {
   async function doRequestInDockerNetwork(
     container: StartedTestContainer,
     port: number | string,
-    path: string,
-    auth?: { username: string; password: string },
-    method: string = "GET"
+    requestData: RequestData
   ) {
     let command = "http -p hb";
-    if (auth) {
-      command += ` -a ${auth.username}:${auth.password}`;
+    if (requestData.auth) {
+      command += ` -a ${requestData.auth.username}:${requestData.auth.password}`;
     }
-    command += ` ${method} http://${container.getIpAddress(
+    command += ` ${requestData.method} http://${container.getIpAddress(
       network.getName()
-    )}:${port}${path}`;
+    )}:${port}${requestData.path}`;
+    if (requestData.forwardedAddress) {
+      command += ` "CloudFront-Viewer-Address:${requestData.forwardedAddress}"`;
+    }
 
     const { output } = await requesterContainer.exec([
       "/bin/ash",
@@ -136,18 +142,11 @@ describe("BasicAuthSidecar", function () {
     };
   }
 
-  async function doSidecarRequest(
-    path: string,
-    auth?: { username: string; password: string },
-    method: string = "GET"
-  ) {
-    return doRequestInDockerNetwork(
-      sidecarContainer,
-      "8080",
-      path,
-      auth,
-      method
-    );
+  async function doSidecarRequest(requestData: RequestData) {
+    if (!requestData.method) {
+      requestData.method = "GET";
+    }
+    return doRequestInDockerNetwork(sidecarContainer, "8080", requestData);
   }
 
   async function startSidecarContainer(env: Environment) {
@@ -180,34 +179,6 @@ describe("BasicAuthSidecar", function () {
       .start();
   }
 
-  async function getTextFileFromContainer(
-    container: StartedTestContainer,
-    path: string
-  ): Promise<string> {
-    const tarStream = tar.extract();
-    const tarArchiveStream = await container.copyArchiveFromContainer(path);
-    tarArchiveStream.pipe(tarStream);
-    let fileContent = "";
-    tarStream.on("entry", (header: any, stream: any, next: any) => {
-      stream.on("data", (chunk: any) => {
-        fileContent += chunk.toString();
-      });
-      stream.on("end", () => {
-        next();
-      });
-      stream.resume();
-    });
-    tarStream.on("finish", () => {
-      tarStream.end();
-    });
-
-    return new Promise((resolve) => {
-      tarStream.on("finish", () => {
-        resolve(fileContent);
-      });
-    });
-  }
-
   afterEach(async () => {
     if (sidecarContainer) {
       await sidecarContainer.stop();
@@ -221,7 +192,7 @@ describe("BasicAuthSidecar", function () {
           BASIC_AUTH_USERNAME: "test",
           BASIC_AUTH_PASSWORD: "test",
         });
-        await doSidecarRequest("/get").then(({ headers }) => {
+        await doSidecarRequest({ path: "/get" }).then(({ headers }) => {
           expect(headers).to.not.be.empty;
           expect(headers.has("server")).to.be.false;
         });
@@ -235,18 +206,21 @@ describe("BasicAuthSidecar", function () {
           IP_ALLOW_LIST: JSON.stringify(["203.0.113.0/24"]),
         });
 
-        await doSidecarRequest("/get").then(({ statusCode }) => {
+        await doSidecarRequest({ path: "/get" }).then(({ statusCode }) => {
           expect(statusCode).to.equal(401);
         });
 
-        await doSidecarRequest("/get", {
-          username: "test",
-          password: "test",
+        await doSidecarRequest({
+          path: "/get",
+          auth: {
+            username: "test",
+            password: "test",
+          },
         }).then(({ statusCode }) => {
           expect(statusCode).to.equal(200);
         });
 
-        await doSidecarRequest("/healthcheck").then(
+        await doSidecarRequest({ path: "/healthcheck" }).then(
           ({ statusCode, headers, body }) => {
             expect(statusCode).to.equal(200);
             expect(headers.get("content-type")).to.equal("text/plain");
@@ -261,7 +235,7 @@ describe("BasicAuthSidecar", function () {
           BASIC_AUTH_PASSWORD: "test",
           IP_ALLOW_LIST: JSON.stringify([requesterContainerIp + "/32"]),
         });
-        await doSidecarRequest("/get").then(({ statusCode }) => {
+        await doSidecarRequest({ path: "/get" }).then(({ statusCode }) => {
           expect(statusCode).to.equal(200);
         });
 
@@ -276,17 +250,15 @@ describe("BasicAuthSidecar", function () {
           ]),
         });
 
-        await doSidecarRequest("/get").then(({ statusCode }) => {
+        await doSidecarRequest({ path: "/get" }).then(({ statusCode }) => {
           expect(statusCode).to.equal(200);
         });
       });
-    });
-
-    context("and request is coming from a upstream proxy", () => {
-      context("and there is just one proxy in the chain", () => {
+      context("when cloudfront is involved", () => {
         let caddyContainer: StartedTestContainer;
 
         before(async function () {
+          this.timeout(120000);
           caddyContainer = await new GenericContainer("caddy:2.7.6-alpine")
             .withNetwork(network)
             .withExposedPorts(8080)
@@ -300,144 +272,60 @@ describe("BasicAuthSidecar", function () {
             ])
             .start();
         });
-        it("shouldn't trust X-Forwarded-For if the proxy is untrusted", async () => {
+
+        it("should be required if cloudfront sends a non-allowed address", async () => {
           await startSidecarContainer({
             BASIC_AUTH_USERNAME: "test",
             BASIC_AUTH_PASSWORD: "test",
-            NGINX_PORT: "8080",
             IP_ALLOW_LIST: JSON.stringify([requesterContainerIp + "/32"]),
-            TRUSTED_PROXIES: JSON.stringify(["203.0.113.0/24"]),
+            TRUSTED_PROXIES: JSON.stringify([
+              caddyContainer.getIpAddress(network.getName()) + "/32",
+            ]),
           });
 
-          await doRequestInDockerNetwork(caddyContainer, "8080", "/get").then(
-            ({ statusCode }) => {
-              expect(statusCode).to.equal(401);
-            }
-          );
+          await doRequestInDockerNetwork(caddyContainer, 8080, {
+            path: "/get",
+            method: "GET",
+            forwardedAddress: "203.0.113.0:8145",
+          }).then(({ statusCode }) => {
+            expect(statusCode).to.equal(401);
+          });
         });
 
-        it("should trust X-Forwarded-For if the proxy is trusted", async () => {
-          const trustedProxiesList = [
-            caddyContainer.getIpAddress(network.getName()) + "/32",
-          ];
+        it("should not be required if cloudfront sends an allowed address", async () => {
           await startSidecarContainer({
             BASIC_AUTH_USERNAME: "test",
             BASIC_AUTH_PASSWORD: "test",
-            NGINX_PORT: "8080",
             IP_ALLOW_LIST: JSON.stringify([requesterContainerIp + "/32"]),
-            TRUSTED_PROXIES: JSON.stringify(trustedProxiesList),
+            TRUSTED_PROXIES: JSON.stringify([
+              caddyContainer.getIpAddress(network.getName()) + "/32",
+            ]),
           });
 
-          const trustedProxiesConf = await getTextFileFromContainer(
-            sidecarContainer,
-            "/etc/nginx/trusted-proxies.conf"
-          );
-
-          for (const proxy of trustedProxiesList) {
-            expect(trustedProxiesConf).to.contain(`set_real_ip_from ${proxy};`);
-          }
-
-          await doRequestInDockerNetwork(caddyContainer, "8080", "/get").then(
-            ({ statusCode }) => {
-              expect(statusCode).to.equal(200);
-            }
-          );
-        });
-      });
-      context("and there are multiple proxies in the chain", () => {
-        let outerCaddyContainer: StartedTestContainer;
-        let innerCaddyContainer: StartedTestContainer;
-
-        before(async () => {
-          outerCaddyContainer = await new GenericContainer("caddy:2.7.6-alpine")
-            .withNetwork(network)
-            .withExposedPorts(8080)
-            .withCommand([
-              "caddy",
-              "reverse-proxy",
-              "--from",
-              ":8080",
-              "--to",
-              "inner-caddy:8080",
-            ])
-            .start();
-
-          const innerCaddyfileContent = `:8080
-          reverse_proxy {
-            to "sidecar:8080"
-            trusted_proxies ${outerCaddyContainer.getIpAddress(network.getName()) + "/32"}
-          }
-          `;
-          innerCaddyContainer = await new GenericContainer("caddy:2.7.6-alpine")
-            .withNetwork(network)
-            .withNetworkAliases("inner-caddy")
-            .withExposedPorts(8080)
-            .withCopyContentToContainer([
-              {
-                content: innerCaddyfileContent,
-                target: "/etc/caddy/Caddyfile",
-              },
-            ])
-            .withCommand(["caddy", "run", "--config", "/etc/caddy/Caddyfile"])
-            .start();
-        });
-
-        it("should trust X-Forwarded-For if all proxies are trusted", async () => {
-          const trustedProxiesList = [
-            outerCaddyContainer.getIpAddress(network.getName()) + "/32",
-            innerCaddyContainer.getIpAddress(network.getName()) + "/32",
-          ];
-          await startSidecarContainer({
-            BASIC_AUTH_USERNAME: "test",
-            BASIC_AUTH_PASSWORD: "test",
-            NGINX_PORT: "8080",
-            IP_ALLOW_LIST: JSON.stringify([requesterContainerIp + "/32"]),
-            TRUSTED_PROXIES: JSON.stringify(trustedProxiesList),
-          });
-
-          const trustedProxiesConf = await getTextFileFromContainer(
-            sidecarContainer,
-            "/etc/nginx/trusted-proxies.conf"
-          );
-
-          for (const proxy of trustedProxiesList) {
-            expect(trustedProxiesConf).to.contain(`set_real_ip_from ${proxy};`);
-          }
-
-          await doRequestInDockerNetwork(
-            outerCaddyContainer,
-            "8080",
-            "/get"
-          ).then(({ statusCode }) => {
+          await doRequestInDockerNetwork(caddyContainer, 8080, {
+            path: "/get",
+            method: "GET",
+            forwardedAddress: `${requesterContainerIp}:8145`,
+          }).then(({ statusCode }) => {
             expect(statusCode).to.equal(200);
           });
         });
 
-        it("shouldn't trust X-Forwarded-For if any proxy is untrusted", async () => {
-          const trustedProxiesList = [
-            outerCaddyContainer.getIpAddress(network.getName()) + "/32",
-            innerCaddyContainer.getIpAddress(network.getName()) + "/32",
-          ];
+        it("should be required if cloudfront sends an allowed IP via a non-trusted proxy", async () => {
+          await startSidecarContainer({
+            BASIC_AUTH_USERNAME: "test",
+            BASIC_AUTH_PASSWORD: "test",
+            IP_ALLOW_LIST: JSON.stringify([requesterContainerIp + "/32"]),
+            TRUSTED_PROXIES: JSON.stringify(["203.0.113.0/32"]), // not the caddy container
+          });
 
-          for (const proxy of trustedProxiesList) {
-            await startSidecarContainer({
-              BASIC_AUTH_USERNAME: "test",
-              BASIC_AUTH_PASSWORD: "test",
-              NGINX_PORT: "8080",
-              IP_ALLOW_LIST: JSON.stringify([requesterContainerIp + "/32"]),
-              TRUSTED_PROXIES: JSON.stringify([proxy]),
-            });
-
-            await doRequestInDockerNetwork(
-              outerCaddyContainer,
-              "8080",
-              "/get"
-            ).then(({ statusCode }) => {
-              expect(statusCode).to.equal(401);
-            });
-
-            await sidecarContainer.stop();
-          }
+          await doRequestInDockerNetwork(caddyContainer, 8080, {
+            path: "/get",
+            method: "GET",
+            forwardedAddress: `${requesterContainerIp}:8145`,
+          }).then(({ statusCode }) => {
+            expect(statusCode).to.equal(401);
+          });
         });
       });
     });


### PR DESCRIPTION
## What

Rather than trying to parse the X-Forwarded-For header, instead use the CloudFront-Viewer-Address header. This header is set by CloudFront and contains the IP address and source port of the viewer request, e.g. `203.0.113.1:12345`.

We will only trust this header if the request is coming from the ALB.

In theory, this would be injectable / bypassable if someone manages to make a request directly through the ALB, but as Cloudfront is applied to integration and the ALB's WAF requires cloudfront be the caller, so that's an unlikely occurrence. Plus, we're using Basic Auth with no real rate limit / brute force protection, so this whole sidecar is more of a polite 'please go away' anyway.

## How to review

If my tests are correct, then this should be a case of "if the tests pass, we're good". Therefore, reviewing the tests is super important.

As this is only applied in integration, there's no good way to test in a lower environment. If it actually does not work when deployed, there will be no regression, as it'll default to basic-auth-for-everyone (the current situation).