### PR TITLE
BAU: improve frontend build and deployment

### DIFF
--- a/.github/workflows/build-deploy-frontend-dev.yml
+++ b/.github/workflows/build-deploy-frontend-dev.yml
@@ -1,12 +1,4 @@
 name: Build and deploy frontend Dev
-env:
-  AWS_REGION: eu-west-2
-  DEPLOYER_ROLE: arn:aws:iam::706615647326:role/deployers/dev-github-actions-publish-to-s3-for-code-signing
-  DEV_GHA_DEPLOYER_ROLE: arn:aws:iam::653994557586:role/dev-auth-deploy-pipeline-GitHubActionsRole-QrtGginNnjDD
-  DEV_TOOLING_ECR_FRONTEND_REPO: frontend-image-repository
-  DEV_BASIC_SIDECAR_ECR_REPO: basic-auth-sidecar-image-repository
-  DEV_ARTIFACT_BUCKET: dev-auth-deploy-pipeline-githubartifactsourcebuck-ssdefc91xjh6
-  DEV_SERVICE_DOWN_ECR_REPO: service-down-page-image-repository
 
 on:
   workflow_dispatch:
@@ -14,155 +6,57 @@ on:
 jobs:
   pr-data:
     name: Get data for merged PR
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      data: ${{ steps.get_pr_data.outputs.result }}
-    steps:
-      - name: Get PR data
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        id: get_pr_data
-        with:
-          script: |
-            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
-                repository(owner: $owner, name: $name) {
-                  object(oid: $oid) {
-                    ... on Commit {
-                      oid
-                      message
-                      associatedPullRequests(first: 1) {
-                        nodes {
-                          number
-                          title
-                          merged
-                          mergedAt
-                          mergeCommit {
-                            oid
-                          }
-                        }
-                      }
-                    }
-                  }
-                  owner {
-                    login
-                  }
-                  name
-                  nameWithOwner
-                }
-              }`
-            const variables = {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                oid: context.sha,
-                shortSha: context.sha.slice(0, 7),
-            }
+    uses: ./.github/workflows/call_get_pr_data.yml
 
-            const result = await github.graphql(query, variables).then((response) => {
-                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
-                const res = {
-                    pr_number: null,
-                    pr_title: null,
-                    pr_merged_at: null,
-                    pr_merge_commit_sha: null,
-
-                    commit_message: firstLineOfCommitMessage,
-
-                    repo_full_name: response.repository.nameWithOwner,
-                    repo_owner: response.repository.owner.login,
-                    repo_name: response.repository.name,
-
-                    repository: response.repository.nameWithOwner,
-                    commitsha: context.sha,
-                    commitmessage: firstLineOfCommitMessage,
-                }
-                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
-
-                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
-                    const prData = response.repository.object.associatedPullRequests.nodes[0];
-                    res.pr_number = prData.number.toString();
-                    res.pr_title = prData.title;
-                    res.pr_merged_at = prData.mergedAt;
-                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
-                    res.commitmessage = prData.title;
-
-                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
-                }
-
-                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
-                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
-                }
-
-                return res;
-            }).catch((error) => {
-                throw error;
-            });
-
-            for (const key in result) {
-                if (result[key] == null) {
-                    result[key] = "";
-                }
-                // strip non-ascii characters from all values
-                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
-            }
-
-            console.log(result);
-            return result;
-
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  build-frontend:
+    name: Build and push Frontend
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Assume AWS DEPLOYER role in tooling acct
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ env.DEPLOYER_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-      - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
-        with:
-          registry: khw46367.live.dynatrace.com
-          username: khw46367
-          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
-      - name: Build, tag, and push frontend
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ env.DEV_TOOLING_ECR_FRONTEND_REPO }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" .
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-      - name: Build, tag, and push basic-auth-sidecar
-        working-directory: basic-auth-sidecar
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ env.DEV_BASIC_SIDECAR_ECR_REPO }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" .
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-      - name: Build, tag, and push service down page
-        working-directory: service-down-page-config
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ env.DEV_SERVICE_DOWN_ECR_REPO }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker build -t "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" .
-          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
+    uses: ./.github/workflows/call_build-push-docker-image.yml
+    with:
+      aws-region: eu-west-2
+    secrets:
+      dynatrace_registry: ${{ secrets.DYNATRACE_REGISTRY_NAME }}
+      dynatrace_token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      deployer_role: ${{ secrets.DEV_DEPLOYER_ROLE }}
+      ecr_repo: ${{ secrets.DEV_TOOLING_ECR_FRONTEND_REPO }}
+  build-sidecar:
+    name: Build and push Basic Auth Sidecar
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/call_build-push-docker-image.yml
+    with:
+      aws-region: eu-west-2
+      context: basic-auth-sidecar
+    secrets:
+      dynatrace_registry: ${{ secrets.DYNATRACE_REGISTRY_NAME }}
+      dynatrace_token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      deployer_role: ${{ secrets.DEV_DEPLOYER_ROLE }}
+      ecr_repo: ${{ secrets.DEV_BASIC_SIDECAR_ECR_REPO }}
+  build-service-down:
+    name: Build and push Service Down Page
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/call_build-push-docker-image.yml
+    with:
+      aws-region: eu-west-2
+      context: service-down-page-config
+    secrets:
+      dynatrace_registry: ${{ secrets.DYNATRACE_REGISTRY_NAME }}
+      dynatrace_token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      deployer_role: ${{ secrets.DEV_DEPLOYER_ROLE }}
+      ecr_repo: ${{ secrets.DEV_SERVICE_DOWN_ECR_REPO }}
   deploy:
     needs:
-      - build
+      - build-frontend
+      - build-sidecar
+      - build-service-down
       - pr-data
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -176,11 +70,13 @@ jobs:
       - name: Set up AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: ${{ env.DEV_GHA_DEPLOYER_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ secrets.DEV_DEPLOY_ROLE }}
+          aws-region: eu-west-2
 
       - name: Upload frontend Terraform files
         working-directory: ci/terraform
+        env:
+          METADATA: ${{ needs.pr-data.outputs.data }}
         run: |
           echo "::group::Zip up frontend terraform"
           zip -r frontend.zip .
@@ -188,10 +84,10 @@ jobs:
 
           echo "::group::Upload artifact to S3"
           OBJECT_VERSION="$(aws s3api put-object \
-            --bucket ${{ env.DEV_ARTIFACT_BUCKET }} \
+            --bucket ${{ secrets.DEV_ARTIFACT_BUCKET }} \
             --key frontend.zip \
             --body frontend.zip \
-            --metadata '${{ toJson(fromJson(needs.pr-data.outputs.data)) }}' \
+            --metadata "${METADATA}" \
             --query VersionId --output text)"
           echo "::endgroup::"
           echo "::notice title=Final artifact uploaded to S3::object: frontend.zip, version: ${OBJECT_VERSION}"

--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -1,10 +1,5 @@
 name: Build and Deploy frontend
 
-env:
-  AWS_REGION: eu-west-2
-
-# Deploy role & Artificate buckets are Logical id  GitHubActionsRole & GitHubArtifactSourceBucket Value from Build Pipeline
-
 on:
   push:
     branches:
@@ -17,161 +12,60 @@ concurrency:
 jobs:
   pr-data:
     name: Get data for merged PR
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
-    outputs:
-      data: ${{ steps.get_pr_data.outputs.result }}
-    steps:
-      - name: Get PR data
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        id: get_pr_data
-        with:
-          script: |
-            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
-                repository(owner: $owner, name: $name) {
-                  object(oid: $oid) {
-                    ... on Commit {
-                      oid
-                      message
-                      associatedPullRequests(first: 1) {
-                        nodes {
-                          number
-                          title
-                          merged
-                          mergedAt
-                          mergeCommit {
-                            oid
-                          }
-                        }
-                      }
-                    }
-                  }
-                  owner {
-                    login
-                  }
-                  name
-                  nameWithOwner
-                }
-              }`
-            const variables = {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                oid: context.sha,
-                shortSha: context.sha.slice(0, 7),
-            }
+    uses: ./.github/workflows/call_get_pr_data.yml
 
