### PR TITLE
AUT-3090: Add switch to enable http keepalive on axios, switch on in staging

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -195,6 +195,10 @@ locals {
       {
         name  = "SUPPORT_NEW_IPV_SPINNER"
         value = var.support_new_ipv_spinner
+      },
+      {
+        name  = "SUPPORT_HTTP_KEEP_ALIVE"
+        value = var.support_http_keep_alive
       }
     ]
 

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -29,6 +29,7 @@ support_reauthentication                            = "1"
 language_toggle_enabled                             = "1"
 no_photo_id_contact_forms                           = "1"
 support_new_ipv_spinner                             = "1"
+support_http_keep_alive                             = "1"
 
 url_for_support_links = "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -402,3 +402,9 @@ variable "support_new_ipv_spinner" {
   default     = "0"
   description = "Enables the new IPV spinner page"
 }
+
+variable "support_http_keep_alive" {
+  type        = string
+  default     = "0"
+  description = "Switch on http keep alive for axios"
+}

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -95,6 +95,7 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
             "NO_PHOTO_ID_CONTACT_FORMS": 1,
             "LANGUAGE_TOGGLE_ENABLED": 1,
             "SUPPORT_NEW_IPV_SPINNER": 1,
+            "SUPPORT_HTTP_KEEP_ALIVE": 0,
         },
     },
     {

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,3 +176,6 @@ export function proveIdentityWelcomeEnabled(): boolean {
 export function supportNewIpvSpinner(): boolean {
   return process.env.SUPPORT_NEW_IPV_SPINNER === "1";
 }
+export function supportHttpKeepAlive(): boolean {
+  return process.env.SUPPORT_HTTP_KEEP_ALIVE === "1";
+}

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -4,14 +4,20 @@ import axios, {
   AxiosError,
   AxiosResponse,
   AxiosRequestHeaders,
+  CreateAxiosDefaults,
 } from "axios";
-import { getApiKey, getFrontendApiBaseUrl } from "../config";
+import {
+  getApiKey,
+  getFrontendApiBaseUrl,
+  supportHttpKeepAlive,
+} from "../config";
 import { ApiResponseResult } from "../types";
 import { HTTP_STATUS_CODES } from "../app.constants";
 import { ApiError } from "./error";
 import { Request } from "express";
 import { createPersonalDataHeaders } from "@govuk-one-login/frontend-passthrough-headers";
 import { logger } from "./logger";
+import { Agent } from "https";
 
 interface CustomAxiosRequestHeaders extends Partial<AxiosRequestHeaders> {}
 
@@ -136,6 +142,7 @@ export class Http {
           status <= HTTP_STATUS_CODES.BAD_REQUEST
         );
       },
+      ...getAdditionalAxiosConfig(),
     });
 
     http.interceptors.response.use(
@@ -146,6 +153,12 @@ export class Http {
     this.instance = http;
     return http;
   }
+}
+
+export function getAdditionalAxiosConfig(): CreateAxiosDefaults {
+  return supportHttpKeepAlive()
+    ? { httpsAgent: new Agent({ keepAlive: true }) }
+    : {};
 }
 
 export const http = new Http();

--- a/test/unit/utils/http.test.ts
+++ b/test/unit/utils/http.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { getInternalRequestConfigWithSecurityHeaders } from "../../../src/utils/http";
+import {
+  getAdditionalAxiosConfig,
+  getInternalRequestConfigWithSecurityHeaders,
+} from "../../../src/utils/http";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../../src/app.constants";
 import { createMockRequest } from "../../helpers/mock-request-helper";
 const headersLibrary = require("@govuk-one-login/frontend-passthrough-headers");
@@ -179,5 +182,21 @@ describe("getInternalRequestConfigWithSecurityHeaders", () => {
     expect(actualConfig.validateStatus(HTTP_STATUS_CODES.BAD_REQUEST)).to.eq(
       false
     );
+  });
+});
+
+describe("getAdditionalAxiosConfig", () => {
+  it("should return empty additional config when the http keep alive switch is off", () => {
+    process.env.SUPPORT_HTTP_KEEP_ALIVE = "0";
+    const additionalConfig = getAdditionalAxiosConfig();
+    expect(additionalConfig).to.be.empty;
+    delete process.env.SUPPORT_HTTP_KEEP_ALIVE;
+  });
+
+  it("should return an httpsAgent with keep alive when the http keep alive switch is on", () => {
+    process.env.SUPPORT_HTTP_KEEP_ALIVE = "1";
+    const additionalConfig = getAdditionalAxiosConfig();
+    expect(additionalConfig.httpsAgent.keepAlive).to.eq(true);
+    delete process.env.SUPPORT_HTTP_KEEP_ALIVE;
   });
 });


### PR DESCRIPTION
## What

Add switch to enable http keepalive on axios.

There are potential performance gains from using http keepalive.  This needs to go through performance test to see if it makes a difference, so has been added behind a feature switch.

Feature to be proven as part of a performance test run in staging, so will only be enabled in the staging environment.

## How to review

1. Code Review
2. Local running with the switch on and off to prove that axios calls are working.