### PR TITLE
AUT-2914: Add middleware for handling missing or invalid csrf tokens

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -88,6 +88,7 @@ import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-a
 import { setGTM } from "./middleware/analytics-middleware";
 import { setCurrentUrlMiddleware } from "./middleware/current-url-middleware";
 import { getRedisConfig } from "./utils/redis";
+import { csrfMissingHandler } from "./handlers/csrf-missing-handler";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -217,6 +218,7 @@ async function createApp(): Promise<express.Application> {
   app.use(pageNotFoundHandler);
 
   // Error Handlers
+  app.use(csrfMissingHandler);
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);
 

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -71,7 +71,7 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should redirect to /check-your-phone when new code requested", async () => {

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
@@ -125,7 +125,7 @@ describe("Integration:: check your email security codes", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when code not entered", async () => {

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -71,7 +71,7 @@ describe("Integration:: check your email", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when code not entered", async () => {

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -72,7 +72,7 @@ describe("Integration:: check your phone", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when code not entered", async () => {

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -199,7 +199,7 @@ describe("Integration:: contact us - public user", () => {
       .query("supportType=PUBLIC")
       .type("form")
       .send({})
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when no radio boxes are selected on the signing in contact-us-further-information page", () => {

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -69,7 +69,7 @@ describe("Integration::register create password", () => {
         email: "test@test.com",
         password: "test@test.com",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when password not entered", async () => {

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -99,7 +99,7 @@ describe("Integration:: enter authenticator app code", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when code not entered", async () => {

--- a/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
@@ -68,7 +68,7 @@ describe("Integration::enter email (create account)", () => {
       .send({
         email: "test@test.com",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when email not entered", async () => {

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -82,7 +82,7 @@ describe("Integration::enter email", () => {
       .send({
         email: "test@test.com",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when email not entered", async () => {

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -117,7 +117,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when code not entered", async () => {

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -72,7 +72,7 @@ describe("Integration::enter password", () => {
       .send({
         password: "password",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when password not entered", async () => {

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -77,7 +77,7 @@ describe("Integration::enter password", () => {
       .send({
         password: "password",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when password not entered", async () => {

--- a/src/components/enter-password/tests/enter-password-support-2fa-before-password-reset-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-support-2fa-before-password-reset-integration.test.ts
@@ -107,7 +107,7 @@ describe("Integration::enter password", () => {
       .send({
         password: "password",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when password not entered", async () => {

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -71,7 +71,7 @@ describe("Integration::enter phone number", () => {
       .send({
         phoneNumber: "123456789",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when uk phone number not entered", async () => {

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -70,7 +70,7 @@ describe("Integration:: resend email code", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should redirect to /check-your-email when new code requested as part of account creation journey", async () => {

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -119,7 +119,7 @@ describe("Integration:: resend mfa code", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should redirect to /enter-code when new code requested as part of sign in journey", async () => {

--- a/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-2fa-before-integration.test.ts
@@ -119,7 +119,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       .send({
         password: "password",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when password not entered", async () => {

--- a/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-forced-2fa-before-integration.test.ts
@@ -76,7 +76,7 @@ describe("Integration::reset password (in 2FA Before Reset Password flow)", () =
       .send({
         password: "password",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when password not entered", async () => {

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -119,7 +119,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .send({
         password: "password",
       })
-      .expect(500, done);
+      .expect(403, done);
   });
 
   it("should return validation error when password not entered", (done) => {

--- a/src/components/select-mfa-options/tests/select-mfa-options-integration.test.ts
+++ b/src/components/select-mfa-options/tests/select-mfa-options-integration.test.ts
@@ -64,7 +64,7 @@ describe("Integration::select-mfa-options", () => {
       .send({
         mfaOptions: "SMS",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when mfa option not selected", async () => {

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -74,7 +74,7 @@ describe("Integration::setup-authenticator-app", () => {
       .send({
         code: "123456",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should return validation error when access code not entered", async () => {

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -73,7 +73,7 @@ describe("Integration:: updated-terms-code", () => {
       .send({
         termsAndConditionsResult: "reject",
       })
-      .expect(500);
+      .expect(403);
   });
 
   it("should redirect to /auth_code when terms accepted", async () => {

--- a/src/handlers/csrf-missing-handler.ts
+++ b/src/handlers/csrf-missing-handler.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from "express";
+
+export function csrfMissingHandler(
+  err: any,
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const CSRF_MISSING_CODE = "EBADCSRFTOKEN";
+  if (err.code === CSRF_MISSING_CODE) {
+    // CSRF token missing or invalid
+    res.status(403).send("Forbidden: Invalid or missing CSRF token");
+  } else {
+    next(err);
+  }
+}

--- a/src/handlers/tests/csrf-missing-handler.test.ts
+++ b/src/handlers/tests/csrf-missing-handler.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+import { NextFunction, Request, Response } from "express";
+import sinon from "sinon";
+import { HTTP_STATUS_CODES } from "../../app.constants";
+import { csrfMissingHandler } from "../csrf-missing-handler";
+
+describe("csrfMissingHandler", () => {
+  let req: Request;
+  let res: Response;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    req = {} as Request;
+    res = {
+      headersSent: false,
+      statusCode: 200,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      render: () => {},
+      status: function (newStatus: number) {
+        this.statusCode = newStatus;
+        return this;
+      },
+      send: sinon.spy(),
+    } as unknown as Response;
+    next = sinon.spy();
+  });
+
+  it("should return unauthorized if the error is a csrf missing error", () => {
+    const err = new Error("Invalid CSRF token") as any;
+    err.code = "EBADCSRFTOKEN";
+
+    csrfMissingHandler(err, req, res, next);
+
+    expect(res.statusCode).to.equal(HTTP_STATUS_CODES.FORBIDDEN);
+    expect(res.send).to.have.been.calledOnceWith(
+      "Forbidden: Invalid or missing CSRF token"
+    );
+    expect(next).not.to.have.been.called;
+  });
+
+  it("should call next for any other error", () => {
+    const err = new Error("Some other error") as any;
+    err.code = "ANOTHER_ERROR";
+
+    csrfMissingHandler(err, req, res, next);
+
+    expect(next).to.have.been.called;
+  });
+});

--- a/test/unit/error-handler.test.ts
+++ b/test/unit/error-handler.test.ts
@@ -31,16 +31,6 @@ describe("Error handlers", () => {
   });
 
   describe("serverErrorHandler", () => {
-    it("should render 500 view when csrf token is invalid", () => {
-      const err: any = new Error("invalid csrf token");
-      err["code"] = "EBADCSRFTOKEN";
-
-      serverErrorHandler(err, req as Request, res as Response, next);
-
-      expect(res.status).to.have.been.calledOnceWith(500);
-      expect(res.render).to.have.been.calledOnceWith("common/errors/500.njk");
-    });
-
     it("should render 500 view when unexpected error", () => {
       const err = new Error("internal server error");
 


### PR DESCRIPTION
Currently, we return a server error in the case of a missing csrf token, as we do not have any specific handling for this case. When we get spam requests, this means we end up return 5xxs and flagging errors.

Adding middleware to handle this case means that we will return 403s, rather than 500s. This solution is in line with the suggestion from csurf: https://www.expressjs.com.cn/resources/middleware/csurf.html

## How to review

1. Code Review
1. Run the app locally, and make a random POST request to it. See that you get a 4xx, not a 5xx.