-            const result = await github.graphql(query, variables).then((response) => {
-                const firstLineOfCommitMessage = response.repository.object.message.slice(0, response.repository.object.message.indexOf("\n"));
-                const res = {
-                    pr_number: null,
-                    pr_title: null,
-                    pr_merged_at: null,
-                    pr_merge_commit_sha: null,
-
-                    commit_message: firstLineOfCommitMessage,
-
-                    repo_full_name: response.repository.nameWithOwner,
-                    repo_owner: response.repository.owner.login,
-                    repo_name: response.repository.name,
-
-                    repository: response.repository.nameWithOwner,
-                    commitsha: context.sha,
-                    commitmessage: firstLineOfCommitMessage,
-                }
-                res["codepipeline-artifact-revision-summary"] = `${context.sha}: ${firstLineOfCommitMessage}`;
-
-                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
-                    const prData = response.repository.object.associatedPullRequests.nodes[0];
-                    res.pr_number = prData.number.toString();
-                    res.pr_title = prData.title;
-                    res.pr_merged_at = prData.mergedAt;
-                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
-                    res.commitmessage = prData.title;
-
-                    res["codepipeline-artifact-revision-summary"] = `${prData.mergeCommit.oid}: ${response.repository.nameWithOwner}#${prData.number} ${prData.title}`;
-                }
-
-                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
-                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
-                }
-
-                return res;
-            }).catch((error) => {
-                throw error;
-            });
-
-            for (const key in result) {
-                if (result[key] == null) {
-                    result[key] = "";
-                }
-                // strip non-ascii characters from all values
-                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
-            }
-
-            console.log(result);
-            return result;
-
-  build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  build-frontend:
+    name: Build and push Frontend
     permissions:
       id-token: write
       contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Assume AWS DEPLOYER role in tooling acct
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ secrets.DEPLOYER_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
-
-      - name: Login to GDS Dev Dynatrace Container Registry
-        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
-        with:
-          registry: khw46367.live.dynatrace.com
-          username: khw46367
-          password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
-
-      - name: Build, tag, and push frontend
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.TOOLING_ECR_FRONTEND_REPO }}
-        run: |
-          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}" .
-          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
-
-      - name: Build, tag, and push basic-auth-sidecar
-        working-directory: basic-auth-sidecar
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.BASIC_SIDECAR_ECR_REPO }}
-        run: |
-          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}" .
-          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
-
-      - name: Build, tag, and push service down page
-        working-directory: service-down-page-config
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.SERVICE_DOWN_ECR_REPO }}
-        run: |
-          docker build -t "${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}" .
-          docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${{ github.sha }}"
-
+    uses: ./.github/workflows/call_build-push-docker-image.yml
+    with:
+      aws-region: eu-west-2
+    secrets:
+      dynatrace_registry: ${{ secrets.DYNATRACE_REGISTRY_NAME }}
+      dynatrace_token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      deployer_role: ${{ secrets.DEPLOYER_ROLE }}
+      ecr_repo: ${{ secrets.TOOLING_ECR_FRONTEND_REPO }}
+  build-sidecar:
+    name: Build and push Basic Auth Sidecar
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/call_build-push-docker-image.yml
+    with:
+      aws-region: eu-west-2
+      context: basic-auth-sidecar
+    secrets:
+      dynatrace_registry: ${{ secrets.DYNATRACE_REGISTRY_NAME }}
+      dynatrace_token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      deployer_role: ${{ secrets.DEPLOYER_ROLE }}
+      ecr_repo: ${{ secrets.BASIC_SIDECAR_ECR_REPO }}
+  build-service-down:
+    name: Build and push Service Down Page
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/call_build-push-docker-image.yml
+    with:
+      aws-region: eu-west-2
+      context: service-down-page-config
+    secrets:
+      dynatrace_registry: ${{ secrets.DYNATRACE_REGISTRY_NAME }}
+      dynatrace_token: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+      deployer_role: ${{ secrets.DEPLOYER_ROLE }}
+      ecr_repo: ${{ secrets.SERVICE_DOWN_ECR_REPO }}
   deploy:
