### PR TITLE
Aut 3613/logout on max credentials enter password

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -259,18 +259,16 @@ export function enterPasswordPost(
     res: Response,
     req: Request
   ) {
-    if (journeyType == JOURNEY_TYPE.REAUTHENTICATION) {
-      if (req.session.client?.redirectUri) {
-        return res.redirect(
-          req.session.client.redirectUri.concat("?error=login_required")
-        );
-      } else {
-        throw new ReauthJourneyError(
-          "Re-auth journey failed due to missing redirect uri in client session."
-        );
-      }
-    } else {
+    if (journeyType != JOURNEY_TYPE.REAUTHENTICATION) {
       return res.redirect(getErrorPathByCode(errorCode));
     }
+    if (!req.session.client?.redirectUri) {
+      throw new ReauthJourneyError(
+        "Re-auth journey failed due to missing redirect uri in client session."
+      );
+    }
+    return res.redirect(
+      req.session.client.redirectUri.concat("?error=login_required")
+    );
   }
 }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -263,6 +263,11 @@ export function enterPasswordPost(
     req: Request
   ) {
     if (journeyType != JOURNEY_TYPE.REAUTHENTICATION) {
+      if (errorCode == ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED) {
+        throw new ReauthJourneyError(
+          "Reauth error code from login handler returned on a non-reauth journey"
+        );
+      }
       return res.redirect(getErrorPathByCode(errorCode));
     }
     if (!req.session.client?.redirectUri) {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -125,7 +125,10 @@ export function enterPasswordPost(
 
     if (!userLogin.success) {
       const errorCode = userLogin.data.code;
-      if (errorCode === ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED) {
+      if (
+        errorCode === ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED ||
+        errorCode === ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED
+      ) {
         return handleMaxCredentialsReached(errorCode, journeyType, res, req);
       }
 

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -148,4 +148,21 @@ describe("Integration::enter password", () => {
       .expect("Location", REDIRECT_URI.concat("?error=login_required"))
       .expect(302);
   });
+
+  it("should sign out of re-authentication flow when user has reached limit on other reauth credentials", async () => {
+    nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).times(6).reply(400, {
+      code: ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED,
+    });
+
+    await request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "password",
+      })
+      .expect("Location", REDIRECT_URI.concat("?error=login_required"))
+      .expect(302);
+  });
 });


### PR DESCRIPTION
## What

If, on entering a password in a reauth journey, the backend responds with an error code indicating that any reauth count (enter email, enter password or enter mfa) has been exceeded, we want to log someone out. 

Previously, we would have only logged someone out if they had exceeded the password count at this point. However, we want to cover off a case where users are doing multiple concurrent reauthentication journeys. If they get logged out for whatever reason in one reauth journey, they should be logged out at the next possible point in the other.

This change means responding to a new error code in the enter password controller.

Also contains a small bit of refactoring.

## How to review

1. Code Review


## Related PRs

[This PR](https://github.com/govuk-one-login/authentication-api/pull/5180) in the backend starts doing this check against all reauth counts, and returning the error response we're responding to here