### PR TITLE
AUT-3499: Remove back button from reauth password screen

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -42,7 +42,11 @@ const ENTER_PASSWORD_ACCOUNT_EXISTS_VALIDATION_KEY =
   "pages.enterPasswordAccountExists.password.validationError.incorrectPassword";
 
 export function enterPasswordGet(req: Request, res: Response): void {
-  res.render(ENTER_PASSWORD_TEMPLATE);
+  const isReauthJourney =
+    getJourneyTypeFromUserSession(req.session.user, {
+      includeReauthentication: true,
+    }) == JOURNEY_TYPE.REAUTHENTICATION;
+  res.render(ENTER_PASSWORD_TEMPLATE, { isReauthJourney: isReauthJourney });
 }
 
 export function enterSignInRetryBlockedGet(

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -4,7 +4,9 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "common/show-password/macro.njk" import govukInputWithShowPasswordWithLabelAsPageHeading %}
-{% set showBack = true %}
+{% if isReauthJourney === false or isReauthJourney === "false" %}
+    {% set showBack = true %}
+{% endif %}
 {% set hrefBack = 'enter-email' %}
 {% set pageTitleName = 'pages.enterPassword.title' | translate %}
 
@@ -14,6 +16,7 @@
 
 <form id="form-tracking" action="/enter-password" method="post" novalidate>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="isReauthJourney" value="{{isReauthJourney}}"/>
 
 {{ govukInputWithShowPasswordWithLabelAsPageHeading(
     'pages.enterPassword.header' | translate,


### PR DESCRIPTION
## What

This PR removes the back button when the session journey type == REAUTHENTICATION. 

## How to review

1. Code Review
2. Deploy to sandpit and run through a sign in journey. See that the back button **_IS_** present on enter password screen when going through this step. Copy and paste ID token at end of journey.
3. Go through reauthentication journey, following the guidance [here](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4317446229/How+to+trigger+reauthentication).  See that back button **_IS NOT_** present on enter password screen when going through this journey.

## Changes to screens
The following screenshot is the enter password screen on the initial SIGN IN part of the journey:
<img width="1728" alt="Screenshot 2024-08-14 at 15 05 10" src="https://github.com/user-attachments/assets/fbecc878-6669-438a-a7c9-d538fce54b95">

The following screenshot is the enter password screen in the REAUTHENTICATION journey:
<img width="1728" alt="Screenshot 2024-08-14 at 15 03 52" src="https://github.com/user-attachments/assets/4acec033-22f8-4c2d-b105-79b9296e05f4">

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [x] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->

- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [x] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