+    needs:
+      - build-frontend
+      - build-sidecar
+      - build-service-down
+      - pr-data
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs:
-      - pr-data
-      - build
     permissions:
       id-token: write
       contents: read
@@ -183,10 +77,12 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ secrets.DEPLOY_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: eu-west-2
 
       - name: Upload frontend Terraform files
         working-directory: ci/terraform
+        env:
+          METADATA: ${{ needs.pr-data.outputs.data }}
         run: |
           echo "::group::Zip up frontend terraform"
           zip -r frontend.zip .
@@ -197,7 +93,7 @@ jobs:
             --bucket ${{ secrets.ARTIFACT_BUCKET }} \
             --key frontend.zip \
             --body frontend.zip \
-            --metadata '${{ toJson(fromJson(needs.pr-data.outputs.data)) }}' \
+            --metadata "${METADATA}" \
             --query VersionId --output text)"
           echo "::endgroup::"
           echo "::notice title=Final artifact uploaded to S3::object: frontend.zip, version: ${OBJECT_VERSION}"

--- a/.github/workflows/call_build-push-docker-image.yml
+++ b/.github/workflows/call_build-push-docker-image.yml
@@ -1,0 +1,82 @@
+name: Build and push Docker image
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        description: "AWS region to deploy to"
+        default: "eu-west-2"
+        type: string
+      context:
+        description: "The build context. Defaults to repository root"
+        default: "."
+        type: string
+      cache-ecr-repo:
+        description: "The name of the ECR repo to use for caching"
+        default: "build-cache"
+        type: string
+    secrets:
+      dynatrace_registry:
+        description: "The Dynatrace registry to use (just the username)"
+      dynatrace_token:
+        description: "The Dynatrace token"
+      deployer_role:
+        description: "The role to assume in the tooling account"
+      ecr_repo:
+        description: "The name of the ECR repo to push to"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CACHE_TAG: ${{ inputs.context == '.' && 'root' || inputs.context }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set up Docker CLI
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
+
+      - name: Assume AWS DEPLOYER role in tooling acct
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ secrets.deployer_role }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Login to GDS Dev Dynatrace Container Registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
+        with:
+          registry: "${{ secrets.dynatrace_registry }}.live.dynatrace.com"
+          username: ${{ secrets.dynatrace_registry }}
+          password: ${{ secrets.dynatrace_token }}
+
+      - name: Build image metadata
+        id: metadata
+        if: github
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: |
+            "${{ steps.login-ecr.outputs.registry }}/${{ secrets.ecr_repo }}"
+          labels: ${{ inputs.context != '.' && format('org.opencontainers.image.title={0}', inputs.context) }}
+          tags: |
+            type=sha,prefix=,suffix=,format=long
+      - name: Build, tag and push image
+        uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
+        env:
+          CACHE_IMAGE: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.cache-ecr-repo }}:${{ env.CACHE_TAG }}-cache
+        with:
+          context: ${{ inputs.context }}
+          build-contexts: |
+            oneagent_codemodules=docker-image://${{ secrets.dynatrace_registry}}.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs
+          push: true
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}
+          cache-to: mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ env.CACHE_IMAGE }}

