### PR TITLE
BAU: Dependabot should also check sidecar docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,9 @@ updates:
     commit-message:
       prefix: BAU
   - package-ecosystem: docker
-    directory: "/"
+    directories:
+      - "basic-auth-sidecar"
+      - "/"
     schedule:
       interval: daily
       time: "03:00"

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -1,0 +1,15 @@
+name: Validate Dependabot
+
+on:
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/dependabot-validate.yml"
+jobs:
+  validate:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: marocchino/validate-dependabot@d8ae5c0d03dd75fbd0ad5f8ab4ba8101ebbd4b37 # v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,13 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/lalten/check-gha-pinning
+    rev: v1.1.0
+    hooks:
+      - id: check-gha-pinning
+        # Skip git check for now until subdirectory support is added (#1)
+        entry: env GHA_PINNING_SKIP_GIT_CHECK=1 check-gha-pinning
+
   - repo: local
     hooks:
       - id: eslint


### PR DESCRIPTION
## What

- dependabot for docker in sidecar as well
- workflow to validate dependabot config file
- pre-commit hook to ensure that actions are pinned to SHAs, not tags

## How to review

Code Review