### PR TITLE
AUT-3617: Fix CSP violation related to analytics

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -32,18 +32,25 @@ export function helmetConfiguration(): Parameters<typeof helmet>[0] {
           (req: Request, res: Response): string =>
             `'nonce-${res.locals.scriptNonce}'`,
           "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
-          "https://www.googletagmanager.com",
+          "https://*.googletagmanager.com",
           "https://www.google-analytics.com",
           "https://ssl.google-analytics.com",
         ],
         imgSrc: [
           "'self'",
           "data:",
-          "https://www.googletagmanager.com",
+          "https://*.google-analytics.com",
+          "https://*.googletagmanager.com",
           "https://www.google-analytics.com",
         ],
         objectSrc: ["'none'"],
-        connectSrc: ["'self'", "https://www.google-analytics.com"],
+        connectSrc: [
+          "'self'",
+          "https://*.google-analytics.com",
+          "https://*.analytics.google.com",
+          "https://*.googletagmanager.com",
+          "https://www.google-analytics.com",
+        ],
       },
     },
     dnsPrefetchControl: {


### PR DESCRIPTION
## What

We've been notified of a CSP violation in production that's causing the browser to refuse to connect to a domain for Google Analytics - the blocked domain is https://region1.google-analytics.com

The [Google Developers site](https://developers.google.com/tag-platform/security/guides/csp) lists directives required for GA4 and Universal Analytics (both GA and UA are currently in use in the authentication frontend).

These directives are required to use GA4

```
script-src:  https://*.googletagmanager.com
img-src:     https://*.google-analytics.com https://*.googletagmanager.com
connect-src: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com
```
Additional directives are required for Universal Analytics:
```
script-src:   https://www.google-analytics.com https://ssl.google-analytics.com
img-src:      https://www.google-analytics.com
connect-src:  https://www.google-analytics.com
```

This PR updates the Helmet configuration to include these directives

<details>

<summary>How I've checked this in AuthDev1</summary>


<p>I've deployed the changes to AuthDev1 to check that</p>

<ol>
<li>the CSP directives are being set as expected (screenshot below of the Response Headers showing the CSP)<img width="898" alt="Screenshot 2024-08-21 at 16 57 40" src="https://github.com/user-attachments/assets/035f1723-5122-42e6-8089-e535cc287a4d"></li>
<li>there are no console errors relating to the CSP violation (there are none)
<img width="897" alt="Screenshot 2024-08-21 at 17 04 39" src="https://github.com/user-attachments/assets/88d64c46-92c4-4ae5-b2fa-309fda4627d8">
</li>
</ol>




</details>


## How to review

Code Review