### PR TITLE
AUT-3052: Fix disappearing links

### DIFF
--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -54,7 +54,7 @@
 
     </form>
 
-    {% if isAccountRecoveryPermitted === true %}
+    {% if isAccountRecoveryPermitted === true or isAccountRecoveryPermitted === "true" %}
         {% set detailsHTML %}
             <p class="govuk-body">
                 {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -40,7 +40,7 @@
 
   </form>
 
-  {% if isAccountRecoveryPermitted === true %}
+  {% if isAccountRecoveryPermitted === true or isAccountRecoveryPermitted === "true" %}
     {% set detailsHTML %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -50,7 +50,7 @@
                    rel="noreferrer noopener">{{ 'pages.enterMfa.details.sendCodeLinkText'| translate }}</a>
                 {{ 'pages.enterMfa.details.text 2' | translate }}
             </p>
-            {% if supportAccountRecovery === true %}
+            {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
                 <p class="govuk-body">
                     {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
                     <a href={{ checkEmailLink }} class="govuk-link"

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -49,7 +49,8 @@
       <a href="{{'pages.enterMfa.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.sendCodeLinkText'| translate}}</a>
       {{'pages.enterMfa.details.text 2' | translate}}
     </p>
-    {% if supportAccountRecovery === true %}
+
+    {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
         <p class="govuk-body">
             {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
             <a href={{ checkEmailLink }} class="govuk-link"
@@ -73,4 +74,3 @@
 
 {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", contentId: "19601dd7-be55-4ab6-aa44-a6358c4239dc", loggedInStatus: false, dynamic: false })}}
 {% endblock %}
- 


### PR DESCRIPTION
Previously, when either sms mfa or an auth app code were submitted incorrectly, the link to reset mfa would disappear - see screenshots below for visual example.

This is because when the template was first rendered (before an incorrect code was submitted), its value is a boolean. However, when we store the cached version (which gets used when the page reloads e.g. for a validation error) the value is a string.

This meant that on page relaod, the equality check (=== true) would return false, and the account recovery content would disappear.

I tried storing the cached value as a boolean rather than a string - e.g. changing

`<input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>`

to

`<input type="hidden" name="isAccountRecoveryPermitted" value={{isAccountRecoveryPermitted}} />`

This still did not work, as under the hood nunjucks converts these cached values to strings anyway, so we still need to either convert the cached value back to a boolean, or adjust the equality check to check for strings and booleans.


## Screenshots

| | On first load, with account recovery permitted | On submitting an invalid mfa code, when account recovery permitted | 
|-----|----|----|
| BEFORE THIS FIX (auth app as an example) |<img width="675" alt="Screenshot 2024-08-12 at 09 46 08" src="https://github.com/user-attachments/assets/2e2938d0-29cd-4518-9c9e-e74d8b6f8c3f"> We have a link to change how we get security codes when the page originally loads| <img width="735" alt="Screenshot 2024-08-12 at 09 46 18" src="https://github.com/user-attachments/assets/86762762-7536-49fb-bc52-59d080c1b56c"> Note here the link to change how you get security codes has disappeared |
| AFTER THIS FIX | As above |<img width="498" alt="Screenshot 2024-08-12 at 09 51 05" src="https://github.com/user-attachments/assets/5df71b5f-c7c5-4c19-8e50-bd3560587429"> We haven't lost the link here| 

SMS is also a problem, but is less obvious at first glance because we still get a dropdown, but after an incorrect code it loses the account recovery link within it.

## How to review

1. Code Review

Check the problem is fixed when account recovery is enabled (you likely won't have to do anything to make sure this is true on the account you're using):
1. Run locally against a backend where you have an account set up with some form of mfa
1. Go through a sign in journey, and pause at the enter mfa step. Observe that you can see a link in a dropdown to change how you get security codes.
1. Enter an incorrect mfa code.
1. Observe that you can still see the link to get security codes.

Check existing behaviour remains when account recovery is disabled:
1. Hardcode the relevant 'isAccountRecoveryEnabled` boolean to false in the controller that renders whichever mfa method you're using.
1. Repeat steps above and check that the link is not present either initially or on page reload.

If you like you can check e.g. the other mfa method, or uplift journeys, or you can trust that the same fix worked there :-) 


## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
