### PR TITLE
BAU: Helmet dependency upgrade with default override

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": "18.x"
+    "node": "18.20.*"
   },
   "scripts": {
     "build-ts": "tsc",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "express-session": "^1.17.2",
     "express-validator": "^6.13.0",
     "govuk-frontend": "^4.8.0",
-    "helmet": "4.6.0",
+    "helmet": "7.1.0",
     "i18next": "^21.6.5",
     "i18next-fs-backend": "^2.3.1",
     "i18next-http-middleware": "^3.2.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -180,7 +180,7 @@ async function createApp(): Promise<express.Application> {
     );
 
   app.use(i18nextMiddleware.handle(i18next));
-  app.use(helmet(helmetConfiguration()));
+  app.use(helmet(helmetConfiguration));
 
   app.use(
     session({

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -1,76 +1,50 @@
-import helmet from "helmet";
-import e, { Request, Response } from "express";
-// Helmet does not export the config type - This is the way the recommend getting it on GitHub.
-export function helmetConfiguration(): Parameters<typeof helmet>[0] {
-  const helmetConfig: {
-    permittedCrossDomainPolicies: boolean;
-    referrerPolicy: boolean;
-    expectCt: boolean;
-    frameguard: { action: string };
-    hsts: { maxAge: number; includeSubDomains: boolean; preload: boolean };
-    dnsPrefetchControl: { allow: boolean };
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: string[];
-        objectSrc: string[];
-        styleSrc: string[];
-        scriptSrc: (string | ((req: e.Request, res: e.Response) => string))[];
-        imgSrc: string[];
-        connectSrc: string[];
-        "form-action"?: string[];
-        "frame-ancestors"?: string[];
-      };
-    };
-  } = {
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"],
-        styleSrc: ["'self'"],
-        scriptSrc: [
-          "'self'",
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-          (req: Request, res: Response): string =>
-            `'nonce-${res.locals.scriptNonce}'`,
-          "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
-          "https://*.googletagmanager.com",
-          "https://www.google-analytics.com",
-          "https://ssl.google-analytics.com",
-        ],
-        imgSrc: [
-          "'self'",
-          "data:",
-          "https://*.google-analytics.com",
-          "https://*.googletagmanager.com",
-          "https://www.google-analytics.com",
-        ],
-        objectSrc: ["'none'"],
-        connectSrc: [
-          "'self'",
-          "https://*.google-analytics.com",
-          "https://*.analytics.google.com",
-          "https://*.googletagmanager.com",
-          "https://www.google-analytics.com",
-        ],
-      },
+import { HelmetOptions } from "helmet";
+import { Request, Response } from "express";
+
+export const helmetConfiguration: HelmetOptions = {
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      styleSrc: ["'self'"],
+      scriptSrc: [
+        "'self'",
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+        (req: Request, res: Response): string =>
+          `'nonce-${res.locals.scriptNonce}'`,
+        "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
+        "https://*.googletagmanager.com",
+        "https://www.google-analytics.com",
+        "https://ssl.google-analytics.com",
+      ],
+      imgSrc: [
+        "'self'",
+        "data:",
+        "https://*.google-analytics.com",
+        "https://*.googletagmanager.com",
+        "https://www.google-analytics.com",
+      ],
+      objectSrc: ["'none'"],
+      connectSrc: [
+        "'self'",
+        "https://*.google-analytics.com",
+        "https://*.analytics.google.com",
+        "https://*.googletagmanager.com",
+        "https://www.google-analytics.com",
+      ],
+      frameAncestors: ["'self'", "https://*.account.gov.uk"],
     },
-    dnsPrefetchControl: {
-      allow: false,
-    },
-    frameguard: {
-      action: "deny",
-    },
-    hsts: {
-      maxAge: 31536000, // 1 Year
-      preload: true,
-      includeSubDomains: true,
-    },
-    referrerPolicy: false,
-    permittedCrossDomainPolicies: false,
-    expectCt: false,
-  };
-  helmetConfig.contentSecurityPolicy.directives["frame-ancestors"] = [
-    "'self'",
-    "https://*.account.gov.uk",
-  ];
-  return helmetConfig;
-}
+  },
+  dnsPrefetchControl: {
+    allow: false,
+  },
+  frameguard: {
+    action: "deny",
+  },
+  hsts: {
+    maxAge: 31536000, // 1 Year
+    preload: true,
+    includeSubDomains: true,
+  },
+  referrerPolicy: false,
+  permittedCrossDomainPolicies: false,
+};

