### PR TITLE
AUT-3407: Add spinner dependency

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -15,3 +15,6 @@ a751091323cf41b551c88234d0566796ebd9e97e
 
 # Trim trailing whitespaces
 518d7cfef9978d9227ff6b1d9b58a214f7c76372
+
+## Reformatting of application.scss
+6e3fa129585afd17adc627e02cc0fc79ab6c82e2

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "^0.0.3",
+    "@govuk-one-login/spinner": "^1.0.1",
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-base32-enc-dec": "^12.0.1",
     "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-sass": "rm -rf dist/public/style.css && sass --load-path=node_modules/govuk-frontend/govuk --no-source-map --quiet-deps src/assets/scss/application.scss dist/public/style.css --style compressed",
     "clean": "rm -rf dist node_modules logs.json",
     "clean-modules": "rm -rf node_modules",
-    "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts -e **/all.js && cp node_modules/govuk-frontend/govuk/all.js dist/public/scripts && cp node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js dist/public/scripts",
+    "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts -e **/all.js && cp node_modules/govuk-frontend/govuk/all.js dist/public/scripts && cp node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js dist/public/scripts && cp node_modules/@govuk-one-login/spinner/spinner-app.js dist/public/scripts",
     "dev": "tsc && concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\"",
     "dummy-server": "node dev-app.js | pino-pretty",
     "depcheck": "depcheck",

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -63,7 +63,7 @@
   background: none;
   cursor: pointer;
   color: #ffffff;
-  box-shadow: 0px 1px #ffffff;
+  box-shadow: 0 1px #ffffff;
   padding: 0;
 }
 
@@ -74,11 +74,11 @@
   background: none;
   padding: 0;
   color: $govuk-link-colour;
-  box-shadow: 0px 1px #ffffff;
-  margin:0;
+  box-shadow: 0 1px #ffffff;
+  margin: 0;
 }
 
-.govuk-btn-as-link:hover{
+.govuk-btn-as-link:hover {
   background: none;
   color: $govuk-link-visited-colour;
   text-decoration: underline;
@@ -91,7 +91,7 @@
 .inverted-button {
   background-color: #ffffff;
   color: #0b0c0c;
-  box-shadow: 0 2px 0 #B1B4B6;
+  box-shadow: 0 2px 0 #b1b4b6;
   font-weight: bold;
 }
 
@@ -183,29 +183,39 @@
 }
 
 .ccms-loader {
-  border: 12px solid #DEE0E2;
+  border: 12px solid #dee0e2;
   border-radius: 50%;
-  border-top-color: #005EA5;
+  border-top-color: #005ea5;
   width: 80px;
   height: 80px;
   -webkit-animation: spin 2s linear infinite;
   animation: spin 2s linear infinite;
 }
+
 @-webkit-keyframes spin {
-  0% { -webkit-transform: rotate(0deg); }
-  100% { -webkit-transform: rotate(360deg); }
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
 }
+
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
-.centre{
-  margin-left:auto;
-  margin-right:auto;
+.centre {
+  margin-left: auto;
+  margin-right: auto;
 }
 
-.text-centre{
+.text-centre {
   text-align: center;
 }
 

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -25,6 +25,7 @@
 @import "components/warning-text/warning-text";
 
 @import "../../../node_modules/@govuk-one-login/frontend-language-toggle/stylesheet/styles";
+@import "prove-identity-callback/spinner";
 
 .interrupt-screen {
   background-color: #1d70b8;

--- a/src/assets/scss/prove-identity-callback/spinner.scss
+++ b/src/assets/scss/prove-identity-callback/spinner.scss
@@ -1,0 +1,64 @@
+.spinner {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border-width: 12px;
+  border-style: solid;
+  border-color: #dee0e2;
+  border-top-color: #005ea5;
+  margin-bottom: govuk-spacing(3);
+
+  @media (forced-colors: active) {
+    forced-color-adjust: none;
+    border-top-color: transparent !important;
+  }
+
+  @media not (prefers-reduced-motion) {
+    -webkit-animation: spin 2s linear infinite;
+    animation: spin 2s linear infinite;
+  }
+
+  @media (prefers-reduced-motion) {
+    transform: rotate(0.125turn);
+  }
+
+  &__ready {
+    border-color: #005ea5;
+    -webkit-animation: none;
+    animation: none;
+  }
+}
+
+.spinner-container {
+  &__error {
+    .spinner,
+    .spinner-state-text {
+      display: none;
+    }
+  }
+}
+
+@-webkit-keyframes spin {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.centre {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+  display: block;
+}

--- a/src/components/prove-identity-callback/index-new-spinner.njk
+++ b/src/components/prove-identity-callback/index-new-spinner.njk
@@ -35,3 +35,7 @@
     {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false }) }}
 
 {% endblock %}
+
+{% block scripts %}
+    <script defer type="text/javascript" src="/public/scripts/spinner-app.js"></script>
+{% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,6 +1204,11 @@
     forwarded-parse "^2.1.2"
     pino "^8.20.0"
 
+"@govuk-one-login/spinner@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/spinner/-/spinner-1.0.1.tgz#62a18e68440154244dee7b4319e4eff8988e6b3a"
+  integrity sha512-oDVYmLx9DSgnDCLuJFqtuNijYlj57u+RI3hLFkOPR9fA4APaei9865z7A8hZ6V3/Yba7lVMRX09lFEAc9/VHUw==
+
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz"


### PR DESCRIPTION
## What

Adds JavaScript and Sass to enable the new spinner. This includes: 

- [x] Adding the NPM package as a dependency
- [x] Updating the `copy-assets` task to bring `spinner-app.js` across the the `scripts` directory
- [x] Updating the Nunjucks template to include the script
- [x] Adding the Sass for the spinner to `application.sass` for inclusion in bundled CSS.

Once merged the spinner page will be enabled in environments where the feature flag is enabled, allowing for testing in `staging`.

## How to review

Code Review commit-by-commit. Two commits are prefixed with "BAU" because they relate to a formatting change.

## Related PRs

* https://github.com/govuk-one-login/authentication-frontend/pull/1904
* https://github.com/govuk-one-login/authentication-frontend/pull/1869
* https://github.com/govuk-one-login/authentication-frontend/pull/1844


