### PR TITLE
Aut-3046: add reauth max codes sent scenario into resent email code c…

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -214,10 +214,11 @@ async function createApp(): Promise<express.Application> {
   registerRoutes(app);
 
   app.use(getCookieLanguageMiddleware);
+  app.use(pageNotFoundHandler);
 
+  // Error Handlers
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);
-  app.use(pageNotFoundHandler);
 
   return app;
 }

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -58,29 +58,29 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
     app = undefined;
   });
 
-  it("should return resend mfa code page", (done) => {
-    request(app)
+  it("should return resend mfa code page", async () => {
+    await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /check-your-phone when new code requested", (done) => {
+  it("should redirect to /check-your-phone when new code requested", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
       .type("form")
       .set("Cookie", cookies)
@@ -89,21 +89,21 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
         isResendCodeRequest: true,
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return 500 error screen when API call fails", (done) => {
+  it("should return 500 error screen when API call fails", async () => {
     nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(500, {
       errorCode: "1234",
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
       .type("form")
       .set("Cookie", cookies)
       .send({
         _csrf: token,
       })
-      .expect(500, done);
+      .expect(500);
   });
 });

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
@@ -112,24 +112,24 @@ describe("Integration:: check your email security codes", () => {
     app = undefined;
   });
 
-  it("should return verify email page", (done) => {
-    request(app)
+  it("should return verify email page", async () => {
+    await request(app)
       .get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when code not entered", (done) => {
-    request(app)
+  it("should return validation error when code not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -141,11 +141,11 @@ describe("Integration:: check your email security codes", () => {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains("Enter the code");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code is less than 6 characters", (done) => {
-    request(app)
+  it("should return validation error when code is less than 6 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -159,11 +159,11 @@ describe("Integration:: check your email security codes", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code is greater than 6 characters", (done) => {
-    request(app)
+  it("should return validation error when code is greater than 6 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -177,12 +177,12 @@ describe("Integration:: check your email security codes", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code entered contains letters", (done) => {
+  it("should return validation error when code entered contains letters", async () => {
     process.env.SUPPORT_ACCOUNT_RECOVERY = "1";
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -196,17 +196,17 @@ describe("Integration:: check your email security codes", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /get-security-codes when valid code entered", (done) => {
+  it("should redirect to /get-security-codes when valid code entered", async () => {
     process.env.SUPPORT_ACCOUNT_RECOVERY = "1";
     nock(baseApi)
       .post(API_ENDPOINTS.VERIFY_CODE)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -215,16 +215,16 @@ describe("Integration:: check your email security codes", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.GET_SECURITY_CODES)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return validation error when incorrect code entered", (done) => {
+  it("should return validation error when incorrect code entered", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).once().reply(400, {
       code: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -238,16 +238,16 @@ describe("Integration:: check your email security codes", () => {
           "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return error page when when incorrect code entered more than 5 times", (done) => {
+  it("should return error page when when incorrect code entered more than 5 times", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).times(6).reply(400, {
       code: ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -259,6 +259,6 @@ describe("Integration:: check your email security codes", () => {
         "Location",
         `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.EmailMaxRetries}`
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -91,8 +91,8 @@ describe("Integration:: authorize", () => {
     app = undefined;
   });
 
-  it("should redirect to /sign-in-or-create", (done) => {
-    request(app)
+  it("should redirect to /sign-in-or-create", async () => {
+    await request(app)
       .get(PATH_NAMES.AUTHORIZE)
       .query({
         client_id: getOrchToAuthExpectedClientId(),
@@ -100,11 +100,11 @@ describe("Integration:: authorize", () => {
         request: "SomeJWE",
       })
       .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /sign-in-or-create with Google Analytics tag if 'result' query exists", (done) => {
-    request(app)
+  it("should redirect to /sign-in-or-create with Google Analytics tag if 'result' query exists", async () => {
+    await request(app)
       .get(PATH_NAMES.AUTHORIZE)
       .query({
         client_id: getOrchToAuthExpectedClientId(),
@@ -113,6 +113,6 @@ describe("Integration:: authorize", () => {
         result: "test-result",
       })
       .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE + "?result=test-result")
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -41,9 +41,9 @@ describe("Integration:: check your email", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -60,22 +60,22 @@ describe("Integration:: check your email", () => {
     delete process.env.SUPPORT_CHECK_EMAIL_FRAUD;
   });
 
-  it("should return verify email page", (done) => {
-    request(app).get(PATH_NAMES.CHECK_YOUR_EMAIL).expect(200, done);
+  it("should return verify email page", async () => {
+    await request(app).get(PATH_NAMES.CHECK_YOUR_EMAIL).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when code not entered", (done) => {
-    request(app)
+  it("should return validation error when code not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -87,11 +87,11 @@ describe("Integration:: check your email", () => {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains("Enter the code");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code is less than 6 characters", (done) => {
-    request(app)
+  it("should return validation error when code is less than 6 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -105,11 +105,11 @@ describe("Integration:: check your email", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code is greater than 6 characters", (done) => {
-    request(app)
+  it("should return validation error when code is greater than 6 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -123,11 +123,11 @@ describe("Integration:: check your email", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code entered contains letters", (done) => {
-    request(app)
+  it("should return validation error when code entered contains letters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -141,10 +141,10 @@ describe("Integration:: check your email", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /create-password when valid code entered", (done) => {
+  it("should redirect to /create-password when valid code entered", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.VERIFY_CODE)
       .once()
@@ -158,7 +158,7 @@ describe("Integration:: check your email", () => {
         isBlockedStatus: "Pending",
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -167,10 +167,10 @@ describe("Integration:: check your email", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return validation error when incorrect code entered", (done) => {
+  it("should return validation error when incorrect code entered", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).once().reply(400, {
       code: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
       success: false,
@@ -184,7 +184,7 @@ describe("Integration:: check your email", () => {
         isBlockedStatus: "Pending",
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -198,10 +198,10 @@ describe("Integration:: check your email", () => {
           "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return error page when when incorrect code entered more than 5 times", (done) => {
+  it("should return error page when when incorrect code entered more than 5 times", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).times(6).reply(400, {
       code: ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES,
       success: false,
@@ -215,7 +215,7 @@ describe("Integration:: check your email", () => {
         isBlockedStatus: "Pending",
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_EMAIL)
       .type("form")
       .set("Cookie", cookies)
@@ -227,6 +227,6 @@ describe("Integration:: check your email", () => {
         "Location",
         `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.EmailMaxRetries}`
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -42,9 +42,9 @@ describe("Integration:: check your phone", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CHECK_YOUR_PHONE)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -61,22 +61,22 @@ describe("Integration:: check your phone", () => {
     app = undefined;
   });
 
-  it("should return check your phone page", (done) => {
-    request(app).get(PATH_NAMES.CHECK_YOUR_PHONE).expect(200, done);
+  it("should return check your phone page", async () => {
+    await request(app).get(PATH_NAMES.CHECK_YOUR_PHONE).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when code not entered", (done) => {
-    request(app)
+  it("should return validation error when code not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -88,11 +88,11 @@ describe("Integration:: check your phone", () => {
         const $ = cheerio.load(res.text);
         expect($("#code-error").text()).to.contains("Enter the code");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code is less than 6 characters", (done) => {
-    request(app)
+  it("should return validation error when code is less than 6 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -106,11 +106,11 @@ describe("Integration:: check your phone", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code is greater than 6 characters", (done) => {
-    request(app)
+  it("should return validation error when code is greater than 6 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -124,11 +124,11 @@ describe("Integration:: check your phone", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code entered contains letters", (done) => {
-    request(app)
+  it("should return validation error when code entered contains letters", async () => {
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -142,10 +142,10 @@ describe("Integration:: check your phone", () => {
           "Enter the code using only 6 digits"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /create-password when valid code entered", (done) => {
+  it("should redirect to /create-password when valid code entered", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.VERIFY_MFA_CODE)
       .once()
@@ -154,7 +154,7 @@ describe("Integration:: check your phone", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -163,16 +163,16 @@ describe("Integration:: check your phone", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return validation error when incorrect code entered", (done) => {
+  it("should return validation error when incorrect code entered", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).once().reply(400, {
       code: ERROR_CODES.INVALID_VERIFY_PHONE_NUMBER_CODE,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -186,16 +186,16 @@ describe("Integration:: check your phone", () => {
           "The code you entered is not correct, or may have expired, try entering it again or request a new code"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to security code expired when incorrect code has been entered 5 times", (done) => {
+  it("should redirect to security code expired when incorrect code has been entered 5 times", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).times(6).reply(400, {
       code: ERROR_CODES.ENTERED_INVALID_VERIFY_PHONE_NUMBER_CODE_MAX_TIMES,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -207,16 +207,16 @@ describe("Integration:: check your phone", () => {
         "Location",
         `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.OtpMaxRetries}`
       )
-      .expect(302, done);
+      .expect(302);
   });
 
-  it('should render the "you requested too many codes" pages when incorrect code has requested more than 5 times', (done) => {
+  it('should render the "you requested too many codes" pages when incorrect code has requested more than 5 times', async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).reply(400, {
       code: ERROR_CODES.VERIFY_PHONE_NUMBER_CODE_REQUEST_BLOCKED,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CHECK_YOUR_PHONE)
       .type("form")
       .set("Cookie", cookies)
@@ -230,11 +230,11 @@ describe("Integration:: check your phone", () => {
       )
       .expect(302);
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CHECK_YOUR_PHONE)
       .expect((res) => {
         res.text.includes("Wait 2 hours");
       })
-      .expect(200, done);
+      .expect(200);
   });
 });

--- a/src/components/common/cookies/tests/cookies-controller-integration.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller-integration.test.ts
@@ -1,7 +1,7 @@
 import request from "supertest";
 import { describe } from "mocha";
-import { expect } from "../../../../../test/utils/test-utils";
-import * as cheerio from "cheerio";
+import { expect, sinon } from "../../../../../test/utils/test-utils";
+import cheerio from "cheerio";
 import decache from "decache";
 import { PATH_NAMES, ANALYTICS_COOKIES } from "../../../../app.constants";
 
@@ -16,9 +16,9 @@ describe("Integration:: cookies controller", () => {
 
     app = await require("../../../../app").createApp();
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.COOKIES_POLICY)
-      .end((err, res) => {
+      .then((res) => {
         $ = cheerio.load(res.text);
         $("table#analytics-cookies tbody td:first-child").each(
           (i: any, elem: any) => {
@@ -30,6 +30,7 @@ describe("Integration:: cookies controller", () => {
   });
 
   after(() => {
+    sinon.restore();
     app = undefined;
   });
 

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -47,7 +47,8 @@ function handleErrors(
     if (
       mfaFailResponse.data.code ===
         ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED ||
-      mfaFailResponse.data.code === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES
+      mfaFailResponse.data.code === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES ||
+      mfaFailResponse.data.code === ERROR_CODES.MFA_SMS_MAX_CODES_SENT
     ) {
       return res.redirect(
         req.session.client.redirectUri.concat("?error=login_required")
@@ -56,7 +57,7 @@ function handleErrors(
   }
 
   if (path && !isResendCodeRequest) {
-    return res.redirect(path);
+    res.redirect(path);
   }
 
   throw new BadRequestError(

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -56,7 +56,7 @@ function handleErrors(
   }
 
   if (path && !isResendCodeRequest) {
-    res.redirect(path);
+    return res.redirect(path);
   }
 
   throw new BadRequestError(

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -30,10 +30,10 @@ describe("Integration:: contact us - public user", () => {
     app = await require("../../../app").createApp();
     smartAgentApiUrl = process.env.SMARTAGENT_API_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CONTACT_US)
       .query("supportType=PUBLIC")
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -49,14 +49,13 @@ describe("Integration:: contact us - public user", () => {
     app = undefined;
   });
 
-  const expectValidationErrorOnPost = (
+  const expectValidationErrorOnPost = async (
     url: string,
     data: Record<string, unknown>,
     errorElement: string,
-    errorDescription: string,
-    done: Mocha.Done
+    errorDescription: string
   ) => {
-    request(app)
+    await request(app)
       .post(url)
       .type("form")
       .set("Cookie", cookies)
@@ -65,14 +64,14 @@ describe("Integration:: contact us - public user", () => {
         const $ = cheerio.load(res.text);
         expect($(errorElement).text()).to.contains(errorDescription);
       })
-      .expect(400, done);
+      .expect(400);
   };
 
-  it("should return contact us page", (done) => {
-    request(app)
+  it("should return contact us page", async () => {
+    await request(app)
       .get(PATH_NAMES.CONTACT_US)
       .query("supportType=PUBLIC")
-      .expect(200, done);
+      .expect(200);
   });
 
   [
@@ -81,8 +80,8 @@ describe("Integration:: contact us - public user", () => {
     "http://remotehost/something",
     "<script>alert(123);</script>",
   ].forEach(function (referer) {
-    it("should return contact us page removing invalid referer url", (done) => {
-      request(app)
+    it("should return contact us page removing invalid referer url", async () => {
+      await request(app)
         .get(PATH_NAMES.CONTACT_US)
         .query("supportType=PUBLIC")
         .set("referer", referer)
@@ -93,7 +92,7 @@ describe("Integration:: contact us - public user", () => {
             encodeURIComponent(referer)
           );
         })
-        .expect(200, done);
+        .expect(200);
     });
   });
 
@@ -105,8 +104,8 @@ describe("Integration:: contact us - public user", () => {
     "http://localhost/anypage",
     "https://localhost/scenario/page",
   ].forEach(function (referer) {
-    it("should return contact us page including valid referer url", (done) => {
-      request(app)
+    it("should return contact us page including valid referer url", async () => {
+      await request(app)
         .get(PATH_NAMES.CONTACT_US)
         .query("supportType=PUBLIC")
         .set("referer", referer)
@@ -116,7 +115,7 @@ describe("Integration:: contact us - public user", () => {
             encodeURIComponent(referer)
           );
         })
-        .expect(200, done);
+        .expect(200);
     });
   });
 
@@ -125,8 +124,8 @@ describe("Integration:: contact us - public user", () => {
     "http://remotehost/something",
     "<script>alert(123);</script>",
   ].forEach(function (referer) {
-    it("should return contact us questions page removing invalid referer queryparam url", (done) => {
-      request(app)
+    it("should return contact us questions page removing invalid referer queryparam url", async () => {
+      await request(app)
         .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
         .query("theme=account_creation")
         .query("subtheme=sign_in_phone_number_issue")
@@ -138,7 +137,7 @@ describe("Integration:: contact us - public user", () => {
             encodeURIComponent(referer)
           );
         })
-        .expect(200, done);
+        .expect(200);
     });
   });
 
@@ -150,8 +149,8 @@ describe("Integration:: contact us - public user", () => {
     "http://localhost/anypage",
     "http://localhost:3000/enter-email",
   ].forEach(function (referer) {
-    it("should return contact us questions page including valid referer queryparam url", (done) => {
-      request(app)
+    it("should return contact us questions page including valid referer queryparam url", async () => {
+      await request(app)
         .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
         .query("theme=account_creation")
         .query("referer=" + referer)
@@ -161,49 +160,49 @@ describe("Integration:: contact us - public user", () => {
             encodeURIComponent(referer)
           );
         })
-        .expect(200, done);
+        .expect(200);
     });
   });
 
-  it("should return contact us further information signing in page", (done) => {
-    request(app)
+  it("should return contact us further information signing in page", async () => {
+    await request(app)
       .get("/contact-us-further-information")
       .query("theme=signing_in")
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return contact us further information account creation page", (done) => {
-    request(app)
+  it("should return contact us further information account creation page", async () => {
+    await request(app)
       .get("/contact-us-further-information")
       .query("theme=account_creation")
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return contact us questions page with only a theme", (done) => {
-    request(app)
+  it("should return contact us questions page with only a theme", async () => {
+    await request(app)
       .get("/contact-us-questions")
       .query("theme=email_subscriptions")
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return contact us questions page with a theme and a subtheme", (done) => {
-    request(app)
+  it("should return contact us questions page with a theme and a subtheme", async () => {
+    await request(app)
       .get("/contact-us-questions")
       .query("theme=signing_in")
       .query("subtheme=no_security_code")
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CONTACT_US)
       .query("supportType=PUBLIC")
       .type("form")
       .send({})
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when no radio boxes are selected on the signing in contact-us-further-information page", (done) => {
+  it("should return validation error when no radio boxes are selected on the signing in contact-us-further-information page", () => {
     const data = {
       _csrf: token,
       theme: "signing_in",
@@ -212,12 +211,11 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-further-information",
       data,
       "#subtheme-error",
-      "Select the problem you had when signing in to your GOV.UK One Login",
-      done
+      "Select the problem you had when signing in to your GOV.UK One Login"
     );
   });
 
-  it("should return validation error when no radio boxes are selected on the proving_identity contact-us-further-information page", (done) => {
+  it("should return validation error when no radio boxes are selected on the proving_identity contact-us-further-information page", () => {
     const data = {
       _csrf: token,
       theme: "proving_identity",
@@ -226,12 +224,11 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-further-information",
       data,
       "#subtheme-error",
-      "Select the problem you had proving your identity",
-      done
+      "Select the problem you had proving your identity"
     );
   });
 
-  it("should return validation error when issue description are not entered on the contact-us-questions page", (done) => {
+  it("should return validation error when issue description are not entered on the contact-us-questions page", () => {
     const data = {
       _csrf: token,
       issueDescription: "",
@@ -242,12 +239,11 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-questions",
       data,
       "#issueDescription-error",
-      "Enter what you were trying to do",
-      done
+      "Enter what you were trying to do"
     );
   });
 
-  it("should return validation error when user selected yes to contact for feedback and left email field empty", (done) => {
+  it("should return validation error when user selected yes to contact for feedback and left email field empty", () => {
     const data = {
       _csrf: token,
       theme: "signing_in",
@@ -260,13 +256,12 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-questions",
       data,
       "#email-error",
-      "Enter your email address",
-      done
+      "Enter your email address"
     );
   });
 
-  it("should return validation error when user selected Text message to a phone number from another country and left the Which country field empty", (done) => {
-    request(app)
+  it("should return validation error when user selected Text message to a phone number from another country and left the Which country field empty", async () => {
+    await request(app)
       .post("/contact-us-questions?radio_buttons=true")
       .type("form")
       .set("Cookie", cookies)
@@ -285,10 +280,10 @@ describe("Integration:: contact us - public user", () => {
           "Enter which country your phone number is from"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when user selected yes to contact for feedback but email is in an invalid format", (done) => {
+  it("should return validation error when user selected yes to contact for feedback but email is in an invalid format", () => {
     const data = {
       _csrf: token,
       theme: "signing_in",
@@ -302,12 +297,11 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-questions",
       data,
       "#email-error",
-      "Enter an email address in the correct format, like name@example.com",
-      done
+      "Enter an email address in the correct format, like name@example.com"
     );
   });
 
-  it("should return validation error when user has not selected how the security code was sent whilst creating an account", (done) => {
+  it("should return validation error when user has not selected how the security code was sent whilst creating an account", () => {
     const data = {
       _csrf: token,
       theme: "account_creation",
@@ -320,13 +314,12 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-questions?radio_buttons=true",
       data,
       "#securityCodeSentMethod-error",
-      "Select whether you expected to get the code by email, text message or authenticator app",
-      done
+      "Select whether you expected to get the code by email, text message or authenticator app"
     );
   });
 
   describe("when a user had a problem with their identity document", () => {
-    it("should return validation error when user has not selected which identity document they were using", (done) => {
+    it("should return validation error when user has not selected which identity document they were using", () => {
       const data = {
         _csrf: token,
         theme: "proving_identity",
@@ -337,14 +330,13 @@ describe("Integration:: contact us - public user", () => {
         "/contact-us-questions",
         data,
         "#identityDocumentUsed-error",
-        "Select which identity document you were using",
-        done
+        "Select which identity document you were using"
       );
     });
   });
 
   describe("when a user had a problem with their bank or building society details", () => {
-    it("should return validation error when user has not selected which problem they had", (done) => {
+    it("should return validation error when user has not selected which problem they had", () => {
       const data = {
         _csrf: token,
         theme: "proving_identity",
@@ -355,14 +347,13 @@ describe("Integration:: contact us - public user", () => {
         "/contact-us-questions",
         data,
         "#problemWith-error",
-        "Select which problem you were having with your bank or building society details",
-        done
+        "Select which problem you were having with your bank or building society details"
       );
     });
   });
 
   describe("when a user had a problem taking a photo of your identity document using the GOV.UK ID Check app", () => {
-    it("should return validation error when user has not selected which identity document they were using", (done) => {
+    it("should return validation error when user has not selected which identity document they were using", () => {
       const data = {
         _csrf: token,
         theme: "id_check_app",
@@ -374,14 +365,13 @@ describe("Integration:: contact us - public user", () => {
         "/contact-us-questions?radio_buttons=true",
         data,
         "#identityDocumentUsed-error",
-        "Select which identity document you were using",
-        done
+        "Select which identity document you were using"
       );
     });
   });
 
   describe("when a user had a problem with their national insurance number", () => {
-    it("should return validation error when user has not described which problem they had", (done) => {
+    it("should return validation error when user has not described which problem they had", () => {
       const data = {
         _csrf: token,
         theme: "proving_identity",
@@ -392,8 +382,7 @@ describe("Integration:: contact us - public user", () => {
         "/contact-us-questions",
         data,
         "#problemWithNationalInsuranceNumber-error",
-        "What problem were you having with your National Insurance number?",
-        done
+        "What problem were you having with your National Insurance number?"
       );
     });
   });
@@ -417,56 +406,53 @@ describe("Integration:: contact us - public user", () => {
       };
     };
 
-    it("should return validation error when user has not entered what they were trying to do", (done) => {
+    it("should return validation error when user has not entered what they were trying to do", () => {
       const data = phoneNumberIssueData("", "additional detail", "UK");
       expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#issueDescription-error",
-        "Enter what you were trying to do",
-        done
+        "Enter what you were trying to do"
       );
     });
 
-    it("should return validation error when user has not entered what happened", (done) => {
+    it("should return validation error when user has not entered what happened", () => {
       const data = phoneNumberIssueData("more detail", "", "UK");
       expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#additionalDescription-error",
-        "Enter what happened",
-        done
+        "Enter what happened"
       );
     });
 
-    it("should return validation error when user has not entered country the phone number is from", (done) => {
+    it("should return validation error when user has not entered country the phone number is from", () => {
       const data = phoneNumberIssueData("more detail", "additional detail", "");
       expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#countryPhoneNumberFrom-error",
-        "Enter which country your phone number is from",
-        done
+        "Enter which country your phone number is from"
       );
     });
 
-    it("should redirect to success page when valid form submitted", (done) => {
+    it("should redirect to success page when valid form submitted", async () => {
       nock(smartAgentApiUrl).post("/").once().reply(200);
 
-      request(app)
+      await request(app)
         .post("/contact-us-questions")
         .type("form")
         .set("Cookie", cookies)
         .send(phoneNumberIssueData("detail", "description", "UK"))
         .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
-        .expect(302, done);
+        .expect(302);
     });
   });
 
-  it("should redirect to success page when form submitted", (done) => {
+  it("should redirect to success page when form submitted", async () => {
     nock(smartAgentApiUrl).post("/").once().reply(200);
 
-    request(app)
+    await request(app)
       .post("/contact-us-questions")
       .type("form")
       .set("Cookie", cookies)
@@ -481,13 +467,13 @@ describe("Integration:: contact us - public user", () => {
         referer: "https://gov.uk/sign-in",
       })
       .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to success page when authenticator app problem form submitted", (done) => {
+  it("should redirect to success page when authenticator app problem form submitted", async () => {
     nock(smartAgentApiUrl).post("/").once().reply(200);
 
-    request(app)
+    await request(app)
       .post("/contact-us-questions")
       .type("form")
       .set("Cookie", cookies)
@@ -503,27 +489,27 @@ describe("Integration:: contact us - public user", () => {
         referer: "https://gov.uk/sign-in",
       })
       .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
-      .expect(302, done);
+      .expect(302);
   });
 
   describe("Links to /contact-us-from-triage-page", () => {
-    it("should redirect to /contact-us", (done) => {
-      request(app)
+    it("should redirect to /contact-us", async () => {
+      await request(app)
         .get("/contact-us-from-triage-page")
         .query("fromURL=http//localhost/sign-in-or-create")
         .expect("Location", `${PATH_NAMES.CONTACT_US}?`)
-        .expect(302, done);
+        .expect(302);
     });
 
-    it("should redirect to /contact-us-further-information", (done) => {
-      request(app)
+    it("should redirect to /contact-us-further-information", async () => {
+      await request(app)
         .get("/contact-us-from-triage-page")
         .query(`theme=${CONTACT_US_THEMES.ID_CHECK_APP}`)
         .expect(
           "Location",
           `${PATH_NAMES.CONTACT_US_FURTHER_INFORMATION}?theme=${CONTACT_US_THEMES.ID_CHECK_APP}`
         )
-        .expect(302, done);
+        .expect(302);
     });
   });
 });

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -39,9 +39,9 @@ describe("Integration::register create password", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -57,23 +57,23 @@ describe("Integration::register create password", () => {
     app = undefined;
   });
 
-  it("should return create password page", (done) => {
-    request(app).get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD).expect(200, done);
+  it("should return create password page", async () => {
+    await request(app).get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .send({
         email: "test@test.com",
         password: "test@test.com",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when password not entered", (done) => {
-    request(app)
+  it("should return validation error when password not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -89,11 +89,11 @@ describe("Integration::register create password", () => {
           "Re-type your password"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when passwords don't match", (done) => {
-    request(app)
+  it("should return validation error when passwords don't match", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -108,11 +108,11 @@ describe("Integration::register create password", () => {
           "Enter the same password in both fields"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password less than 8 characters", (done) => {
-    request(app)
+  it("should return validation error when password less than 8 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -127,11 +127,11 @@ describe("Integration::register create password", () => {
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when no numbers present in password", (done) => {
-    request(app)
+  it("should return validation error when no numbers present in password", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -146,11 +146,11 @@ describe("Integration::register create password", () => {
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password all numeric", (done) => {
-    request(app)
+  it("should return validation error when password all numeric", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -165,16 +165,16 @@ describe("Integration::register create password", () => {
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password is amongst most common passwords", (done) => {
+  it("should return validation error when password is amongst most common passwords", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.SIGNUP_USER)
       .once()
       .reply(400, { code: 1040 });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -189,16 +189,16 @@ describe("Integration::register create password", () => {
           "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to get security codes when valid password entered", (done) => {
+  it("should redirect to get security codes when valid password entered", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.SIGNUP_USER)
       .once()
       .reply(HTTP_STATUS_CODES.OK, {});
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
       .set("Cookie", cookies)
@@ -208,6 +208,6 @@ describe("Integration::register create password", () => {
         "confirm-password": "testpassword1",
       })
       .expect("Location", PATH_NAMES.GET_SECURITY_CODES)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
@@ -39,9 +39,9 @@ describe("Integration::enter email (create account)", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -57,22 +57,22 @@ describe("Integration::enter email (create account)", () => {
     app = undefined;
   });
 
-  it("should return enter email page", (done) => {
-    request(app).get(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT).expect(200, done);
+  it("should return enter email page", async () => {
+    await request(app).get(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .send({
         email: "test@test.com",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when email not entered", (done) => {
-    request(app)
+  it("should return validation error when email not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -86,11 +86,11 @@ describe("Integration::enter email (create account)", () => {
           "Enter your email address"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when invalid email entered", (done) => {
-    request(app)
+  it("should return validation error when invalid email entered", async () => {
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -106,7 +106,7 @@ describe("Integration::enter email (create account)", () => {
       })
       .expect(400);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -122,7 +122,7 @@ describe("Integration::enter email (create account)", () => {
       })
       .expect(400);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -136,10 +136,10 @@ describe("Integration::enter email (create account)", () => {
           "Enter an email address in the correct format, like name@example.com\n"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /enter-password page when email address exists", (done) => {
+  it("should redirect to /enter-password page when email address exists", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -148,7 +148,7 @@ describe("Integration::enter email (create account)", () => {
         doesUserExist: true,
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -157,10 +157,10 @@ describe("Integration::enter email (create account)", () => {
         email: "test@test.com",
       })
       .expect("Location", PATH_NAMES.ENTER_PASSWORD_ACCOUNT_EXISTS)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /check-your-email when email address not found", (done) => {
+  it("should redirect to /check-your-email when email address not found", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -172,7 +172,7 @@ describe("Integration::enter email (create account)", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -181,15 +181,15 @@ describe("Integration::enter email (create account)", () => {
         email: "test@test.com",
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_EMAIL)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return internal server error when /user-exists API call response is 500", (done) => {
+  it("should return internal server error when /user-exists API call response is 500", async () => {
     nock(baseApi).post(API_ENDPOINTS.USER_EXISTS).once().reply(500, {
       message: "Internal Server error",
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -197,10 +197,10 @@ describe("Integration::enter email (create account)", () => {
         _csrf: token,
         email: "test@test.com",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", (done) => {
+  it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -212,7 +212,7 @@ describe("Integration::enter email (create account)", () => {
       .once()
       .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_CODE_REQUEST_BLOCKED });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -224,10 +224,10 @@ describe("Integration::enter email (create account)", () => {
         "Location",
         `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.EmailBlocked}`
       )
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /security-code-invalid-request when request OTP more than 5 times", (done) => {
+  it("should redirect to /security-code-invalid-request when request OTP more than 5 times", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -239,7 +239,7 @@ describe("Integration::enter email (create account)", () => {
       .once()
       .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT)
       .type("form")
       .set("Cookie", cookies)
@@ -252,6 +252,6 @@ describe("Integration::enter email (create account)", () => {
           "you asked to resend the security code too many codes"
         );
       })
-      .expect(200, done);
+      .expect(200);
   });
 });

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -67,6 +67,7 @@ describe("Integration::enter email", () => {
   });
 
   after(() => {
+    sinon.restore();
     app = undefined;
   });
 
@@ -74,18 +75,18 @@ describe("Integration::enter email", () => {
     request(app).get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .send({
         email: "test@test.com",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when email not entered", (done) => {
-    request(app)
+  it("should return validation error when email not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -99,11 +100,11 @@ describe("Integration::enter email", () => {
           "Enter your email address"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when invalid email entered", (done) => {
-    request(app)
+  it("should return validation error when invalid email entered", async () => {
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -119,7 +120,7 @@ describe("Integration::enter email", () => {
       })
       .expect(400);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -135,7 +136,7 @@ describe("Integration::enter email", () => {
       })
       .expect(400);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -149,10 +150,10 @@ describe("Integration::enter email", () => {
           "Enter an email address in the correct format, like name@example.com\n"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /enter-password page when email address exists", (done) => {
+  it("should redirect to /enter-password page when email address exists", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -161,7 +162,7 @@ describe("Integration::enter email", () => {
         doesUserExist: true,
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -170,10 +171,10 @@ describe("Integration::enter email", () => {
         email: "test@test.com",
       })
       .expect("Location", PATH_NAMES.ENTER_PASSWORD)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /account-not-found when email address not found", (done) => {
+  it("should redirect to /account-not-found when email address not found", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -182,7 +183,7 @@ describe("Integration::enter email", () => {
         doesUserExist: false,
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -191,10 +192,10 @@ describe("Integration::enter email", () => {
         email: "test@test.com",
       })
       .expect("Location", PATH_NAMES.ACCOUNT_NOT_FOUND)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return internal server error when /user-exists API call response is 500", (done) => {
+  it("should return internal server error when /user-exists API call response is 500", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -205,7 +206,7 @@ describe("Integration::enter email", () => {
       .once()
       .reply(200, {});
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -213,10 +214,10 @@ describe("Integration::enter email", () => {
         _csrf: token,
         email: "test@test.com",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /enter-password page when email address exists and check re-auth users api call is successfully", (done) => {
+  it("should redirect to /enter-password page when email address exists and check re-auth users api call is successfully", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
 
     nock(baseApi)
@@ -232,7 +233,7 @@ describe("Integration::enter email", () => {
         doesUserExist: true,
       });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
       .type("form")
       .set("Cookie", cookies)
@@ -241,7 +242,7 @@ describe("Integration::enter email", () => {
         email: "test@test.com",
       })
       .expect("Location", PATH_NAMES.ENTER_PASSWORD)
-      .expect(302, done);
+      .expect(302);
   });
 
   it("should redirect to /signed-out with login_required error when user fails re-auth", async () => {

--- a/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
@@ -90,7 +90,7 @@ describe("Integration:: enter mfa", () => {
     app = undefined;
   });
 
-  it("should redirect to rp if user entered 6 incorrect codes in the reauth journey", (done) => {
+  it("should redirect to rp if user entered 6 incorrect codes in the reauth journey", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
 
     nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).times(6).reply(400, {
@@ -98,7 +98,7 @@ describe("Integration:: enter mfa", () => {
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.ENTER_MFA)
       .type("form")
       .set("Cookie", cookies)
@@ -107,6 +107,6 @@ describe("Integration:: enter mfa", () => {
         code: "123455",
       })
       .expect("Location", EXAMPLE_REDIRECT_URI.concat("?error=login_required"))
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -61,22 +61,22 @@ describe("Integration::enter password", () => {
     nock.cleanAll();
   });
 
-  it("should return enter password page", (done) => {
-    request(app).get(ENDPOINT).expect(200, done);
+  it("should return enter password page", async () => {
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .send({
         password: "password",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when password not entered", (done) => {
-    request(app)
+  it("should return validation error when password not entered", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -88,14 +88,14 @@ describe("Integration::enter password", () => {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains("Enter your password");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password is incorrect", (done) => {
+  it("should return validation error when password is incorrect", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(401);
     process.env.SUPPORT_2HR_LOCKOUT = "0";
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -109,13 +109,13 @@ describe("Integration::enter password", () => {
           "Enter the correct password"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /auth-code when password is correct (VTR Cm)", (done) => {
+  it("should redirect to /auth-code when password is correct (VTR Cm)", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(200);
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -124,15 +124,15 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /account-locked from sign-in flow when incorrect password entered 5 times", (done) => {
+  it("should redirect to /account-locked from sign-in flow when incorrect password entered 5 times", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).times(6).reply(400, {
       code: ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED,
     });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -141,6 +141,6 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.ACCOUNT_LOCKED)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -66,22 +66,22 @@ describe("Integration::enter password", () => {
     nock.cleanAll();
   });
 
-  it("should return enter password page", (done) => {
-    request(app).get(ENDPOINT).expect(200, done);
+  it("should return enter password page", async () => {
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .send({
         password: "password",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when password not entered", (done) => {
-    request(app)
+  it("should return validation error when password not entered", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -93,14 +93,14 @@ describe("Integration::enter password", () => {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains("Enter your password");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password is incorrect", (done) => {
+  it("should return validation error when password is incorrect", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(401);
     process.env.SUPPORT_2HR_LOCKOUT = "0";
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -114,13 +114,13 @@ describe("Integration::enter password", () => {
           "Enter the correct password"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /auth-code when password is correct (VTR Cm)", (done) => {
+  it("should redirect to /auth-code when password is correct (VTR Cm)", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(200);
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -129,15 +129,15 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should sign out of re-authentication flow when incorrect password entered 5 times", (done) => {
+  it("should sign out of re-authentication flow when incorrect password entered 5 times", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).times(6).reply(400, {
       code: ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED,
     });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -146,6 +146,6 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", REDIRECT_URI.concat("?error=login_required"))
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/enter-password/tests/enter-password-support-2fa-before-password-reset-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-support-2fa-before-password-reset-integration.test.ts
@@ -91,27 +91,27 @@ describe("Integration::enter password", () => {
     delete process.env.SUPPORT_2FA_B4_PASSWORD_RESET;
   });
 
-  it("should return enter password page", (done) => {
-    request(app).get(ENDPOINT).expect(200, done);
+  it("should return enter password page", async () => {
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return enter password page when support reauthentication flag is on and check reauth users api call is successfull", (done) => {
+  it("should return enter password page when support reauthentication flag is on and check reauth users api call is successfull", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
-    request(app).get(ENDPOINT).expect(200, done);
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .send({
         password: "password",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when password not entered", (done) => {
-    request(app)
+  it("should return validation error when password not entered", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -123,14 +123,14 @@ describe("Integration::enter password", () => {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains("Enter your password");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password is incorrect", (done) => {
+  it("should return validation error when password is incorrect", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(401);
     process.env.SUPPORT_2HR_LOCKOUT = "0";
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -144,10 +144,10 @@ describe("Integration::enter password", () => {
           "Enter the correct password"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is not required", (done) => {
+  it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is not required", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(200, {
       mfaRequired: false,
       mfaMethodType: "SMS",
@@ -156,7 +156,7 @@ describe("Integration::enter password", () => {
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -165,10 +165,10 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.RESET_PASSWORD_REQUIRED)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is required", (done) => {
+  it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is required", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(200, {
       mfaRequired: true,
       mfaMethodType: "SMS",
@@ -177,7 +177,7 @@ describe("Integration::enter password", () => {
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -186,15 +186,15 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_SMS)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /account-locked during sign in flow when incorrect password entered 5 times", (done) => {
+  it("should redirect to /account-locked during sign in flow when incorrect password entered 5 times", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).times(6).reply(400, {
       code: ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED,
     });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -203,6 +203,6 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.ACCOUNT_LOCKED)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -39,9 +39,9 @@ describe("Integration::enter phone number", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -55,26 +55,27 @@ describe("Integration::enter phone number", () => {
   after(() => {
     process.env.SUPPORT_2HR_LOCKOUT = "0";
     sinon.restore();
+    app = undefined;
   });
 
-  it("should return enter phone number page", (done) => {
-    request(app)
+  it("should return enter phone number page", async () => {
+    await request(app)
       .get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .send({
         phoneNumber: "123456789",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when uk phone number not entered", (done) => {
-    request(app)
+  it("should return validation error when uk phone number not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -88,11 +89,11 @@ describe("Integration::enter phone number", () => {
           "Enter a UK mobile phone number"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when uk phone number entered is not valid", (done) => {
-    request(app)
+  it("should return validation error when uk phone number entered is not valid", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -106,11 +107,11 @@ describe("Integration::enter phone number", () => {
           "Enter a UK mobile phone number"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when uk phone number entered contains text", (done) => {
-    request(app)
+  it("should return validation error when uk phone number entered contains text", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -124,11 +125,11 @@ describe("Integration::enter phone number", () => {
           "Enter a UK mobile phone number using only numbers or the + symbol"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when uk phone number entered less than 12 characters", (done) => {
-    request(app)
+  it("should return validation error when uk phone number entered less than 12 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -142,11 +143,11 @@ describe("Integration::enter phone number", () => {
           "Enter a UK mobile phone number, like 07700 900000"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when uk phone number entered greater than 12 characters", (done) => {
-    request(app)
+  it("should return validation error when uk phone number entered greater than 12 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -160,16 +161,16 @@ describe("Integration::enter phone number", () => {
           "Enter a UK mobile phone number, like 07700 900000"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /check-your-phone page when valid UK phone number entered", (done) => {
+  it("should redirect to /check-your-phone page when valid UK phone number entered", async () => {
     nock(baseApi)
       .post("/send-notification")
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -178,11 +179,11 @@ describe("Integration::enter phone number", () => {
         phoneNumber: "07738394991",
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return validation error when international phone number not entered", (done) => {
-    request(app)
+  it("should return validation error when international phone number not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -198,11 +199,11 @@ describe("Integration::enter phone number", () => {
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when international phone number entered is not valid", (done) => {
-    request(app)
+  it("should return validation error when international phone number entered is not valid", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -218,11 +219,11 @@ describe("Integration::enter phone number", () => {
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when international phone number entered contains text", (done) => {
-    request(app)
+  it("should return validation error when international phone number entered contains text", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -238,11 +239,11 @@ describe("Integration::enter phone number", () => {
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when international phone number entered less than 8 characters", (done) => {
-    request(app)
+  it("should return validation error when international phone number entered less than 8 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -258,11 +259,11 @@ describe("Integration::enter phone number", () => {
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when international phone number entered greater than 16 characters", (done) => {
-    request(app)
+  it("should return validation error when international phone number entered greater than 16 characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -278,16 +279,16 @@ describe("Integration::enter phone number", () => {
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /check-your-phone page when valid international phone number entered", (done) => {
+  it("should redirect to /check-your-phone page when valid international phone number entered", async () => {
     nock(baseApi)
       .post("/send-notification")
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -297,16 +298,16 @@ describe("Integration::enter phone number", () => {
         internationalPhoneNumber: "+33645453322",
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it('should render 2hr lockout "You asked for too many codes" error page when request OTP more than 5 times', (done) => {
+  it('should render 2hr lockout "You asked for too many codes" error page when request OTP more than 5 times', async () => {
     nock(baseApi).persist().post("/send-notification").times(6).reply(400, {
       code: ERROR_CODES.VERIFY_PHONE_NUMBER_MAX_CODES_SENT,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -322,16 +323,16 @@ describe("Integration::enter phone number", () => {
       .expect((res) => {
         res.text.includes("You will not be able to continue for 2 hours.");
       })
-      .expect(200, done);
+      .expect(200);
   });
 
-  it('should redirect to SECURITY_CODE_REQUEST_EXCEEDED and render the 2hr lockout "you cannot create" error page when user has exceeded the OTP request limit', (done) => {
+  it('should redirect to SECURITY_CODE_REQUEST_EXCEEDED and render the 2hr lockout "you cannot create" error page when user has exceeded the OTP request limit', async () => {
     nock(baseApi).post("/send-notification").once().reply(400, {
       code: ERROR_CODES.VERIFY_PHONE_NUMBER_CODE_REQUEST_BLOCKED,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
       .set("Cookie", cookies)
@@ -353,6 +354,6 @@ describe("Integration::enter phone number", () => {
           "otpBlocked"
         )
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -17,10 +17,11 @@ describe("Integration::healthcheck", () => {
 
   after(() => {
     sandbox.restore();
+    sinon.restore();
     app = undefined;
   });
 
-  it("healthcheck should return 200 OK", (done) => {
-    request(app).get(PATH_NAMES.HEALTHCHECK).expect(200, done);
+  it("healthcheck should return 200 OK", async () => {
+    await request(app).get(PATH_NAMES.HEALTHCHECK).expect(200);
   });
 });

--- a/src/components/landing/tests/landing-integration.test.ts
+++ b/src/components/landing/tests/landing-integration.test.ts
@@ -37,10 +37,10 @@ describe("Integration:: landing", () => {
     app = undefined;
   });
 
-  it("should redirect to /sign-in-or-create", (done) => {
-    request(app)
+  it("should redirect to /sign-in-or-create", async () => {
+    await request(app)
       .get(PATH_NAMES.ROOT)
       .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/prove-identity/tests/prove-identity-integration.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-integration.test.ts
@@ -115,7 +115,7 @@ describe("Integration::prove identity", () => {
     expect(response.headers.location).to.eq(PATH_NAMES.UNAVAILABLE_PERMANENT);
   });
 
-  const makeRequestToProveIdentityEndpoint = () => {
+  const makeRequestToProveIdentityEndpoint = async () => {
     return request(app).get(PATH_NAMES.PROVE_IDENTITY).set("Cookie", cookies);
   };
 });

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -59,27 +59,27 @@ describe("Integration:: resend email code", () => {
     app = undefined;
   });
 
-  it("should return resend email code page", (done) => {
-    request(app).get(PATH_NAMES.RESEND_EMAIL_CODE).expect(200, done);
+  it("should return resend email code page", async () => {
+    await request(app).get(PATH_NAMES.RESEND_EMAIL_CODE).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.RESEND_EMAIL_CODE)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /check-your-email when new code requested as part of account creation journey", (done) => {
+  it("should redirect to /check-your-email when new code requested as part of account creation journey", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_EMAIL_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -87,12 +87,12 @@ describe("Integration:: resend email code", () => {
         _csrf: token,
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_EMAIL)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", () => {
+  it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", async () => {
     const testSpecificCookies = cookies + "; re=true";
-    request(app)
+    await request(app)
       .get(PATH_NAMES.RESEND_EMAIL_CODE)
       .set("Cookie", testSpecificCookies)
       .expect((res) => {
@@ -100,28 +100,28 @@ describe("Integration:: resend email code", () => {
       });
   });
 
-  it("should return 500 error screen when API call fails", (done) => {
+  it("should return 500 error screen when API call fails", async () => {
     nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(500, {
       errorCode: "1234",
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_EMAIL_CODE)
       .type("form")
       .set("Cookie", cookies)
       .send({
         _csrf: token,
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /security-code-invalid-request when request OTP more than 5 times", (done) => {
+  it("should redirect to /security-code-invalid-request when request OTP more than 5 times", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .times(6)
       .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_EMAIL_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -132,16 +132,16 @@ describe("Integration:: resend email code", () => {
         "Location",
         "/security-code-invalid-request?actionType=emailMaxCodesSent"
       )
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", (done) => {
+  it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .once()
       .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_CODE_REQUEST_BLOCKED });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_EMAIL_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -152,6 +152,6 @@ describe("Integration:: resend email code", () => {
         "Location",
         "/security-code-requested-too-many-times?actionType=emailBlocked"
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -7,7 +7,7 @@
 {% set hrefBack = 'enter-code' %}
 
 {% set phoneNumberMessage %}
-   {{ 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber | returnLastCharacters({limit: 3}) }}</span>
+   {{ 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate }} <span class='govuk-!-font-weight-bold'>{{ redactedPhoneNumber | returnLastCharacters({limit: 3}) }}</span>
 {% endset %}
 
 {% block content %}

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -31,10 +31,12 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
       support2hrLockout: support2hrLockout(),
     });
   } else {
-    const journeyType = getJourneyTypeFromUserSession(req.session.user);
+    const journeyType = getJourneyTypeFromUserSession(req.session.user, {
+      includeReauthentication: true,
+    });
 
     res.render("resend-mfa-code/index.njk", {
-      phoneNumber: req.session.user.redactedPhoneNumber,
+      redactedPhoneNumber: req.session.user.redactedPhoneNumber,
       isResendCodeRequest: req.query?.isResendCodeRequest,
       support2hrLockout: support2hrLockout(),
       supportReauthentication: supportReauthentication(),

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -94,7 +94,6 @@ describe("Integration:: resend mfa code", () => {
     await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .expect((res) => {
-        console.log(res.text);
         const $ = cheerio.load(res.text);
         expect($.text()).to.contain("you will be locked out for 2 hours.");
       })
@@ -107,7 +106,6 @@ describe("Integration:: resend mfa code", () => {
     await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .expect((res) => {
-        console.log(res.text);
         const $ = cheerio.load(res.text);
         expect($.text()).to.contain("you will be signed out");
       })
@@ -184,6 +182,21 @@ describe("Integration:: resend mfa code", () => {
       .expect(500);
   });
 
+  it("should return 400 error screen when API call fails", async () => {
+    nock(baseApi).post(API_ENDPOINTS.MFA).once().reply(400, {
+      errorCode: "1015",
+    });
+
+    await request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(500);
+  });
+
   it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "0";
 
@@ -192,7 +205,7 @@ describe("Integration:: resend mfa code", () => {
       .times(6)
       .reply(400, { code: ERROR_CODES.MFA_SMS_MAX_CODES_SENT });
 
-    await request(app)
+    request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -214,7 +227,7 @@ describe("Integration:: resend mfa code", () => {
       .once()
       .reply(400, { code: ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED });
 
-    await request(app)
+    request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -43,6 +43,7 @@ describe("Integration:: resend mfa code", () => {
         next();
       });
 
+    process.env.SUPPORT_REAUTHENTICATION = "0";
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
@@ -68,66 +69,68 @@ describe("Integration:: resend mfa code", () => {
     app = undefined;
   });
 
-  it("should return resend mfa code page", (done) => {
-    request(app)
+  it("should return resend mfa code page", async () => {
+    await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("title").text()).to.contain("Get security code");
       })
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should include the last three digits of the user's telephone number", (done) => {
-    request(app)
+  it("should include the last three digits of the user's telephone number", async () => {
+    await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($.text()).to.contain(testRedactedPhoneNumber.slice(-3));
       })
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should state user could be locked out", (done) => {
-    process.env.SUPPORT_REAUTHENTICATION = "0";
-    request(app)
+  it("should state user could be locked out", async () => {
+    process.env.SUPPORT_2HR_LOCKOUT = "1";
+    await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .expect((res) => {
+        console.log(res.text);
         const $ = cheerio.load(res.text);
         expect($.text()).to.contain("you will be locked out for 2 hours.");
       })
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should state reauthenticating user could be logged out", (done) => {
+  it("should state reauthenticating user could be logged out", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
-    request(app)
+    process.env.SUPPORT_2HR_LOCKOUT = "1";
+    await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .expect((res) => {
-        // console.log(res.text)
+        console.log(res.text);
         const $ = cheerio.load(res.text);
         expect($.text()).to.contain("you will be signed out");
       })
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /enter-code when new code requested as part of sign in journey", (done) => {
+  it("should redirect to /enter-code when new code requested as part of sign in journey", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.MFA)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -135,16 +138,16 @@ describe("Integration:: resend mfa code", () => {
         _csrf: token,
       })
       .expect("Location", PATH_NAMES.ENTER_MFA)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /check-your-phone when new code requested as part of account creation journey", (done) => {
+  it("should redirect to /check-your-phone when new code requested as part of account creation journey", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.MFA)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -153,12 +156,12 @@ describe("Integration:: resend mfa code", () => {
         isResendCodeRequest: true,
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", () => {
+  it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", async () => {
     const testSpecificCookies = cookies + "; re=true";
-    request(app)
+    await request(app)
       .get(PATH_NAMES.RESEND_MFA_CODE)
       .set("Cookie", testSpecificCookies)
       .expect((res) => {
@@ -166,29 +169,30 @@ describe("Integration:: resend mfa code", () => {
       });
   });
 
-  it("should return 500 error screen when API call fails", (done) => {
+  it("should return 500 error screen when API call fails", async () => {
     nock(baseApi).post(API_ENDPOINTS.MFA).once().reply(500, {
       errorCode: "1234",
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)
       .send({
         _csrf: token,
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", (done) => {
+  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "0";
+
     nock(baseApi)
       .post(API_ENDPOINTS.MFA)
       .times(6)
       .reply(400, { code: ERROR_CODES.MFA_SMS_MAX_CODES_SENT });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -199,38 +203,18 @@ describe("Integration:: resend mfa code", () => {
         "Location",
         "/security-code-requested-too-many-times?actionType=mfaMaxCodesSent"
       )
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", (done) => {
+  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "0";
-
-    validateSessionStub.callsFake(function (
-      req: any,
-      res: any,
-      next: any
-    ): void {
-      res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
-
-      req.session.user = {
-        email: "test@test.com",
-        phoneNumber: testPhoneNumber,
-        redactedPhoneNumber: testRedactedPhoneNumber,
-        journey: {
-          nextPath: PATH_NAMES.ENTER_MFA,
-          optionalPaths: [PATH_NAMES.RESEND_MFA_CODE],
-        },
-      };
-
-      next();
-    });
 
     nock(baseApi)
       .post(API_ENDPOINTS.MFA)
       .once()
       .reply(400, { code: ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESEND_MFA_CODE)
       .type("form")
       .set("Cookie", cookies)
@@ -241,6 +225,6 @@ describe("Integration:: resend mfa code", () => {
         "Location",
         "/security-code-invalid-request?actionType=mfaBlocked"
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
@@ -44,9 +44,9 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
 
     nock(baseApi).persist().post("/mfa").reply(204);
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -62,24 +62,24 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
     app = undefined;
   });
 
-  it("should return updated check auth app page", (done) => {
+  it("should return updated check auth app page", async () => {
     nock(baseApi).persist().post("/mfa").reply(204);
-    request(app)
+    await request(app)
       .get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#updatedHeading").length).to.eq(1);
       })
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should redirect to reset password step when valid sms code is entered", (done) => {
+  it("should redirect to reset password step when valid sms code is entered", async () => {
     nock(baseApi)
       .persist()
       .post(API_ENDPOINTS.VERIFY_MFA_CODE)
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
       .type("form")
       .set("Cookie", cookies)
@@ -88,16 +88,16 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.RESET_PASSWORD)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return error page when when user is locked out", (done) => {
+  it("should return error page when when user is locked out", async () => {
     nock(baseApi).persist().post(API_ENDPOINTS.VERIFY_MFA_CODE).reply(400, {
       code: ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED,
       success: false,
     });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
       .type("form")
       .set("Cookie", cookies)
@@ -109,6 +109,6 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
         "Location",
         `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.AuthAppMfaMaxRetries}`
       )
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -67,12 +67,12 @@ describe("Integration::reset password check email ", () => {
     app = undefined;
   });
 
-  it("should return reset password check email page", (done) => {
+  it("should return reset password check email page", async () => {
     nock(baseApi).post("/reset-password-request").once().reply(204);
-    request(app).get("/reset-password-check-email").expect(200, done);
+    await request(app).get("/reset-password-check-email").expect(200);
   });
 
-  it("should redirect to /reset-password-2fa-auth-app if user's 2FA is set to AUTH_APP", (done) => {
+  it("should redirect to /reset-password-2fa-auth-app if user's 2FA is set to AUTH_APP", async () => {
     nock(baseApi)
       .persist()
       .post(API_ENDPOINTS.VERIFY_CODE)
@@ -80,7 +80,7 @@ describe("Integration::reset password check email ", () => {
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app)
+    await request(app)
       .post("/reset-password-check-email")
       .type("form")
       .set("Cookie", cookies)
@@ -89,6 +89,6 @@ describe("Integration::reset password check email ", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -64,12 +64,12 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
     delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
   });
 
-  it("should return reset password page", (done) => {
+  it("should return reset password page", async () => {
     setupAccountInterventionsResponse(baseApi, noInterventions);
-    request(app).get(ENDPOINT).expect(200, done);
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return the blocked screen when someone has a blocked intervention", (done) => {
+  it("should return the blocked screen when someone has a blocked intervention", async () => {
     setupAccountInterventionsResponse(baseApi, {
       blocked: true,
       passwordResetRequired: false,
@@ -77,15 +77,15 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       reproveIdentity: false,
     });
 
-    request(app)
+    await request(app)
       .get(ENDPOINT)
       .expect(function (res) {
         expect(res.headers.location).to.eq("/unavailable-permanent");
       })
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return the suspended screen when someone has a suspended intervention", (done) => {
+  it("should return the suspended screen when someone has a suspended intervention", async () => {
     setupAccountInterventionsResponse(baseApi, {
       blocked: false,
       passwordResetRequired: false,
@@ -93,15 +93,15 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       reproveIdentity: false,
     });
 
-    request(app)
+    await request(app)
       .get(ENDPOINT)
       .expect(function (res) {
         expect(res.headers.location).to.eq("/unavailable-temporary");
       })
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should return reset password page when someone has a reset password intervention", (done) => {
+  it("should return reset password page when someone has a reset password intervention", async () => {
     setupAccountInterventionsResponse(baseApi, {
       blocked: false,
       passwordResetRequired: true,
@@ -109,21 +109,21 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       reproveIdentity: false,
     });
 
-    request(app).get(ENDPOINT).expect(200, done);
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .send({
         password: "password",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when password not entered", (done) => {
-    request(app)
+  it("should return validation error when password not entered", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -136,11 +136,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains("Enter your password");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when passwords don't match", (done) => {
-    request(app)
+  it("should return validation error when passwords don't match", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -155,11 +155,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Enter the same password in both fields"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password less than 8 characters", (done) => {
-    request(app)
+  it("should return validation error when password less than 8 characters", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -174,13 +174,13 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password is amongst most common passwords", (done) => {
+  it("should return validation error when password is amongst most common passwords", async () => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1040 });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -195,13 +195,13 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return error when new password is the same as existing password", (done) => {
+  it("should return error when new password is the same as existing password", async () => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1024 });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -216,11 +216,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "You are already using that password. Enter a different password"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when no numbers present in password", (done) => {
-    request(app)
+  it("should return validation error when no numbers present in password", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -235,11 +235,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password all numeric", (done) => {
-    request(app)
+  it("should return validation error when password all numeric", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -254,15 +254,15 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /auth-code when valid password entered", (done) => {
+  it("should redirect to /auth-code when valid password entered", async () => {
     nock(baseApi).post("/reset-password").once().reply(204);
     nock(baseApi).post("/login").once().reply(200);
     nock(baseApi).post("/mfa").once().reply(204);
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -272,6 +272,6 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
         "confirm-password": "Testpassword1",
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
@@ -45,9 +45,9 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
     baseApi = process.env.FRONTEND_API_BASE_URL;
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app)
+    await request(app)
       .get(ENDPOINT)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -63,24 +63,24 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
     app = undefined;
   });
 
-  it("should return reset password page", (done) => {
+  it("should return reset password page", async () => {
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app).get(ENDPOINT).expect(200, done);
+    await request(app).get(ENDPOINT).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .send({
         password: "password",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when password not entered", (done) => {
-    request(app)
+  it("should return validation error when password not entered", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -93,11 +93,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains("Enter your password");
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when passwords don't match", (done) => {
-    request(app)
+  it("should return validation error when passwords don't match", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -112,11 +112,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Enter the same password in both fields"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password less than 8 characters", (done) => {
-    request(app)
+  it("should return validation error when password less than 8 characters", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -131,13 +131,13 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password is amongst most common passwords", (done) => {
+  it("should return validation error when password is amongst most common passwords", async () => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1040 });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -152,13 +152,13 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return error when new password is the same as existing password", (done) => {
+  it("should return error when new password is the same as existing password", async () => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1024 });
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -173,11 +173,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "You are already using that password. Enter a different password"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when no numbers present in password", (done) => {
-    request(app)
+  it("should return validation error when no numbers present in password", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -192,11 +192,11 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when password all numeric", (done) => {
-    request(app)
+  it("should return validation error when password all numeric", async () => {
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -211,15 +211,15 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
           "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /auth-code when valid password entered", (done) => {
+  it("should redirect to /auth-code when valid password entered", async () => {
     nock(baseApi).post("/reset-password").once().reply(204);
     nock(baseApi).post("/login").once().reply(200);
     nock(baseApi).post("/mfa").once().reply(204);
 
-    request(app)
+    await request(app)
       .post(ENDPOINT)
       .type("form")
       .set("Cookie", cookies)
@@ -229,6 +229,6 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
         "confirm-password": "Testpassword1",
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/select-mfa-options/tests/select-mfa-options-integration.test.ts
+++ b/src/components/select-mfa-options/tests/select-mfa-options-integration.test.ts
@@ -35,9 +35,9 @@ describe("Integration::select-mfa-options", () => {
 
     app = await require("../../../app").createApp();
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.GET_SECURITY_CODES)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -53,22 +53,22 @@ describe("Integration::select-mfa-options", () => {
     app = undefined;
   });
 
-  it("should return get security codes page", (done) => {
-    request(app).get(PATH_NAMES.GET_SECURITY_CODES).expect(200, done);
+  it("should return get security codes page", async () => {
+    await request(app).get(PATH_NAMES.GET_SECURITY_CODES).expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.GET_SECURITY_CODES)
       .type("form")
       .send({
         mfaOptions: "SMS",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when mfa option not selected", (done) => {
-    request(app)
+  it("should return validation error when mfa option not selected", async () => {
+    await request(app)
       .post(PATH_NAMES.GET_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -82,11 +82,11 @@ describe("Integration::select-mfa-options", () => {
           "Select how you want to get security codes"
         );
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /setup-authenticator-app page when mfaOptions is AUTH_APP", (done) => {
-    request(app)
+  it("should redirect to /setup-authenticator-app page when mfaOptions is AUTH_APP", async () => {
+    await request(app)
       .post(PATH_NAMES.GET_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -95,11 +95,11 @@ describe("Integration::select-mfa-options", () => {
         mfaOptions: "AUTH_APP",
       })
       .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
-      .expect(302, done);
+      .expect(302);
   });
 
-  it("should redirect to /enter-phone-number page when mfaOptions is SMS", (done) => {
-    request(app)
+  it("should redirect to /enter-phone-number page when mfaOptions is SMS", async () => {
+    await request(app)
       .post(PATH_NAMES.GET_SECURITY_CODES)
       .type("form")
       .set("Cookie", cookies)
@@ -108,6 +108,6 @@ describe("Integration::select-mfa-options", () => {
         mfaOptions: "SMS",
       })
       .expect("Location", PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -43,9 +43,9 @@ describe("Integration::setup-authenticator-app", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -61,24 +61,24 @@ describe("Integration::setup-authenticator-app", () => {
     app = undefined;
   });
 
-  it("should return setup authenticator app page", (done) => {
-    request(app)
+  it("should return setup authenticator app page", async () => {
+    await request(app)
       .get(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
-      .expect(200, done);
+      .expect(200);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
       .type("form")
       .send({
         code: "123456",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should return validation error when access code not entered", (done) => {
-    request(app)
+  it("should return validation error when access code not entered", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
       .type("form")
       .set("Cookie", cookies)
@@ -92,11 +92,11 @@ describe("Integration::setup-authenticator-app", () => {
         );
         expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when access code is too long (more than 6 digits)", (done) => {
-    request(app)
+  it("should return validation error when access code is too long (more than 6 digits)", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
       .type("form")
       .set("Cookie", cookies)
@@ -111,11 +111,11 @@ describe("Integration::setup-authenticator-app", () => {
         );
         expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should return validation error when code has non-digit characters", (done) => {
-    request(app)
+  it("should return validation error when code has non-digit characters", async () => {
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
       .type("form")
       .set("Cookie", cookies)
@@ -130,10 +130,10 @@ describe("Integration::setup-authenticator-app", () => {
         );
         expect($("#secret-key").text()).to.contain(AUTH_APP_SECRET);
       })
-      .expect(400, done);
+      .expect(400);
   });
 
-  it("should redirect to /account-created page when successful validation of code", (done) => {
+  it("should redirect to /account-created page when successful validation of code", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.VERIFY_MFA_CODE)
       .once()
@@ -143,7 +143,7 @@ describe("Integration::setup-authenticator-app", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT, { success: true });
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
       .type("form")
       .set("Cookie", cookies)
@@ -152,6 +152,6 @@ describe("Integration::setup-authenticator-app", () => {
         code: "123456",
       })
       .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -42,9 +42,9 @@ describe("Integration:: updated-terms-code", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    request(app)
+    await request(app)
       .get(PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS)
-      .end((err, res) => {
+      .then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
@@ -60,29 +60,29 @@ describe("Integration:: updated-terms-code", () => {
     app = undefined;
   });
 
-  it("should return update terms and conditions page", (done) => {
-    request(app)
+  it("should return update terms and conditions page", async () => {
+    await request(app)
       .get(PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS)
-      .expect(HTTP_STATUS_CODES.OK, done);
+      .expect(HTTP_STATUS_CODES.OK);
   });
 
-  it("should return error when csrf not present", (done) => {
-    request(app)
+  it("should return error when csrf not present", async () => {
+    await request(app)
       .post(PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS)
       .type("form")
       .send({
         termsAndConditionsResult: "reject",
       })
-      .expect(500, done);
+      .expect(500);
   });
 
-  it("should redirect to /auth_code when terms accepted", (done) => {
+  it("should redirect to /auth_code when terms accepted", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.UPDATE_PROFILE)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    request(app)
+    await request(app)
       .post(PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS)
       .type("form")
       .set("Cookie", cookies)
@@ -91,6 +91,6 @@ describe("Integration:: updated-terms-code", () => {
         termsAndConditionsResult: "accept",
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302, done);
+      .expect(302);
   });
 });

--- a/test/helpers/common-test-variables.ts
+++ b/test/helpers/common-test-variables.ts
@@ -1,3 +1,5 @@
+import { redactPhoneNumber } from "../../src/utils/strings";
+
 export const commonVariables = {
   email: "joe.bloggs@example.com",
   sessionId: "123456-djjad",
@@ -7,4 +9,6 @@ export const commonVariables = {
   apiKey: "apiKey",
   auditEncodedString:
     "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc",
+  testPhoneNumber: "0123456789",
+  testRedactedPhoneNumber: redactPhoneNumber("0123456789"),
 };


### PR DESCRIPTION
## What

Redirect the User back to the RP in a logged out state after they exceed the maximum number of re-requests of SMS security codes when trying to reset their password after starting a re-authentication journey.

<!-- Describe what you have changed and why -->

Updated controller to redirect to orchestration with path parameters that indicate the User should be logged out.  The User is not logged out.

The integration tests were changed to make await async calls to allow them to be run reliably locally.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
