### PR TITLE
FIX: Pass serviceName to spinner template

### DIFF
--- a/src/components/prove-identity-callback/index-new-spinner.njk
+++ b/src/components/prove-identity-callback/index-new-spinner.njk
@@ -5,7 +5,7 @@
     <form action="/ipv-callback" method="post" novalidate="novalidate">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
         <div id="spinner-container"
-             data-initial-heading="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.heading' | translate + serviceName }}"
+             data-initial-heading="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.heading' | translate }}{{ serviceName }}"
              data-initial-spinnerStateText="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.spinnerStateText' | translate }}"
              data-initial-spinnerState="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.initial.spinnerState' | translate }}"
              data-error-heading="{{ 'pages.proveIdentityCheckNew.progressivelyEnhancedVersion.error.heading' | translate }}"

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -37,7 +37,9 @@ export function proveIdentityCallbackGetOrPost(
 
     if (response.data.status === IdentityProcessingStatus.PROCESSING) {
       if (supportNewIpvSpinner()) {
-        return res.render("prove-identity-callback/index-new-spinner.njk");
+        return res.render("prove-identity-callback/index-new-spinner.njk", {
+          serviceName: clientName,
+        });
       }
 
       return res.render("prove-identity-callback/index.njk", {


### PR DESCRIPTION
## What

Testing in staging environment has revealed that the service name is shown as 'undefined'. This PR:

1. updates the controller to pass the `serviceName` variable through to the template
2. creates a separate block for `serviceName` to be rendered (rather than relying on Nunjucks to do the concatenation).

## How to review

Code Review
