### PR TITLE
Aut 3530/logout on failed counts mfa

### DIFF
--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -307,5 +307,24 @@ describe("Verify code controller tests", () => {
         EXAMPLE_REDIRECT_URI.concat("?error=login_required")
       );
     });
+
+    it("should redirect to logged out if reauth is enabled and user entered too many invalid reauth details", async () => {
+      const verifyCodeService = fakeVerifyCodeServiceHelper(
+        false,
+        ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED
+      );
+
+      await verifyCodePost(
+        verifyCodeService,
+        noInterventionsService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
+
+      expect(noInterventionsService.accountInterventionStatus).to.not.be.called;
+
+      expect(res.redirect).to.have.calledWith(
+        EXAMPLE_REDIRECT_URI.concat("?error=login_required")
+      );
+    });
   });
 });

--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -16,14 +16,17 @@ import {
 } from "../../../../app.constants";
 import { ERROR_CODES, getErrorPathByCode } from "../../constants";
 import { createMockRequest } from "../../../../../test/helpers/mock-request-helper";
+import { AccountInterventionsInterface } from "../../../account-intervention/types";
 
 describe("Verify code controller tests", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
+  let noInterventionsService: AccountInterventionsInterface;
+
   const EXAMPLE_REDIRECT_URI = "https://example.com/redirect";
   beforeEach(() => {
     process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
-
+    noInterventionsService = accountInterventionsFakeHelper(noInterventions);
     res = mockResponse();
   });
 
@@ -31,60 +34,67 @@ describe("Verify code controller tests", () => {
     delete process.env.SUPPORT_ACCOUNT_INTERVENTIONS;
   });
 
-  it("if code is valid and NOTIFICATION_TYPE.EMAIL_CODE redirects to /enter-password without calling account interventions", async () => {
-    const verifyCodeService = fakeVerifyCodeServiceHelper(true);
-    const accountInterventionService =
-      accountInterventionsFakeHelper(noInterventions);
-
-    req = createMockRequest(PATH_NAMES.ENTER_PASSWORD);
-    req.session.user = { email: "test@test.com" };
-
-    await verifyCodePost(verifyCodeService, accountInterventionService, {
+  describe("verify email notification type", () => {
+    const verifyCodePostOptions = {
       notificationType: NOTIFICATION_TYPE.VERIFY_EMAIL,
       template: "check-your-email/index.njk",
       validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
       validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-    })(req as Request, res as Response);
-
-    expect(accountInterventionService.accountInterventionStatus).to.not.be
-      .called;
-
-    expect(res.redirect).to.have.calledWith("/enter-password");
-  });
-
-  it("if code is invalid and too many email opt codes entered during registration redirect to /security-code-invalid without calling account interventions", async () => {
-    const verifyCodeService = fakeVerifyCodeServiceHelper(
-      false,
-      ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES
-    );
-    const accountInterventionService =
-      accountInterventionsFakeHelper(noInterventions);
-
-    req = createMockRequest(PATH_NAMES.CHECK_YOUR_EMAIL);
-    req.session.user = {
-      email: "test@test.com",
-      isAccountCreationJourney: true,
     };
 
-    await verifyCodePost(verifyCodeService, accountInterventionService, {
-      notificationType: NOTIFICATION_TYPE.VERIFY_EMAIL,
-      template: "check-your-email/index.njk",
-      validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-      validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-    })(req as Request, res as Response);
+    it("if code is valid and NOTIFICATION_TYPE.EMAIL_CODE redirects to /enter-password without calling account interventions", async () => {
+      const verifyCodeService = fakeVerifyCodeServiceHelper(true);
 
-    expect(accountInterventionService.accountInterventionStatus).to.not.be
-      .called;
+      req = createMockRequest(PATH_NAMES.ENTER_PASSWORD);
+      req.session.user = { email: "test@test.com" };
 
-    expect(res.redirect).to.have.calledWith(
-      getErrorPathByCode(
+      await verifyCodePost(
+        verifyCodeService,
+        noInterventionsService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
+
+      expect(noInterventionsService.accountInterventionStatus).to.not.be.called;
+
+      expect(res.redirect).to.have.calledWith("/enter-password");
+    });
+
+    it("if code is invalid and too many email opt codes entered during registration redirect to /security-code-invalid without calling account interventions", async () => {
+      const verifyCodeService = fakeVerifyCodeServiceHelper(
+        false,
         ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES
-      )
-    );
+      );
+
+      req = createMockRequest(PATH_NAMES.CHECK_YOUR_EMAIL);
+      req.session.user = {
+        email: "test@test.com",
+        isAccountCreationJourney: true,
+      };
+
+      await verifyCodePost(
+        verifyCodeService,
+        noInterventionsService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
+
+      expect(noInterventionsService.accountInterventionStatus).to.not.be.called;
+
+      expect(res.redirect).to.have.calledWith(
+        getErrorPathByCode(
+          ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES
+        )
+      );
+    });
   });
 
   describe("When code is valid and NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES and code is valid", () => {
     const verifyCodeService = fakeVerifyCodeServiceHelper(true);
+    const verifyCodePostOptions = {
+      notificationType: NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+      template: "check-your-email/index.njk",
+      validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
+      validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
+    };
     beforeEach(() => {
       req = createMockRequest(
         PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES
@@ -99,13 +109,11 @@ describe("Verify code controller tests", () => {
         temporarilySuspended: false,
         reproveIdentity: false,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType:
-          NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -119,13 +127,11 @@ describe("Verify code controller tests", () => {
         passwordResetRequired: false,
         reproveIdentity: false,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType:
-          NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -139,13 +145,11 @@ describe("Verify code controller tests", () => {
         blocked: false,
         reproveIdentity: false,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType:
-          NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -159,13 +163,11 @@ describe("Verify code controller tests", () => {
         blocked: false,
         reproveIdentity: true,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType:
-          NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -173,17 +175,13 @@ describe("Verify code controller tests", () => {
     });
 
     it("if account has no AIS status, redirects to /get-security-codes", async () => {
-      const accountInterventionService =
-        accountInterventionsFakeHelper(noInterventions);
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType:
-          NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        noInterventionsService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
-      expect(accountInterventionService.accountInterventionStatus).to.have.been
+      expect(noInterventionsService.accountInterventionStatus).to.have.been
         .called;
       expect(res.redirect).to.have.calledWith("/get-security-codes");
     });
@@ -191,23 +189,26 @@ describe("Verify code controller tests", () => {
 
   describe("When code is valid and NOTIFICATION_TYPE.MFA_SMS", () => {
     const verifyCodeService = fakeVerifyCodeServiceHelper(true);
+    const verifyCodePostOptions = {
+      notificationType: NOTIFICATION_TYPE.MFA_SMS,
+      template: "check-your-email/index.njk",
+      validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
+      validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
+      journeyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
+    };
     beforeEach(() => {
       req = createMockRequest(PATH_NAMES.RESET_PASSWORD_2FA_SMS);
       req.session.user = { email: "test@test.com" };
     });
 
     it("if account has no AIS status, redirects to reset password", async () => {
-      const accountInterventionService =
-        accountInterventionsFakeHelper(noInterventions);
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType: NOTIFICATION_TYPE.MFA_SMS,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-        journeyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        noInterventionsService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
-      expect(accountInterventionService.accountInterventionStatus).to.have.been
+      expect(noInterventionsService.accountInterventionStatus).to.have.been
         .called;
       expect(res.redirect).to.have.calledWith("/reset-password");
     });
@@ -219,13 +220,11 @@ describe("Verify code controller tests", () => {
         passwordResetRequired: false,
         reproveIdentity: false,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType: NOTIFICATION_TYPE.MFA_SMS,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-        journeyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -239,13 +238,11 @@ describe("Verify code controller tests", () => {
         temporarilySuspended: false,
         reproveIdentity: false,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType: NOTIFICATION_TYPE.MFA_SMS,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-        journeyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -259,13 +256,11 @@ describe("Verify code controller tests", () => {
         blocked: false,
         reproveIdentity: false,
       });
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
-        notificationType: NOTIFICATION_TYPE.MFA_SMS,
-        template: "check-your-email/index.njk",
-        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
-        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
-        journeyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
-      })(req as Request, res as Response);
+      await verifyCodePost(
+        verifyCodeService,
+        accountInterventionService,
+        verifyCodePostOptions
+      )(req as Request, res as Response);
 
       expect(accountInterventionService.accountInterventionStatus).to.have.been
         .called;
@@ -277,8 +272,6 @@ describe("Verify code controller tests", () => {
         false,
         ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES
       );
-      const accountInterventionService =
-        accountInterventionsFakeHelper(noInterventions);
       process.env.SUPPORT_REAUTHENTICATION = "1";
 
       req = createMockRequest(PATH_NAMES.ENTER_MFA);
@@ -291,7 +284,7 @@ describe("Verify code controller tests", () => {
         redirectUri: EXAMPLE_REDIRECT_URI,
       };
 
-      await verifyCodePost(verifyCodeService, accountInterventionService, {
+      await verifyCodePost(verifyCodeService, noInterventionsService, {
         notificationType: NOTIFICATION_TYPE.MFA_SMS,
         template: "enter-mfa/index.njk",
         validationKey: "pages.enterMfa.code.validationError.invalidCode",
@@ -299,8 +292,7 @@ describe("Verify code controller tests", () => {
         journeyType: JOURNEY_TYPE.REAUTHENTICATION,
       })(req as Request, res as Response);
 
-      expect(accountInterventionService.accountInterventionStatus).to.not.be
-        .called;
+      expect(noInterventionsService.accountInterventionStatus).to.not.be.called;
 
       expect(res.redirect).to.have.calledWith(
         EXAMPLE_REDIRECT_URI.concat("?error=login_required")

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -68,7 +68,9 @@ export function verifyCodePost(
         if (
           result.data.code ===
             ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED ||
-          result.data.code === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES
+          result.data.code === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES ||
+          result.data.code ===
+            ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED
         ) {
           return res.redirect(
             req.session.client.redirectUri.concat("?error=login_required")

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -158,6 +158,19 @@ export const enterAuthenticatorAppCodePost = (
         ).toUTCString();
       }
 
+      if (error === ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED) {
+        if (
+          supportReauthentication() &&
+          journeyType == JOURNEY_TYPE.REAUTHENTICATION
+        ) {
+          return handleReauthFailure(req, res);
+        } else {
+          throw new ReauthJourneyError(
+            "Reauth erorr response returned on a non reauth journey"
+          );
+        }
+      }
+
       const path = getErrorPathByCode(result.data.code);
 
       if (path) {

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -306,5 +306,34 @@ describe("enter authenticator app code controller", () => {
         `https://rp.gov.uk/redirect?error=login_required`
       );
     });
+
+    it("should redirect to orchestration with error required login reauth journey on reauth sign in details exceeded", async () => {
+      process.env.SUPPORT_REAUTHENTICATION = "1";
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          data: {
+            code: ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED,
+            message: "",
+          },
+          success: false,
+        }),
+      } as unknown as VerifyMfaCodeInterface;
+
+      req.t = sinon.fake.returns("translated string");
+      req.body.code = "678988";
+      res.locals.sessionId = "123456-djjad";
+      req.session.user.reauthenticate = "reauth";
+      req.session.client.redirectUri = "https://rp.gov.uk/redirect";
+
+      await enterAuthenticatorAppCodePost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
+      expect(res.redirect).to.have.been.calledWith(
+        `https://rp.gov.uk/redirect?error=login_required`
+      );
+    });
   });
 });


### PR DESCRIPTION
## What

On mfa entry (auth app or sms) in the reauth journey, we want to log someone out if the response from the backend indicates that they have exceeded any reauth credential entry counts. This is to handle edge cases around multiple reauth journeys taking place for a single user at once.

This won't currently affect behaviour, as we'll need to make a change to the backend to start sending these error responses at these points.

Also contains some test refactors.

## How to review

1. Code Review commit by commit

