### PR TITLE
AUT-1555: Add journey to reset password routes

### DIFF
--- a/src/components/reset-password/reset-password-routes.ts
+++ b/src/components/reset-password/reset-password-routes.ts
@@ -15,7 +15,12 @@ import { accountInterventionsMiddleware } from "../../middleware/account-interve
 
 const router = express.Router();
 
-router.get(PATH_NAMES.RESET_PASSWORD_REQUEST, resetPasswordRequestGet);
+router.get(
+  PATH_NAMES.RESET_PASSWORD_REQUEST,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  resetPasswordRequestGet
+);
 
 router.get(
   PATH_NAMES.RESET_PASSWORD,
@@ -33,7 +38,12 @@ router.post(
   asyncHandler(resetPasswordPost())
 );
 
-router.get(PATH_NAMES.RESET_PASSWORD_REQUIRED, resetPasswordRequiredGet);
+router.get(
+  PATH_NAMES.RESET_PASSWORD_REQUIRED,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  resetPasswordRequiredGet
+);
 
 router.post(
   PATH_NAMES.RESET_PASSWORD_REQUIRED,


### PR DESCRIPTION
Without this, a user was allowed to manually transition to these pages from an invalid state (e.g. their account was not found). This meant that they would end up hitting a backend error at some point, rather than this not being allowed in the first place.

Also added session middleware as it seems correct to be doing both of these checks


## How to review

1. Code Review
1. Run the app locally
1. When signing in, enter an email that doesn't have an account associated with it, and see that you hit the account not found error
1. Manually change the url to /reset-password-request, or /reset-password-required
1. See that you are redirected back to /account not found, and do not hit any unexpected errors
1. Compare this behaviour against staging
1. Also try a normal reset password journey locally, and verify that it still works.

