### PR TITLE
AUT-3613: Log a reauth user out if they are blocked for reauth

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -84,6 +84,19 @@ export function authorizeGet(
     setSessionDataFromClaims(req, claims);
     setSessionDataFromAuthResponse(req, startAuthResponse);
 
+    if (
+      supportReauthentication() &&
+      req.session.user.reauthenticate &&
+      startAuthResponse.data.user.isBlockedForReauth
+    ) {
+      logger.info(
+        `Start response indicates user with session ${res.locals.sessionId} is blocked for reauth, redirecting back to orchestration`
+      );
+      return res.redirect(
+        req.session.client.redirectUri.concat("?error=login_required")
+      );
+    }
+
     req.session.user.isAccountCreationJourney = undefined;
 
     logger.info(`Reauth claim length ${claims.reauthenticate?.length}`);

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -15,6 +15,7 @@ export interface UserSessionInfo {
   gaCrossDomainTrackingId?: string;
   docCheckingAppUser: boolean;
   mfaMethodType?: string;
+  isBlockedForReauth: boolean;
 }
 
 export interface AuthorizeServiceInterface {


### PR DESCRIPTION
This ensures that a user who has exceeded the max tries for credential entry on reauth cannot start a new reauth journey - if the start response indicates that a user has any blocks, they will be logged out rather than allowed to proceed with a reauth journey

## How to review


1. Code Review
1. Deploy to authdev1 with the relevant backend (main) deployed
1. Open two different browsers. Log in in both
1. Start a reauth journey in one. Enter the wrong email or the wrong password to the point where you're logged out
1. Start a reauth journey in your other browser. Note that you are immediately logged out

## Related PRs:

Backend PR that started returning this information from the start response: https://github.com/govuk-one-login/authentication-api/pull/5152