--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -32,6 +32,7 @@ export const helmetConfiguration: HelmetOptions = {
         "https://www.google-analytics.com",
       ],
       frameAncestors: ["'self'", "https://*.account.gov.uk"],
+      formAction: null,
     },
   },
   dnsPrefetchControl: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -917,7 +917,12 @@
   resolved "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
+"@jridgewell/sourcemap-codec@^1.4.14":
   version "1.4.15"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -1512,24 +1517,24 @@
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
 "@tsconfig/node10@^1.0.7":
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz"
-  integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
 
 "@tsconfig/node12@^1.0.7":
-  version "1.0.9"
-  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz"
-  integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
 "@tsconfig/node14@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz"
-  integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/node16@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz"
-  integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -1926,11 +1931,18 @@ acorn-jsx@^5.3.2:
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^8.1.1:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
+  integrity sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==
+  dependencies:
+    acorn "^8.11.0"
 
-acorn@^8.4.1, acorn@^8.9.0:
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+
+acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
@@ -2066,7 +2078,7 @@ archy@^1.0.0:
 
 arg@^4.1.0:
   version "4.1.3"
-  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
@@ -2720,7 +2732,7 @@ crc32-stream@^6.0.0:
 
 create-require@^1.1.0:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2:
@@ -2894,7 +2906,7 @@ dezalgo@^1.0.4:
 
 diff@^4.0.1:
   version "4.0.2"
-  resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.2.0:
@@ -3721,10 +3733,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-helmet@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.npmjs.org/helmet/-/helmet-4.6.0.tgz"
-  integrity sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==
+helmet@7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-7.1.0.tgz#287279e00f8a3763d5dccbaf1e5ee39b8c3784ca"
+  integrity sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==
 
 help-me@^5.0.0:
   version "5.0.0"
@@ -4240,7 +4252,7 @@ make-dir@^3.0.0, make-dir@^3.0.2:
 
 make-error@^1.1.1:
   version "1.3.6"
-  resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 media-typer@0.3.0:
@@ -6195,7 +6207,7 @@ yargs@^17.7.2:
 
 yn@3.1.1:
   version "3.1.1"
-  resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5861,9 +5861,9 @@ typedarray-to-buffer@^3.1.5:
     is-typedarray "^1.0.0"
 
 typescript@^4.5.4:
-  version "4.5.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.14.5:
   version "3.19.2"


### PR DESCRIPTION
## What

This PR does three things, all of which are required to meet a dependency bump for `helmet` that was initially proposed by dependabot (see https://github.com/govuk-one-login/authentication-frontend/pull/1716):

1. Updates the TypeScript version to that required by Helmet, and updates Node engine to that required by this TypeScript version (See commit message for f4e495d362293231ae02a4d5fefe95a18214e5a2)
2. Updates the Helmet dependency, refactors the Helmet config and removes a deprecated option (See commit  message for c4f16b820983a1c4af1b53861b0ec7889952fc4d)
3. Overrides one of the new default CSP directives set by Helmet because this was causing our acceptance tests to fail (See commit message for ab4e31d982938d9a58aa689a3b483cd755c0edb3)

### How this PR changes the CSP

The upgrade to `helmet` will add these new directives to the CSP:

* `base-uri 'self';` directs that the <base> element can use URLs that match the same origin as the page
* `font-src 'self' https: data:;` directs to only allow loading of fonts via `@font-face` over a specific scheme and from the same origin
* `script-src-attr 'none';` directs that inline script handlers should not be allowed
* `upgrade-insecure-requests` directs that all insecure URLs (HTTP) shoul be treated as though they have been replaced with secure URLs (those served over HTTPS)

## How to review

1. Code Review
1. Deploy to a dev environment and test an account creation or sign-in journey (Note: I have tested both the account creation and sign-in journeys in dev before sharing the PR)

## Related PRs

This PR replays the Helmet dependency bump that was introduced in #1996 and subsequently reverted in #1998
