### PR TITLE
AUT-3401: Add scheme and subdomain to link href

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2374,7 +2374,7 @@
             "message": {
               "text1": "Ewch yn ôl i`r gwasanaeth yr oeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio`ch peiriant chwilio neu ddod o hyd iddo o`r ",
               "link": {
-                "href": "GOV.UK",
+                "href": "https://www.gov.uk",
                 "text": "hafan GOV.UK"
               },
               "text2": "."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2374,7 +2374,7 @@
             "message": {
               "text1": "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the ",
               "link": {
-                "href": "GOV.UK",
+                "href": "https://www.gov.uk",
                 "text": "GOV.UK homepage"
               },
               "text2": "."


### PR DESCRIPTION
## What

Adds scheme and subdomain to a link in translation files. This link is presented to users who encounter an error on the new spinner page. 

## Why

This has been made in response to feedback from the Orchestration Tech lead that "translations seem to be incorrect or missing in some places", linking to this line in the translation file (See comment in Jira ticket for AUT-3408). While making this change, I have checked that all translations referenced in `data-` attributes are present. The only issue I could see is this one.

## How to review

Code Review

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/1869 - introduced these translation file entries along with the HTML-only version of the page
- https://github.com/govuk-one-login/authentication-frontend/pull/1925 -amended the structure of the HTML in response to feedback from the Orchestration Tech Lead