--- a/.github/workflows/call_get_pr_data.yml
+++ b/.github/workflows/call_get_pr_data.yml
@@ -1,0 +1,109 @@
+name: Get PR Data
+on:
+  workflow_call:
+    outputs:
+      data:
+        description: "JSON string representation of the metadata"
+        value: ${{ jobs.get-pr-data.outputs.data }}
+
+jobs:
+  get-pr-data:
+    name: Get data for merged PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      data: ${{ steps.get_pr_data.outputs.result }}
+    steps:
+      - name: Get PR data
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: get_pr_data
+        with:
+          result-encoding: string
+          # language=javascript prefix="module.exports = async ({github, context}) => {\n" suffix=}
+          script: |
+            const query = `query($owner: String!, $name: String!, $oid: GitObjectID!) {
+                repository(owner: $owner, name: $name) {
+                  object(oid: $oid) {
+                    ... on Commit {
+                      oid
+                      message
+                      associatedPullRequests(first: 1) {
+                        nodes {
+                          number
+                          title
+                          merged
+                          mergedAt
+                          mergeCommit {
+                            oid
+                          }
+                        }
+                      }
+                    }
+                  }
+                  owner {
+                    login
+                  }
+                  name
+                  nameWithOwner
+                }
+              }`
+            const variables = {
+                owner: context.repo.owner,
+                name: context.repo.repo,
+                oid: context.sha,
+            }
+
+            const result = await github.graphql(query, variables).then((response) => {
+                const firstLineOfCommitMessage = response.repository.object.message.split("\n")[0];
+                const shortCommitSha = context.sha.slice(0, 7);
+                const res = {
+                    pr_number: null,
+                    pr_title: null,
+                    pr_merged_at: null,
+                    pr_merge_commit_sha: null,
+
+                    commit_message: firstLineOfCommitMessage,
+
+                    repo_full_name: response.repository.nameWithOwner,
+                    repo_owner: response.repository.owner.login,
+                    repo_name: response.repository.name,
+
+                    repository: response.repository.nameWithOwner,
+                    commitsha: context.sha,
+                    commitmessage: firstLineOfCommitMessage,
+                }
+                res["codepipeline-artifact-revision-summary"] = `${shortCommitSha}: ${firstLineOfCommitMessage}`;
+
+                if (response.repository.object.associatedPullRequests.nodes.length > 0 && response.repository.object.associatedPullRequests.nodes[0].merged) {
+                    const prData = response.repository.object.associatedPullRequests.nodes[0];
+                    const shortMergeCommitSha = prData.mergeCommit.oid.slice(0, 7);
+                    res.pr_number = prData.number.toString();
+                    res.pr_title = prData.title;
+                    res.pr_merged_at = prData.mergedAt;
+                    res.pr_merge_commit_sha = prData.mergeCommit.oid;
+                    res.commitmessage = prData.title;
+
+                    res["codepipeline-artifact-revision-summary"] = `${shortMergeCommitSha}: #${prData.number} (${response.repository.nameWithOwner}) - ${prData.title}`;
+                }
+
+                if (res["codepipeline-artifact-revision-summary"].length > 2048) {
+                    res["codepipeline-artifact-revision-summary"] = res["codepipeline-artifact-revision-summary"].slice(0, 2048);
+                }
+
+                return res;
+            }).catch((error) => {
+                throw error;
+            });
+
+            for (const key in result) {
+                if (result[key] == null) {
+                    result[key] = "";
+                }
+                // strip non-ascii characters from all values
+                result[key] = result[key].replace(/[^\x20-\x7E]/g, '');
+            }
+
+            console.log(result);
+            return JSON.stringify(result);

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,6 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/lalten/check-gha-pinning
-    rev: v1.1.0
-    hooks:
-      - id: check-gha-pinning
-        # Skip git check for now until subdirectory support is added (#1)
-        entry: env GHA_PINNING_SKIP_GIT_CHECK=1 check-gha-pinning
-
   - repo: local
     hooks:
       - id: eslint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,25 @@
