### PR TITLE
BAU: Turn off new IPV spinner in integration

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -19,7 +19,7 @@ support_2hr_lockout           = "1"
 support_reauthentication      = "0"
 language_toggle_enabled       = "1"
 no_photo_id_contact_forms     = "0"
-support_new_ipv_spinner       = "1"
+support_new_ipv_spinner       = "0"
 
 code_request_blocked_minutes                        = "120"
 account_recovery_code_entered_wrong_blocked_minutes = "120"


### PR DESCRIPTION
## What

The feature flag introduced in AUT-3390 should not have been enabled in the integration environment (see #1844 for the original PR). This PR turns off the feature flag.

## How to review

Code review

## Related PRs

* https://github.com/govuk-one-login/authentication-frontend/pull/1844 - Added the feature flag
* https://github.com/govuk-one-login/authentication-frontend/pull/1869 - Linked the feature flag to the presentation of the new page

