### PR TITLE
BAU: Use refactored devplatform-upload-action-ecr

### DIFF
--- a/.github/workflows/deploy-frontend-sp.yml
+++ b/.github/workflows/deploy-frontend-sp.yml
@@ -7,18 +7,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy-basic-auth-sidecar:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       id-token: write
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
       - name: Build and push basic-auth-sidecar image
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # v1.3.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@8f14d1af61737413dc6eb39f071f01dc6d0e6c45 # v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
@@ -26,10 +23,16 @@ jobs:
           working-directory: basic-auth-sidecar
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
           ecr-repo-name: ${{ secrets.BASIC_AUTH_SIDECAR_ECR_REPOSITORY }}
-          checkout-repo: false
 
+  deploy-service-down-page:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
       - name: Build and push service down page image
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # v1.3.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@8f14d1af61737413dc6eb39f071f01dc6d0e6c45 # v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
@@ -37,17 +40,27 @@ jobs:
           working-directory: service-down-page-config
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
           ecr-repo-name: ${{ secrets.SERVICE_DOWN_PAGE_ECR_REPOSITORY }}
-          checkout-repo: false
 
+  deploy-frontend:
+    needs:
+      - deploy-basic-auth-sidecar
+      - deploy-service-down-page
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write
+      contents: read
+    steps:
       - name: Build, push and deploy frontend
-        uses: govuk-one-login/devplatform-upload-action-ecr@5431bcea6158b6c12776a96e067b1e02bf91b13d # v1.3.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@8f14d1af61737413dc6eb39f071f01dc6d0e6c45 # v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
           artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
           ecr-repo-name: ${{ secrets.FRONTEND_ECR_REPOSITORY }}
-          checkout-repo: false
           template-file: cloudformation/deploy/template.yaml
           private-docker-registry: khw46367.live.dynatrace.com
           private-docker-login-username: khw46367
           private-docker-login-password: ${{ secrets.DYNATRACE_PAAS_TOKEN }}
+          build-contexts: |
+            oneagent_codemodules=docker-image://${{ secrets.DYNATRACE_REGISTRY_NAME}}.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs


### PR DESCRIPTION
## What

- Use latest refactored devplatform-upload-action-ecr
- Pass in `oneagent_codemodules` build context
- Build sidecar and service-down page in parallel to speed up the
  workflow

## How to review

Run manually - ensure it runs!

## Related PRs

🚨  https://github.com/govuk-one-login/devplatform-upload-action-ecr/pull/19 must be merged first, and the SHA updated to the new tag 🚨 
