### PR TITLE
⚠️ DO NOT APPROVE:  AUT-3665: Demonstrate independent pages approach.

### DIFF
--- a/src/components/common/layout/mobile/base.njk
+++ b/src/components/common/layout/mobile/base.njk
@@ -1,0 +1,134 @@
+{% extends "govuk/template.njk" %}
+{% from "ga4-opl/macro.njk" import ga4OnPageLoad %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "frontend-language-toggle/macro.njk" import languageSelect %}
+
+{% block head %}
+
+    <!--[if !IE 8]><!-->
+    <link href="/public/style.css" rel="stylesheet">
+    <!--<![endif]-->
+
+    {# For Internet Explorer 8, you need to compile specific stylesheet #}
+    {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
+    <!--[if IE 8]>
+    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
+    <![endif]-->
+
+    {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
+    <!--[if lt IE 9]>
+    <script src="/html5-shiv/html5shiv.js"></script>
+    <![endif]-->
+
+    {% block headMetaData %}{% endblock %}
+
+{% endblock %}
+
+{% block pageTitle %}
+    {% if error or errors %}
+        {{ 'general.errorTitlePrefix' | translate }}
+        -
+    {% endif %}
+    {% if pageTitleName %}
+        {{ pageTitleName }}
+        -
+    {% endif %}
+    {{ 'general.serviceNameTitle' | translate }}
+{% endblock %}
+
+{% block bodyStart %}
+    {% include 'common/layout/banner.njk' %}
+{% endblock %}
+
+{% block header %}
+    <header class="govuk-header" data-module="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+            <div class="govuk-header__logo">
+                    <svg
+                            focusable="false"
+                            role="img"
+                            class="govuk-header__logotype"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 148 30"
+                            height="30"
+                            fill="#fff"
+                            width="148"
+                            aria-label="GOV.UK">
+                        <title>GOV.UK</title>
+                        <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+                    </svg>
+            </div>
+        </div>
+    </header>
+{% endblock %}
+
+{% block main %}
+    <div class="govuk-width-container {{ containerClasses }}">
+        {% block beforeContent %}{% endblock %}
+        {% if languageToggleEnabled %}
+        {{ languageSelect({
+            ariaLabel: 'general.languageToggle.ariaLabel' | translate,
+            activeLanguage: htmlLang,
+            url: currentUrl,
+            languages: [
+                {
+                    code: 'en',
+                    text: 'English',
+                    visuallyHidden: 'general.languageToggle.visuallyHiddenChangeLanguage' | translate
+                },
+                {
+                    code:'cy',
+                    text: 'Cymraeg',
+                    visuallyHidden: 'general.languageToggle.visuallyHiddenChangeLanguage' | translate
+                }]
+        })
+        }}
+        {% endif %}
+
+
+        {% if showBack %}
+            {{ govukBackLink({
+                text: "general.back" | translate,
+                href: hrefBack
+            }) }}
+        {% endif %}
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"
+              role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+                    {% block content %}{% endblock %}
+                </div>
+            </div>
+        </main>
+    </div>
+{% endblock %}
+
+{% block footer %}
+
+{% endblock %}
+
+{% block bodyEnd %}
+    {% block scripts %}{% endblock %}
+    <script type="text/javascript" src="/public/scripts/cookies.js"></script>
+    <script type="text/javascript" src="/public/scripts/application.js"></script>
+    <script type="text/javascript" src="/public/scripts/all.js"></script>
+    <script type="text/javascript" src="/public/scripts/analytics.js"></script>
+    <script type="text/javascript" {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
+        if (window.DI) {
+            if (window.DI.appInit) {
+                window
+                    .DI
+                    .appInit({
+                        ga4ContainerId: "{{ga4ContainerId}}",
+                        uaContainerId: "{{uaContainerId}}"
+                    }, {
+                        isDataSensitive: false,
+                        disableGa4Tracking: {{isGa4Disabled}},
+                        disableUaTracking: {{isUaDisabled}},
+                        cookieDomain: "{{analyticsCookieDomain}}"
+                    });
+            }
+        }
+    </script>
+{% endblock %}

--- a/src/components/sign-in-or-create/mobile-templates/index.njk
+++ b/src/components/sign-in-or-create/mobile-templates/index.njk
@@ -1,0 +1,34 @@
+{% extends "common/layout/mobile/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitleName = 'mobileAppPages.signInOrCreate.title' | translate %}
+
+{% block content %}
+    {% include "common/errors/errorSummary.njk" %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'mobileAppPages.signInOrCreate.header' | translate | striptags | safe }} </h1>
+
+    <p class="govuk-body">
+        {{ 'mobileAppPages.signInOrCreate.introParagraph' | translate }}
+    </p>
+
+    <form action="/sign-in-or-create" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="supportInternationalNumbers" value="{{ supportInternationalNumbers }}" />
+
+        <div>
+            {{ govukButton({
+                text: 'mobileAppPages.signInOrCreate.signInButtonText' | translate,
+                classes: "govuk-button--primary",
+                attributes: {
+                    "id": "sign-in-button"
+                }
+            }) }}
+        </div>
+
+    </form>
+
+    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true })}}
+
+{% endblock %}

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { mobileOrWebTemplate } from "../../utils/mobile-or-web-template";
 
 export async function signInOrCreateGet(
   req: Request,
@@ -12,7 +13,14 @@ export async function signInOrCreateGet(
   if (req.query.redirectPost) {
     return await signInOrCreatePost(req, res);
   }
-  res.render("sign-in-or-create/index.njk", {
+
+  // Do not approve a PR with the following line
+  // ===========================================
+  // It is forcing the controller to render the
+  // template that is intended for the mobile app.
+  const template = mobileOrWebTemplate("sign-in-or-create/index.njk", true);
+
+  res.render(template, {
     serviceType: req.session.client.serviceType,
   });
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -160,6 +160,13 @@
       }
     }
   },
+  "mobileAppPages": {
+    "signInOrCreate": {
+      "header": "Mewngofnodwch gyda GOV.UK One Login",
+      "introParagraph": "Gallwch ddefnyddio eich GOV.UK One Login i brofi pwy ydych a chael mynediad at rai o wasanaethau’r llywodraeth.",
+      "signInButtonText": "Mewngofnodi"
+    }
+  },
   "pages": {
     "signInOrCreate": {
       "mandatory": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -163,7 +163,7 @@
   "mobileAppPages": {
     "signInOrCreate": {
       "header": "Mewngofnodwch gyda GOV.UK One Login",
-      "introParagraph": "Gallwch ddefnyddio eich GOV.UK One Login i brofi pwy ydych a chael mynediad at rai o wasanaethau’r llywodraeth.",
+      "introParagraph": "Gallwch ddefnyddio eich GOV.UK One Login i brofi pwy ydych a chael mynediad at rai o wasanaethau'r llywodraeth.",
       "signInButtonText": "Mewngofnodi"
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -160,6 +160,13 @@
       }
     }
   },
+  "mobileAppPages": {
+    "signInOrCreate": {
+      "header": "Sign in with GOV.UK One Login",
+      "introParagraph": "You can use your GOV.UK One Login to prove your identity and access some government services.",
+      "signInButtonText": "Sign in"
+    }
+  },
   "pages": {
     "signInOrCreate": {
       "mandatory": {

--- a/src/utils/mobile-or-web-template.ts
+++ b/src/utils/mobile-or-web-template.ts
@@ -6,6 +6,9 @@ export function mobileOrWebTemplate(
   const mobileTemplatesFolderName = "mobile-templates";
 
   return isMobileContext
-    ? webTemplate.replace(capturePathAndFilenameRegExp, `$1${mobileTemplatesFolderName}/$2`)
+    ? webTemplate.replace(
+        capturePathAndFilenameRegExp,
+        `$1${mobileTemplatesFolderName}/$2`
+      )
     : webTemplate;
 }

--- a/src/utils/mobile-or-web-template.ts
+++ b/src/utils/mobile-or-web-template.ts
@@ -1,0 +1,11 @@
+export function mobileOrWebTemplate(
+  webTemplate: string,
+  isMobileContext: boolean
+): string {
+  const capturePathAndFilenameRegExp = /([a-z-]*\/)([a-z-]+\.njk)/;
+  const mobileTemplatesFolderName = "mobile-templates";
+
+  return isMobileContext
+    ? webTemplate.replace(capturePathAndFilenameRegExp, `$1${mobileTemplatesFolderName}/$2`)
+    : webTemplate;
+}

--- a/test/unit/utils/mobile-or-web-template.test.ts
+++ b/test/unit/utils/mobile-or-web-template.test.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { mobileOrWebTemplate } from "../../../src/utils/mobile-or-web-template";
+
+describe("mobileOrWebTemplate", () => {
+  const webTemplate = "sign-in-or-create/index.njk";
+
+  describe("", () => {
+    it("should return the original webTemplate when isMobileContext is false", () => {
+      expect(mobileOrWebTemplate(webTemplate, false)).to.equal(webTemplate);
+    });
+
+    it("should not return the original webTemplate when isMobileContext is true", () => {
+      expect(mobileOrWebTemplate(webTemplate, true)).to.not.equal(webTemplate);
+    });
+
+    it("should return the webTemplate filename with '-mobile-context.njk' suffix when isMobileContext is true", () => {
+      const expectedTransforms: any = {
+        "sign-in-or-create/index.njk":
+          "sign-in-or-create/mobile-templates/index.njk",
+        "account-creation/resend-mfa-code/index.njk":
+          "account-creation/resend-mfa-code/mobile-templates/index.njk",
+      };
+
+      for (const property in expectedTransforms) {
+        expect(mobileOrWebTemplate(property, true)).to.equal(
+          expectedTransforms[property]
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Demonstrates how we might implement the independent pages approach set out in the ADR. See Jira ticket for more information. 

This is achieved by: 

- Introducing a helper function that will translate a web template path to use its mobile counterpart where the context is mobile (See commit feb7dffe786dc7bd18497832480a98b97a1d027a for more detail)
- Introducing a mobile specific layout that will be used by all mobile templates (See commit f1e331f1f2636c4241a8435cb9d89d8e27355090 for more detail)
- Introducing a separate locale block to be used for all mobile templates (See commit 1d326f2ca0840f388953732aab0d866141067cd2 for more detail)
- Adds and forces the render of a mobile landing page template (See commit 9673732cd32d51b19d74d778d71031fcec5ec68a)
- Adds a commit also breaks the tests to prevent this change from making it to production (See commit b6f7528e671266a8061f91fda96462ac8b1ce3a9)

