### PR TITLE
BAU: Switch reauth off in build and integration

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -14,7 +14,7 @@ alb_idle_timeout = 30
 support_account_recovery                            = "1"
 support_authorize_controller                        = "1"
 support_account_interventions                       = "1"
-support_reauthentication                            = "1"
+support_reauthentication                            = "0"
 support_2fa_b4_password_reset                       = "1"
 support_2hr_lockout                                 = "1"
 support_check_email_fraud                           = "1"
@@ -39,7 +39,7 @@ orch_to_auth_audience           = "https://signin.build.account.gov.uk/"
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-#cloudfront enabled flag 
+#cloudfront enabled flag
 cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 cloudfront_WafAcl_Logdestination = "csls_cw_logs_destination_prodpython"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,7 +2,7 @@ environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 service_down_page   = true
 
-#cloudfront enabled flag 
+#cloudfront enabled flag
 cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 cloudfront_WafAcl_Logdestination = "csls_cw_logs_destination_prodpython"
@@ -16,7 +16,7 @@ support_account_interventions = "1"
 support_authorize_controller  = "1"
 support_2fa_b4_password_reset = "1"
 support_2hr_lockout           = "1"
-support_reauthentication      = "1"
+support_reauthentication      = "0"
 language_toggle_enabled       = "1"
 no_photo_id_contact_forms     = "0"
 


### PR DESCRIPTION
## What

Switch reauth off in build and integration.

- Off in build so that the configuration matches production.
- Off in integration as communicated to HMRC that reauth will not be available while changes are being made.

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/393


