### PR TITLE
ATO-984 (2/5): Pass `previousSessionId` to StartHandler in POST request

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -63,7 +63,7 @@ export function authorizeGet(
       persistentSessionId,
       req,
       claims.reauthenticate,
-      claims.old_session_id
+      claims.previous_session_id
     );
 
     if (!startAuthResponse.success) {

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -62,7 +62,8 @@ export function authorizeGet(
       clientSessionId,
       persistentSessionId,
       req,
-      claims.reauthenticate
+      claims.reauthenticate,
+      claims.old_session_id
     );
 
     if (!startAuthResponse.success) {

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -25,15 +25,16 @@ export function authorizeService(
     if (supportReauthentication() && reauthenticate) {
       reauthenticateOption = reauthenticate !== "";
     }
-    const response = await axios.client.get<StartAuthResponse>(
+    const body = oldSessionId ? { "old-session-id": oldSessionId } : {};
+    const response = await axios.client.post<StartAuthResponse>(
       API_ENDPOINTS.START,
+      body,
       getInternalRequestConfigWithSecurityHeaders(
         {
           sessionId: sessionId,
           clientSessionId: clientSessionId,
           persistentSessionId: persistentSessionId,
           reauthenticate: reauthenticateOption,
-          oldSessionId: oldSessionId,
         },
         req,
         API_ENDPOINTS.START

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -19,13 +19,15 @@ export function authorizeService(
     persistentSessionId: string,
     req: Request,
     reauthenticate?: string,
-    oldSessionId?: string
+    previousSessionId?: string
   ): Promise<ApiResponseResult<StartAuthResponse>> {
     let reauthenticateOption = undefined;
     if (supportReauthentication() && reauthenticate) {
       reauthenticateOption = reauthenticate !== "";
     }
-    const body = oldSessionId ? { "old-session-id": oldSessionId } : {};
+    const body = previousSessionId
+      ? { "previous-session-id": previousSessionId }
+      : {};
     const response = await axios.client.post<StartAuthResponse>(
       API_ENDPOINTS.START,
       body,

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -18,7 +18,8 @@ export function authorizeService(
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    reauthenticate?: string
+    reauthenticate?: string,
+    oldSessionId?: string
   ): Promise<ApiResponseResult<StartAuthResponse>> {
     let reauthenticateOption = undefined;
     if (supportReauthentication() && reauthenticate) {
@@ -32,6 +33,7 @@ export function authorizeService(
           clientSessionId: clientSessionId,
           persistentSessionId: persistentSessionId,
           reauthenticate: reauthenticateOption,
+          oldSessionId: oldSessionId,
         },
         req,
         API_ENDPOINTS.START

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -33,6 +33,7 @@ export type Claims = {
   rp_state: string;
   reauthenticate?: string;
   claim?: string;
+  old_session_id?: string;
 };
 
 export const requiredClaimsKeys = [

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -33,7 +33,7 @@ export type Claims = {
   rp_state: string;
   reauthenticate?: string;
   claim?: string;
-  old_session_id?: string;
+  previous_session_id?: string;
 };
 
 export const requiredClaimsKeys = [

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../../test/helpers/service-test-helper";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 
-const oldSessionId = "4waJ14KA9IyxKzY7bIGIA3hUDos";
+const previousSessionId = "4waJ14KA9IyxKzY7bIGIA3hUDos";
 
 describe("authorize service", () => {
   let postStub: SinonStub;
@@ -102,7 +102,7 @@ describe("authorize service", () => {
     ).to.be.true;
   });
 
-  it("sends a request with old session ID in the body when given", () => {
+  it("sends a request with previous session ID in the body when given", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(
       sessionId,
@@ -110,13 +110,13 @@ describe("authorize service", () => {
       diPersistentSessionId,
       req,
       undefined,
-      oldSessionId
+      previousSessionId
     );
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { "old-session-id": oldSessionId },
+        { "previous-session-id": previousSessionId },
         {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -15,8 +15,10 @@ import {
 } from "../../../../test/helpers/service-test-helper";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 
+const oldSessionId = "4waJ14KA9IyxKzY7bIGIA3hUDos";
+
 describe("authorize service", () => {
-  let getStub: SinonStub;
+  let postStub: SinonStub;
   let service: AuthorizeServiceInterface;
   const { sessionId, clientSessionId, diPersistentSessionId } = commonVariables;
   const req = createMockRequest(PATH_NAMES.AUTHORIZE, {
@@ -28,13 +30,13 @@ describe("authorize service", () => {
     process.env.API_BASE_URL = "another-base-url";
     const httpInstance = new Http();
     service = authorizeService(httpInstance);
-    getStub = sinon.stub(httpInstance.client, "get");
+    postStub = sinon.stub(httpInstance.client, "post");
   });
 
   afterEach(() => {
     resetApiKeyAndBaseUrlEnvVars();
     delete process.env.SUPPORT_REAUTHENTICATION;
-    getStub.reset();
+    postStub.reset();
   });
 
   it("sends a request with the correct headers set to true when reauth is requested and the feature flag is set", () => {
@@ -48,13 +50,17 @@ describe("authorize service", () => {
     );
 
     expect(
-      getStub.calledOnceWithExactly(API_ENDPOINTS.START, {
-        headers: {
-          ...expectedHeadersFromCommonVarsWithSecurityHeaders,
-          Reauthenticate: true,
-        },
-        proxy: false,
-      })
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {},
+        {
+          headers: {
+            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
+            Reauthenticate: true,
+          },
+          proxy: false,
+        }
+      )
     ).to.be.true;
   });
 
@@ -69,10 +75,14 @@ describe("authorize service", () => {
     );
 
     expect(
-      getStub.calledOnceWithExactly(API_ENDPOINTS.START, {
-        headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
-        proxy: false,
-      })
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {},
+        {
+          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
+          proxy: false,
+        }
+      )
     ).to.be.true;
   });
 
@@ -81,10 +91,39 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req);
 
     expect(
-      getStub.calledOnceWithExactly(API_ENDPOINTS.START, {
-        headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
-        proxy: false,
-      })
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {},
+        {
+          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
+          proxy: false,
+        }
+      )
+    ).to.be.true;
+  });
+
+  it("sends a request with old session ID in the body when given", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    service.start(
+      sessionId,
+      clientSessionId,
+      diPersistentSessionId,
+      req,
+      undefined,
+      oldSessionId
+    );
+
+    expect(
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        { "old-session-id": oldSessionId },
+        {
+          headers: {
+            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
+          },
+          proxy: false,
+        }
+      )
     ).to.be.true;
   });
 });

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -23,7 +23,8 @@ export interface AuthorizeServiceInterface {
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    reauthenticate?: string
+    reauthenticate?: string,
+    oldSessionId?: string
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -24,7 +24,7 @@ export interface AuthorizeServiceInterface {
     persistentSessionId: string,
     req: Request,
     reauthenticate?: string,
-    oldSessionId?: string
+    previousSessionId?: string
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -36,6 +36,7 @@ export interface ConfigOptions {
   baseURL?: string;
   userLanguage?: string;
   reauthenticate?: boolean;
+  oldSessionId?: string;
 }
 
 export function createApiResponse<T>(
@@ -104,6 +105,10 @@ export function getInternalRequestConfigWithSecurityHeaders(
 
   if (options.userLanguage) {
     config.headers["User-Language"] = options.userLanguage;
+  }
+
+  if (options.oldSessionId) {
+    config.headers["Old-Session-Id"] = options.oldSessionId;
   }
 
   return config;

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -36,7 +36,6 @@ export interface ConfigOptions {
   baseURL?: string;
   userLanguage?: string;
   reauthenticate?: boolean;
-  oldSessionId?: string;
 }
 
 export function createApiResponse<T>(
@@ -105,10 +104,6 @@ export function getInternalRequestConfigWithSecurityHeaders(
 
   if (options.userLanguage) {
     config.headers["User-Language"] = options.userLanguage;
-  }
-
-  if (options.oldSessionId) {
-    config.headers["Old-Session-Id"] = options.oldSessionId;
   }
 
   return config;


### PR DESCRIPTION
## Background

`previousSessionId` will be added as a claim in authorize request to Authentication (see 3 below).

This is required in order to break session dependencies between Authentication and Orchestration. When Auth has its own session store (see 2 below), the hash key for the session will be `sessionId`. When `sessionId` gets updated, the record will need to be recreated, and in order to do this, Auth need `previousSessionId` in order to map the previous session ID to the new one (which will be extracted from the gs cookie).

## What

Originally `previousSessionId` was added as a header in the GET request to /start. This has since been changed due to [this comment](https://github.com/govuk-one-login/authentication-api/pull/5154#discussion_r1738887805), but is still present in the commit history.

Request to /start has been changed from GET to POST. This allows `previousSessionId` (and upcoming data needed to passed via API to split Auth / Orch session dependency) to be sent in the request body.


## Related PRs

ATO-984 incremental deployment:
1. https://github.com/govuk-one-login/authentication-api/pull/5171
2. https://github.com/govuk-one-login/authentication-frontend/pull/2006
3. https://github.com/govuk-one-login/authentication-api/pull/5172
4. https://github.com/govuk-one-login/authentication-api/pull/5174
5. TODO: Remove GET from /start methods
