### PR TITLE
AUT-3401: Replace auto refresh with HTML form

### DIFF
--- a/src/components/prove-identity-callback/index-new-spinner.njk
+++ b/src/components/prove-identity-callback/index-new-spinner.njk
@@ -2,21 +2,35 @@
 {% set pageTitleName = 'pages.proveIdentityCheckNew.htmlOnlyVersion.title' | translate %}
 
 {% block content %}
-
-    <form action="/ipv-callback" method="post" novalidate="novalidate">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-        <div class="govuk-form-group">
-            <h1 class="govuk-label-wrapper">
-                <label class="govuk-label govuk-label--l" for="more-detail">
-                    {{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.header' | translate }}
-                </label>
-            </h1>
-            <p class="govuk-body">{{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.paragraph' | translate }}</p>
-            <button type="submit" class="govuk-button">
-                {{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.button' | translate }}
-            </button>
-        </div>
-    </form>
+    <div id="spinner-container"
+         data-initial-heading="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.heading' | translate + serviceName }}"
+         data-initial-spinnerStateText="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.spinnerStateText' | translate }}"
+         data-initial-spinnerState="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.spinnerState' | translate }}"
+         data-error-heading="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.heading' | translate }}"
+         data-error-messageText="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.messageText' | translate }}"
+         data-error-whatYouCanDo-heading="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.whatYouCanDo.heading' | translate }}"
+         data-error-whatYouCanDo-message-text1="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.whatYouCanDo.message.text1' | translate }}"
+         data-error-whatYouCanDo-message-link-href="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.whatYouCanDo.message.link.href' | translate }}"
+         data-error-whatYouCanDo-message-link-text="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.whatYouCanDo.message.link.text' | translate }}"
+         data-error-whatYouCanDo-message-text2="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.whatYouCanDo.message.text2' | translate }}"
+         data-complete-spinnerState="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.complete.spinnerState' | translate }}"
+         data-longWait-spinnerStateText="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.longWait.spinnerStateText' | translate }}"
+    >
+        <form action="/ipv-callback" method="post" novalidate="novalidate">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            <div class="govuk-form-group">
+                <h1 class="govuk-label-wrapper">
+                    <label class="govuk-label govuk-label--l" for="more-detail">
+                        {{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.header' | translate }}
+                    </label>
+                </h1>
+                <p class="govuk-body">{{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.paragraph' | translate }}</p>
+                <button type="submit" class="govuk-button">
+                    {{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.button' | translate }}
+                </button>
+            </div>
+        </form>
+    </div>
 
     {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false }) }}
 

--- a/src/components/prove-identity-callback/index-new-spinner.njk
+++ b/src/components/prove-identity-callback/index-new-spinner.njk
@@ -1,0 +1,23 @@
+{% extends "common/layout/base.njk" %}
+{% set pageTitleName = 'pages.proveIdentityCheckNew.htmlOnlyVersion.title' | translate %}
+
+{% block content %}
+
+    <form action="/ipv-callback" method="post" novalidate="novalidate">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <div class="govuk-form-group">
+            <h1 class="govuk-label-wrapper">
+                <label class="govuk-label govuk-label--l" for="more-detail">
+                    {{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.header' | translate }}
+                </label>
+            </h1>
+            <p class="govuk-body">{{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.paragraph' | translate }}</p>
+            <button type="submit" class="govuk-button">
+                {{ 'pages.proveIdentityCheckNew.htmlOnlyVersion.button' | translate }}
+            </button>
+        </div>
+    </form>
+
+    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false }) }}
+
+{% endblock %}

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -13,8 +13,9 @@ import {
   OIDC_ERRORS,
 } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
+import { supportNewIpvSpinner } from "../../config";
 
-export function proveIdentityCallbackGet(
+export function proveIdentityCallbackGetOrPost(
   service: ProveIdentityCallbackServiceInterface = proveIdentityCallbackService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
@@ -35,6 +36,10 @@ export function proveIdentityCallbackGet(
     }
 
     if (response.data.status === IdentityProcessingStatus.PROCESSING) {
+      if (supportNewIpvSpinner()) {
+        return res.render("prove-identity-callback/index-new-spinner.njk");
+      }
+
       return res.render("prove-identity-callback/index.njk", {
         serviceName: clientName,
       });

--- a/src/components/prove-identity-callback/prove-identity-callback-routes.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-routes.ts
@@ -4,7 +4,7 @@ import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import {
-  proveIdentityCallbackGet,
+  proveIdentityCallbackGetOrPost,
   proveIdentityCallbackSessionExpiryError,
   proveIdentityStatusCallbackGet,
 } from "./prove-identity-callback-controller";
@@ -18,7 +18,15 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   processIdentityRateLimitMiddleware,
-  asyncHandler(proveIdentityCallbackGet())
+  asyncHandler(proveIdentityCallbackGetOrPost())
+);
+
+router.post(
+  PATH_NAMES.PROVE_IDENTITY_CALLBACK,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  processIdentityRateLimitMiddleware,
+  asyncHandler(proveIdentityCallbackGetOrPost())
 );
 
 router.get(

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../app.constants";
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import {
-  proveIdentityCallbackGet,
+  proveIdentityCallbackGetOrPost,
   proveIdentityStatusCallbackGet,
 } from "../prove-identity-callback-controller";
 import {
@@ -52,7 +52,7 @@ describe("prove identity callback controller", () => {
           },
         }),
       } as unknown as ProveIdentityCallbackServiceInterface;
-      await proveIdentityCallbackGet(fakeProveIdentityService)(
+      await proveIdentityCallbackGetOrPost(fakeProveIdentityService)(
         req as Request,
         res as Response
       );
@@ -70,7 +70,7 @@ describe("prove identity callback controller", () => {
         }),
       } as unknown as ProveIdentityCallbackServiceInterface;
 
-      await proveIdentityCallbackGet(fakeProveIdentityService)(
+      await proveIdentityCallbackGetOrPost(fakeProveIdentityService)(
         req as Request,
         res as Response
       );
@@ -78,6 +78,31 @@ describe("prove identity callback controller", () => {
       expect(res.render).to.have.been.calledWith(
         "prove-identity-callback/index.njk"
       );
+    });
+
+    describe("when the SUPPORT_NEW_IPV_SPINNER feature flag is enabled", () => {
+      it("should use the index-new-spinner template when the feature flag is enabled", async () => {
+        process.env.SUPPORT_NEW_IPV_SPINNER = "1";
+
+        const fakeProveIdentityService: ProveIdentityCallbackServiceInterface =
+          {
+            processIdentity: sinon.fake.returns({
+              success: true,
+              data: {
+                status: IdentityProcessingStatus.PROCESSING,
+              },
+            }),
+          } as unknown as ProveIdentityCallbackServiceInterface;
+
+        await proveIdentityCallbackGetOrPost(fakeProveIdentityService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(res.render).to.have.been.calledWith(
+          "prove-identity-callback/index-new-spinner.njk"
+        );
+      });
     });
 
     it("should redirect back to service when identity processing has errored", async () => {
@@ -90,7 +115,7 @@ describe("prove identity callback controller", () => {
         }),
       } as unknown as ProveIdentityCallbackServiceInterface;
 
-      await proveIdentityCallbackGet(fakeProveIdentityService)(
+      await proveIdentityCallbackGetOrPost(fakeProveIdentityService)(
         req as Request,
         res as Response
       );
@@ -116,7 +141,7 @@ describe("prove identity callback controller", () => {
         }),
       } as unknown as ProveIdentityCallbackServiceInterface;
 
-      await proveIdentityCallbackGet(fakeProveIdentityService)(
+      await proveIdentityCallbackGetOrPost(fakeProveIdentityService)(
         req as Request,
         res as Response
       );

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2353,10 +2353,38 @@
     },
     "proveIdentityCheckNew": {
       "htmlOnlyVersion": {
-        "title": "Mae oedi cyn eich dychwelyd i’r gwasanaeth",
-        "header": "Mae oedi cyn eich dychwelyd i’r gwasanaeth",
-        "paragraph": "Ceisiwch barhau i’r gwasanaeth eto.",
-        "button": "Parhau i’r gwasanaeth"
+        "title": "Mae oedi cyn eich dychwelyd i`r gwasanaeth",
+        "header": "Mae oedi cyn eich dychwelyd i`r gwasanaeth",
+        "paragraph": "Ceisiwch barhau i`r gwasanaeth eto.",
+        "button": "Parhau i`r gwasanaeth"
+      },
+      "progressivelyEnhancedVersion": {
+        "initial": {
+          "heading": "Yn eich dychwelyd i ",
+          "spinnerStateText": "Aros i gael eich dychwelyd i`r gwasanaeth",
+          "spinnerState": "aros"
+        },
+        "error": {
+          "heading": "Sori, mae yna broblem",
+          "messageText": "Ni allwn eich dychwelyd at y gwasanaeth ar hyn o bryd.",
+          "whatYouCanDo": {
+            "heading": "Beth allwch ei wneud",
+            "message": {
+              "text1": "Ewch yn ôl i`r gwasanaeth yr oeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio`ch peiriant chwilio neu ddod o hyd iddo o`r ",
+              "link": {
+                "href": "GOV.UK",
+                "text": "hafan GOV.UK"
+              },
+              "text2": "."
+            }
+          }
+        },
+        "complete": {
+          "spinnerState": "Gallwch nawr barhau i`r gwasanaeth"
+        },
+        "longWait": {
+          "spinnerStateText": "Rydym yn dal i geisio eich dychwelyd i`r gwasanaeth"
+        }
       }
     },
     "getSecurityCodes": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2351,6 +2351,14 @@
       "paragraph1": "Arhoswch",
       "paragraph2": "Rydym yn dal i geisio"
     },
+    "proveIdentityCheckNew": {
+      "htmlOnlyVersion": {
+        "title": "Mae oedi cyn eich dychwelyd i’r gwasanaeth",
+        "header": "Mae oedi cyn eich dychwelyd i’r gwasanaeth",
+        "paragraph": "Ceisiwch barhau i’r gwasanaeth eto.",
+        "button": "Parhau i’r gwasanaeth"
+      }
+    },
     "getSecurityCodes": {
       "title": "Dewis sut i gael codau diogelwch",
       "header": "Dewis sut i gael codau diogelwch",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2351,6 +2351,14 @@
       "paragraph1": "Please wait",
       "paragraph2": "We’re still trying"
     },
+    "proveIdentityCheckNew": {
+      "htmlOnlyVersion": {
+        "title": "There is a delay returning you to the service",
+        "header": "There is a delay returning you to the service",
+        "paragraph": "Try to continue to the service again.",
+        "button": "Continue to the service"
+      }
+    },
     "getSecurityCodes": {
       "title": "Choose how to get security codes",
       "header": "Choose how to get security codes",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2357,6 +2357,34 @@
         "header": "There is a delay returning you to the service",
         "paragraph": "Try to continue to the service again.",
         "button": "Continue to the service"
+      },
+      "progressivelyEnhancedVersion": {
+        "initial": {
+          "heading": "Returning you to ",
+          "spinnerStateText": "Wait to be returned to the service",
+          "spinnerState": "pending"
+        },
+        "error": {
+          "heading": "Sorry, there is a problem",
+          "messageText": "We cannot return you to the service at the moment.",
+          "whatYouCanDo": {
+            "heading": "What you can do",
+            "message": {
+              "text1": "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the ",
+              "link": {
+                "href": "GOV.UK",
+                "text": "GOV.UK homepage"
+              },
+              "text2": "."
+            }
+          }
+        },
+        "complete": {
+          "spinnerState": "You can now continue to the service"
+        },
+        "longWait": {
+          "spinnerStateText": "Were still trying to return you to the service"
+        }
       }
     },
     "getSecurityCodes": {


### PR DESCRIPTION
## What

This fixes the accessibility issue arising from automatic page refreshes by introducing a form that will instead allow the user to refresh the page when they are ready to do so. Bear in mind that this HTML-only version of the page will <mark>only be presented to those users who do not have access to client-side JavaScript</mark>: users with access to JavaScript will see the page as enhanced by the spinner.

For the time-being, this new form is behind a feature flag. 

Rather than creating a new controller method, it seemed sensible to repurpose the existing method to handle both `GET` and `POST` requests, but I'd be happy to introduce a new handler if the reviewer feels that would be best. 

### Screenshots 

<details>
<summary>English</summary>
<img width="391" alt="Screenshot 2024-07-25 at 11 52 37" src="https://github.com/user-attachments/assets/ebd1f7e8-335f-4a84-8921-7ca6086918b1">
</details>

<details>
<summary>Welsh</summary>
<img width="391" alt="Screenshot 2024-07-25 at 11 52 54" src="https://github.com/user-attachments/assets/25c66249-5380-44c2-97b3-955db0038a55">
</details>

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.

## Related PRs

- The relevant feature flag was introduced in https://github.com/govuk-one-login/authentication-frontend/pull/1844
