### PR TITLE
BAU: Fix shutdown script

### DIFF
--- a/shutdown.sh
+++ b/shutdown.sh
@@ -13,5 +13,5 @@ required_vars_frontend=$(grep "\${" docker-compose.frontend.yml | sed "s/.*\${\(
 # shellcheck disable=SC2016
 # Replace all required env vars with dummy values (integer between 2000 and 65000, so they are valid ports)
 printf '%s\n%s' "${required_vars}" "${required_vars_frontend}" | sort | uniq | xargs -L1 -I{} bash -c 'echo "{}" | sed "s/asdf/$(jot -r 1 2000 65000)/"' >"${tmp_env}"
-docker-compose --env-file="${tmp_env}" -f docker-compose.yml -f docker-compose.frontend.yml down
+docker compose --env-file="${tmp_env}" -f docker-compose.yml -f docker-compose.frontend.yml down
 killall node 2>/dev/null || echo "No local running node processes stopped..."


### PR DESCRIPTION
## What

Changed 'docker-compose' to 'docker compose' in the shutdown.sh script as 'docker-compose' has been depracated:

"GitHub deprecated v1, and you need to change the command from, e.g., docker-compose build to docker compose build (remove the dash)" - mentioned [here](https://github.com/orgs/community/discussions/116610)

## How to review

1. Code Review