### PR TITLE
ATO-965: update cookie page with browser session id

### DIFF
--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -196,6 +196,16 @@
                     text: 'pages.cookiePolicy.essential.info.table.rows.row12.col2' | translate,
                     classes: 'govuk-body-s'
                 }
+            ],
+            [
+                {
+                    text: "bsid",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row13.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
             ]
         ]
     }) }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -749,6 +749,9 @@
               },
               "row12": {
                 "col2": "15 munud"
+              },
+              "row13": {
+                "col2": "Pan fyddwch yn cau eich porwr gwe"
               }
             }
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -749,6 +749,9 @@
               },
               "row12": {
                 "col2": "15 minutes"
+              },
+              "row13": {
+                "col2": "When you close your web browser"
               }
             }
           }


### PR DESCRIPTION
Add browser session id cookie on cookie policy page. 

We have created a new cookie to track the browser session of users. The new cookie implemented is due to needing a way of making sure users are logged out when the browser is closed.