### PR TITLE
AUT-3686: Fix broken sentence for 2hr lockout warning

### DIFF
--- a/src/components/account-creation/resend-mfa-code/index.njk
+++ b/src/components/account-creation/resend-mfa-code/index.njk
@@ -26,7 +26,7 @@
         }) }}
 
         {% if support2hrLockout %}
-        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}}</p>
+        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}} {{'pages.resendMfaCode.action' | translate}}</p>
         {% endif %}
 
         <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -21,7 +21,7 @@
         }) }}
 
         {% if support2hrLockout %}
-        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}}</p>
+        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}} {{'pages.resendMfaCode.action' | translate}}</p>
         {% endif %}
 
         <p class="govuk-body">{{'pages.resendMfaCode.email.paragraph' | translate}}</p>

--- a/src/components/reset-password-check-email/index-reset-password-resend-code.njk
+++ b/src/components/reset-password-check-email/index-reset-password-resend-code.njk
@@ -15,7 +15,7 @@
     }) }}
 
     {% if support2hrLockout %}
-        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}}</p>
+        <p class="govuk-body">{{'pages.resendMfaCode.paragraph1' | translate}} {{'pages.resendMfaCode.action' | translate}}</p>
     {% endif %}
 
     <p class="govuk-body">{{ 'pages.resendMfaCode.email.paragraph' | translate }}</p>


### PR DESCRIPTION
## What

399095bbce10ab1421621e31ce76b79659b60b70 introduced a split in the string that warns the user if they request more than 5 security codes they will be locked out for 2 hours. There are certain other template pages that warn of the same, but the split string was not concatenated, meaning the pages would only show the first half of the sentence.

This adds the last half of the sentence back where it is missing.

## How to review

1. Code Review, compare to the string before the split in 399095bbce10ab1421621e31ce76b79659b60b70

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/1860