### PR TITLE
AUT-3402: Add condition to reflect INTERVENTION status

### DIFF
--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -98,6 +98,12 @@ export function proveIdentityStatusCallbackGet(
         });
       }
 
+      if (response.data.status === IdentityProcessingStatus.INTERVENTION) {
+        res.status(HTTP_STATUS_CODES.OK).json({
+          status: IdentityProcessingStatus.INTERVENTION,
+        });
+      }
+
       if (response.data.status === IdentityProcessingStatus.ERROR) {
         res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR).json({
           status: IdentityProcessingStatus.ERROR,

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -191,6 +191,26 @@ describe("prove identity callback controller", () => {
         status: IdentityProcessingStatus.PROCESSING,
       });
     });
+    it("should return status INTERVENTION when identity processing is INTERVENTION", async () => {
+      const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
+        processIdentity: sinon.fake.returns({
+          success: true,
+          data: {
+            status: IdentityProcessingStatus.INTERVENTION,
+          },
+        }),
+      } as unknown as ProveIdentityCallbackServiceInterface;
+      await proveIdentityStatusCallbackGet(fakeProveIdentityService)(
+        req as Request,
+        res as Response,
+        next
+      );
+
+      expect(res.status).to.have.been.calledWith(200);
+      expect(res.json).to.have.been.calledWith({
+        status: IdentityProcessingStatus.INTERVENTION,
+      });
+    });
     it("should return status ERROR when identity processing is in ERROR", async () => {
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
         processIdentity: sinon.fake.returns({


### PR DESCRIPTION
## What

Introduces a new condition into the `proveIdentityStatusCallbackGet` handler to reflect the `IdentityProcessingStatus.INTERVENTION` status having been returned. 

This is being introduced in response to feedback from the Orchestration Tech Lead following their review of the code earlier today.

## How to review

Code review.

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1867 introduced the route and handler this PR amends