-FROM node:18.20.3-alpine3.20@sha256:e37da457874383fa9217067867ec85fe8fe59f0bfa351ec9752a95438680056e as builder
+FROM node:18.20.3-alpine3.20@sha256:e37da457874383fa9217067867ec85fe8fe59f0bfa351ec9752a95438680056e AS builder
 WORKDIR /app
-COPY package.json ./
-COPY yarn.lock ./
+COPY package.json yarn.lock ./
+RUN yarn install
 COPY tsconfig.json ./
-COPY ./src ./src
 COPY ./@types ./@types
-RUN yarn install && yarn build && yarn clean-modules && yarn install --production=true
+COPY ./src ./src
+RUN yarn build && yarn install --production
 
-FROM node:18.20.3-alpine3.20@sha256:e37da457874383fa9217067867ec85fe8fe59f0bfa351ec9752a95438680056e as final
+FROM node:18.20.3-alpine3.20@sha256:e37da457874383fa9217067867ec85fe8fe59f0bfa351ec9752a95438680056e AS final
 
-COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+COPY --from=oneagent_codemodules / /
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
 WORKDIR /app
 COPY --chown=node:node --from=builder /app/package*.json ./
 COPY --chown=node:node --from=builder /app/node_modules/ node_modules
 COPY --chown=node:node --from=builder /app/dist/ dist
 
-ENV NODE_ENV "production"
-ENV PORT 3000
+ENV NODE_ENV="production"
+ENV PORT=3000
 
 EXPOSE $PORT
 USER node
 CMD ["yarn", "start"]
-
-
-

--- a/basic-auth-sidecar/Dockerfile
+++ b/basic-auth-sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline-alpine as builder
+FROM nginx:mainline-alpine AS builder
 
 ARG ENABLED_MODULES=headers-more
 

--- a/scripts/trigger-gha-current-branch.sh
+++ b/scripts/trigger-gha-current-branch.sh
@@ -19,4 +19,5 @@ if ! git merge-base --is-ancestor HEAD "@{u}"; then
     echo "Local branch appears to be diverged from remote. This may be okay, I just thought you should know."
 fi
 
-gh workflow run "build-deploy-frontend-dev.yml" --ref "${current_branch}"
+gh workflow run "build-deploy-frontend-dev.yml" --ref "${current_branch}" &&
+    gh workflow view "build-deploy-frontend-dev.yml" --web


### PR DESCRIPTION
## What

- Move pr-data into reusable workflow
- pr-data now returns the output of `JSON.stringify`, not an object,
  meaning that quotes will be automatically escaped in the output
- pull pr-data into the push job via `env`, meaning that single quotes
  inside of the string will not allow shell escaping.
- Build docker image with `docker/build-push-action`. This means we get
  a nice build summary on the action run. It also makes caching easier.
- Enable build caching, using a separate MUTABLE ecr repository. This
  dramatically speeds up the build process, as we can avoid rebuilding
  identical image layers, such as the initial `yarn install` in the
  case that no dependencies have changed.
- Rework the Dockerfiles to be more cacheable: things that are less
  likely to change should be above things that do change, so that we
  reuse as many cached layers as possible
- Move the image building into a reusable workflow
- Move dev variables into GHA secrets.

## How to review

Ensure this branch deploys correctly in `dev` by manually running the `build-deploy-frontend-dev.yml`, targetting this branch.

After deploying, ensure that the frontend works correctly in the dev environment.


## Related PRs

https://github.com/alphagov/di-infrastructure/pull/599
