### PR TITLE
AUT-3052: Display Link on MFA code entery page

### DIFF
--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -133,17 +133,27 @@ export const enterAuthenticatorAppCodePost = (
       journeyType
     );
 
+    const checkEmailLink = pathWithQueryParam(
+      PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES,
+      "type",
+      MFA_METHOD_TYPE.AUTH_APP
+    );
+
     if (!result.success) {
       const error = result.data.code;
 
       if (error === ERROR_CODES.AUTH_APP_INVALID_CODE) {
-        const error = formatValidationError(
+        const validationError = formatValidationError(
           "code",
           req.t(
             "pages.enterAuthenticatorAppCode.code.validationError.invalidCode"
           )
         );
-        return renderBadRequest(res, req, template, error);
+
+        return renderBadRequest(res, req, template, validationError, {
+          isAccountRecoveryPermitted: req.session.user.isAccountRecoveryPermitted,
+          checkEmailLink,
+        });
       }
 
       if (error === ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED) {

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -40,7 +40,6 @@
 
   </form>
 
-  {% if isAccountRecoveryPermitted === true %}
     {% set detailsHTML %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
@@ -52,7 +51,6 @@
       summaryText: 'pages.enterAuthenticatorAppCode.details.summary' | translate,
       html: detailsHTML
     }) }}
-  {% endif %}
 
   {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", contentId: "89461417-df3f-46a8-9c37-713b9dd78085", loggedInStatus: false, dynamic: false })}}
 {% endblock %}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -12,7 +12,7 @@
   <form id="form-tracking" action="/enter-authenticator-app-code" method="post" novalidate="novalidate">
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-    <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
+    <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted | default(false)}}"/>
     <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
 
     {{ govukInput({
@@ -40,6 +40,7 @@
 
   </form>
 
+  {% if isAccountRecoveryPermitte %}
     {% set detailsHTML %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
@@ -51,6 +52,7 @@
       summaryText: 'pages.enterAuthenticatorAppCode.details.summary' | translate,
       html: detailsHTML
     }) }}
+  {% endif %}
 
   {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", contentId: "89461417-df3f-46a8-9c37-713b9dd78085", loggedInStatus: false, dynamic: false })}}
 {% endblock %}


### PR DESCRIPTION

## What

Ensured the details section with the 'I do not have access to the authenticator app' link remains visible when an incorrect authenticator app code is entered.


## How to review


1. Code Review
2. Deploy to a dev environment and test:
-Enter correct email address, press Continue.
-Enter correct password, press Continue.
-The ‘Enter the 6 digit security code shown in your authenticator app’ page is displayed with the ‘I do not have access to the authenticator app’ link.
-Enter an incorrect auth app code, press Continue. The error message is displayed for the incorrect code, but the ‘I do not have access to the authenticator app’ link is remains visible.

