### PR TITLE
AUT-3374: Use env vars and SSM to get redis config

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,7 +18,6 @@ import Backend from "i18next-fs-backend";
 import {
   getLanguageToggleEnabled,
   getNodeEnv,
-  getRedisConfig,
   getSessionExpiry,
   getSessionSecret,
   support2FABeforePasswordReset,
@@ -88,6 +87,7 @@ import { temporarilyBlockedRouter } from "./components/account-intervention/temp
 import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes";
 import { setGTM } from "./middleware/analytics-middleware";
 import { setCurrentUrlMiddleware } from "./middleware/current-url-middleware";
+import { getRedisConfig } from "./utils/redis";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,3 @@
-import { RedisConfig } from "./utils/types";
-import ssm from "./utils/ssm";
-import { Parameter } from "@aws-sdk/client-ssm";
-import { ENVIRONMENT_NAME } from "./app.constants";
-
 export function getLogLevel(): string {
   return process.env.LOGS_LEVEL || "debug";
 }
@@ -39,14 +34,6 @@ export function getGtmId(): string {
   return process.env.GTM_ID;
 }
 
-export function getRedisHost(): string {
-  return process.env.REDIS_HOST ?? "redis";
-}
-
-export function getRedisPort(): number {
-  return Number(process.env.REDIS_PORT) ?? 6379;
-}
-
 export function supportAccountRecovery(): boolean {
   return process.env.SUPPORT_ACCOUNT_RECOVERY === "1";
 }
@@ -57,38 +44,6 @@ export function supportAuthorizeController(): boolean {
 
 export function getSupportLinkUrl(): string {
   return process.env.URL_FOR_SUPPORT_LINKS || "/contact-us";
-}
-
-export async function getRedisConfig(): Promise<RedisConfig> {
-  if (getNodeEnv() !== ENVIRONMENT_NAME.PROD) {
-    return { host: getRedisHost(), port: getRedisPort() };
-  }
-
-  const appEnv = getAppEnv();
-  const hostKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-host`;
-  const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-port`;
-  const passwordKey = `${appEnv}-${process.env.REDIS_KEY}-redis-password`;
-
-  const params = {
-    Names: [hostKey, portKey, passwordKey],
-    WithDecryption: true,
-  };
-
-  const result = await ssm.getParameters(params);
-
-  if (result.InvalidParameters && result.InvalidParameters.length > 0) {
-    throw Error("Invalid SSM config values for redis");
-  }
-
-  return {
-    host: result.Parameters.find((p: Parameter) => p.Name === hostKey).Value,
-    port: Number(
-      result.Parameters.find((p: Parameter) => p.Name === portKey).Value
-    ),
-    password: result.Parameters.find((p: Parameter) => p.Name === passwordKey)
-      .Value,
-    tls: true,
-  };
 }
 
 export function getAwsRegion(): string {

--- a/src/utils/redis.ts
+++ b/src/utils/redis.ts
@@ -1,0 +1,128 @@
+import { Parameter } from "@aws-sdk/client-ssm";
+import { RedisConfig } from "./types";
+import { ENVIRONMENT_NAME } from "../app.constants";
+import ssm from "./ssm";
+import { getAppEnv, getNodeEnv } from "../config";
+import { GetParametersCommandOutput } from "@aws-sdk/client-ssm/dist-types/commands/GetParametersCommand";
+import * as process from "node:process";
+
+function getRedisHost(): string | undefined {
+  return getNodeEnv() !== ENVIRONMENT_NAME.PROD
+    ? (process.env.REDIS_HOST ?? "redis")
+    : process.env.REDIS_HOST;
+}
+
+function getRedisPort(): string | undefined {
+  return getNodeEnv() !== ENVIRONMENT_NAME.PROD
+    ? (process.env.REDIS_PORT ?? "6379")
+    : process.env.REDIS_PORT;
+}
+
+function getRedisPassword(): string | undefined {
+  return process.env.REDIS_PASSWORD;
+}
+
+export async function getRedisConfig(): Promise<RedisConfig> {
+  let redisHost: string | undefined = getRedisHost();
+  let redisPort: string | undefined = getRedisPort();
+  let redisPassword: string | undefined = getRedisPassword();
+  if (getNodeEnv() !== ENVIRONMENT_NAME.PROD) {
+    return { host: getRedisHost(), port: Number(getRedisPort()) };
+  }
+
+  if (redisHost && redisPort && redisPassword) {
+    return {
+      host: redisHost,
+      port: Number(redisPort),
+      password: redisPassword,
+      tls: true,
+    };
+  }
+
+  const { hostKey, portKey, passwordKey } = getRedisKeys();
+
+  const ssmParams: string[] = [];
+
+  if (!redisHost) {
+    ssmParams.push(hostKey);
+  }
+  if (!redisPort) {
+    ssmParams.push(portKey);
+  }
+  if (!redisPassword) {
+    ssmParams.push(passwordKey);
+  }
+
+  if (ssmParams.length !== 0) {
+    const result = await fetchParametersFromSSM(ssmParams);
+
+    if (ssmParams.includes(hostKey)) {
+      redisHost = getValueFromSSMResult(result, hostKey);
+    }
+    if (ssmParams.includes(portKey)) {
+      redisPort = getValueFromSSMResult(result, portKey);
+    }
+    if (ssmParams.includes(passwordKey)) {
+      redisPassword = getValueFromSSMResult(result, passwordKey);
+    }
+  }
+
+  return {
+    host: redisHost,
+    port: Number(redisPort),
+    password: redisPassword,
+    tls: true,
+  };
+}
+
+function getRedisKeys(): {
+  hostKey: string;
+  portKey: string;
+  passwordKey: string;
+} {
+  const appEnv = getAppEnv();
+  const redisKey = process.env.REDIS_KEY;
+  if (!process.env.REDIS_KEY) {
+    throw Error("There is no REDIS_KEY present in env variables");
+  }
+  return {
+    hostKey: `${appEnv}-${redisKey}-redis-master-host`,
+    portKey: `${appEnv}-${redisKey}-redis-port`,
+    passwordKey: `${appEnv}-${redisKey}-redis-password`,
+  };
+}
+
+function getValueFromSSMResult(
+  result: { Parameters?: Parameter[] },
+  key: string
+): string {
+  const maybeValue = result.Parameters?.find(
+    (p: Parameter) => p.Name === key
+  )?.Value;
+  if (maybeValue === undefined) {
+    throw Error(`Expected to find key ${key} in ssm parameters`);
+  } else {
+    return maybeValue;
+  }
+}
+
+async function fetchParametersFromSSM(
+  ssmParams: string[]
+): Promise<GetParametersCommandOutput> {
+  const params = {
+    Names: ssmParams,
+    WithDecryption: true,
+  };
+
+  const result = await ssm.getParameters(params);
+
+  if (result.InvalidParameters && result.InvalidParameters.length > 0) {
+    throw Error("Invalid SSM config values for redis");
+  }
+
+  return result;
+}
+
+module.exports = {
+  getRedisConfig,
+};

--- a/test/unit/utils/redis.test.ts
+++ b/test/unit/utils/redis.test.ts
@@ -1,0 +1,144 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { ENVIRONMENT_NAME } from "../../../src/app.constants";
+import { sinon } from "../../../test/utils/test-utils";
+import ssm from "../../../src/utils/ssm";
+import { getRedisConfig } from "../../../src/utils/redis";
+
+describe("get correct redis config values", () => {
+  let getParametersStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    process.env.REDIS_KEY = "redis-key";
+    process.env.APP_ENV = "test";
+    getParametersStub = sinon.stub(ssm, "getParameters");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    delete process.env.REDIS_HOST;
+    delete process.env.REDIS_PORT;
+    delete process.env.REDIS_PASSWORD;
+  });
+
+  it("should return expected host and port only when not in prod", async () => {
+    process.env.REDIS_HOST = "expected_redis_host";
+    process.env.REDIS_PORT = "1234";
+    process.env.NODE_ENV = ENVIRONMENT_NAME.DEV;
+
+    const redisConfig = await getRedisConfig();
+
+    expect(redisConfig.host).to.eql("expected_redis_host");
+    expect(redisConfig.port).to.eql(1234);
+  });
+
+  describe("should return correct values when in prod", () => {
+    it("should get correct values from env vars when present", async () => {
+      process.env.NODE_ENV = ENVIRONMENT_NAME.PROD;
+      process.env.REDIS_HOST = "expected_redis_host";
+      process.env.REDIS_PORT = "1234";
+      process.env.REDIS_PASSWORD = "expected_redis_password";
+
+      const redisConfig = await getRedisConfig();
+
+      expect(redisConfig.host).to.equal("expected_redis_host");
+      expect(redisConfig.port).to.equal(1234);
+      expect(redisConfig.password).to.equal("expected_redis_password");
+      expect(redisConfig.tls).to.equal(true);
+    });
+
+    it("should get values from SSM when no env vars are present", async () => {
+      process.env.NODE_ENV = ENVIRONMENT_NAME.PROD;
+
+      getParametersStub.resolves({
+        $metadata: undefined,
+        InvalidParameters: [],
+        Parameters: [
+          {
+            Name: "test-redis-key-redis-master-host",
+            Type: "String",
+            Value: "hostValue",
+          },
+          { Name: "test-redis-key-redis-port", Type: "String", Value: "1234" },
+          {
+            Name: "test-redis-key-redis-password",
+            Type: "String",
+            Value: "passwordValue",
+          },
+        ],
+      });
+
+      const redisConfig = await getRedisConfig();
+
+      expect(redisConfig).to.eql({
+        host: "hostValue",
+        port: 1234,
+        password: "passwordValue",
+        tls: true,
+      });
+    });
+
+    it("should throw error when invalid parameters are used to get ssm values", async () => {
+      process.env.NODE_ENV = ENVIRONMENT_NAME.PROD;
+
+      getParametersStub.resolves({
+        $metadata: undefined,
+        InvalidParameters: [
+          "invalid-redis-host",
+          "invalid-redis-port",
+          "invalid-redis-password",
+        ],
+        Parameters: [],
+      });
+
+      try {
+        await getRedisConfig();
+      } catch (error) {
+        expect(error).to.be.an("error");
+        expect(error.message).to.be.equal(
+          "Invalid SSM config values for redis"
+        );
+      }
+    });
+
+    it("should throw error when result does not contain expected ssm parameter", async () => {
+      process.env.NODE_ENV = ENVIRONMENT_NAME.PROD;
+
+      getParametersStub.resolves({
+        $metadata: undefined,
+        InvalidParameters: [],
+        Parameters: [
+          {
+            Name: "test-redis-key-redis-master-host",
+            Type: "String",
+            Value: "hostValue",
+          },
+          { Name: "test-redis-key-redis-port", Type: "String", Value: "1234" },
+        ],
+      });
+
+      try {
+        await getRedisConfig();
+      } catch (error) {
+        expect(error).to.be.an("error");
+        expect(error.message).to.be.equal(
+          "Expected to find key test-redis-key-redis-password in ssm parameters"
+        );
+      }
+    });
+
+    it("should throw error when invalid parameters are used to get ssm values", async () => {
+      process.env.NODE_ENV = ENVIRONMENT_NAME.PROD;
+      delete process.env.REDIS_KEY;
+
+      try {
+        await getRedisConfig();
+      } catch (error) {
+        expect(error).to.be.an("error");
+        expect(error.message).to.be.equal(
+          "There is no REDIS_KEY present in env variables"
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

- Moved logic associated with getting redis config to redis.ts
- When getting redis config, we first look for environment variables, then look for parameters in SSM
- If environment variables are not found in DEV environment, default values for 'host' and 'port' are returned
- If environment variables are not found in PROD, we try to get parameters from SSM

## Why

The frontend currently uses SSM to retrieve the parameters for establishing a connection to elasticache (redis).  The frontend should be modified to look for these values in environment variables instead.  The environment variables will be obfuscated when viewed in the console so there is no security issue using them.

The change should be written is such a way that the frontend will fallback to using SSM if the environment variables aren’t present.  This will allow it to be deployed via the old and the new pipeline.

## How to review

1. Code Review

Should be very careful about this PR, as changes primarily only effect production


