### PR TITLE
Revert "ATO-984 (2/5): Pass `previousSessionId` to StartHandler in POST request"

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -62,8 +62,7 @@ export function authorizeGet(
       clientSessionId,
       persistentSessionId,
       req,
-      claims.reauthenticate,
-      claims.previous_session_id
+      claims.reauthenticate
     );
 
     if (!startAuthResponse.success) {

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -18,19 +18,14 @@ export function authorizeService(
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    reauthenticate?: string,
-    previousSessionId?: string
+    reauthenticate?: string
   ): Promise<ApiResponseResult<StartAuthResponse>> {
     let reauthenticateOption = undefined;
     if (supportReauthentication() && reauthenticate) {
       reauthenticateOption = reauthenticate !== "";
     }
-    const body = previousSessionId
-      ? { "previous-session-id": previousSessionId }
-      : {};
-    const response = await axios.client.post<StartAuthResponse>(
+    const response = await axios.client.get<StartAuthResponse>(
       API_ENDPOINTS.START,
-      body,
       getInternalRequestConfigWithSecurityHeaders(
         {
           sessionId: sessionId,

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -33,7 +33,6 @@ export type Claims = {
   rp_state: string;
   reauthenticate?: string;
   claim?: string;
-  previous_session_id?: string;
 };
 
 export const requiredClaimsKeys = [

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -15,10 +15,8 @@ import {
 } from "../../../../test/helpers/service-test-helper";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 
-const previousSessionId = "4waJ14KA9IyxKzY7bIGIA3hUDos";
-
 describe("authorize service", () => {
-  let postStub: SinonStub;
+  let getStub: SinonStub;
   let service: AuthorizeServiceInterface;
   const { sessionId, clientSessionId, diPersistentSessionId } = commonVariables;
   const req = createMockRequest(PATH_NAMES.AUTHORIZE, {
@@ -30,13 +28,13 @@ describe("authorize service", () => {
     process.env.API_BASE_URL = "another-base-url";
     const httpInstance = new Http();
     service = authorizeService(httpInstance);
-    postStub = sinon.stub(httpInstance.client, "post");
+    getStub = sinon.stub(httpInstance.client, "get");
   });
 
   afterEach(() => {
     resetApiKeyAndBaseUrlEnvVars();
     delete process.env.SUPPORT_REAUTHENTICATION;
-    postStub.reset();
+    getStub.reset();
   });
 
   it("sends a request with the correct headers set to true when reauth is requested and the feature flag is set", () => {
@@ -50,17 +48,13 @@ describe("authorize service", () => {
     );
 
     expect(
-      postStub.calledOnceWithExactly(
-        API_ENDPOINTS.START,
-        {},
-        {
-          headers: {
-            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
-            Reauthenticate: true,
-          },
-          proxy: false,
-        }
-      )
+      getStub.calledOnceWithExactly(API_ENDPOINTS.START, {
+        headers: {
+          ...expectedHeadersFromCommonVarsWithSecurityHeaders,
+          Reauthenticate: true,
+        },
+        proxy: false,
+      })
     ).to.be.true;
   });
 
@@ -75,14 +69,10 @@ describe("authorize service", () => {
     );
 
     expect(
-      postStub.calledOnceWithExactly(
-        API_ENDPOINTS.START,
-        {},
-        {
-          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
-          proxy: false,
-        }
-      )
+      getStub.calledOnceWithExactly(API_ENDPOINTS.START, {
+        headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
+        proxy: false,
+      })
     ).to.be.true;
   });
 
@@ -91,39 +81,10 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req);
 
     expect(
-      postStub.calledOnceWithExactly(
-        API_ENDPOINTS.START,
-        {},
-        {
-          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
-          proxy: false,
-        }
-      )
-    ).to.be.true;
-  });
-
-  it("sends a request with previous session ID in the body when given", () => {
-    process.env.SUPPORT_REAUTHENTICATION = "1";
-    service.start(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      undefined,
-      previousSessionId
-    );
-
-    expect(
-      postStub.calledOnceWithExactly(
-        API_ENDPOINTS.START,
-        { "previous-session-id": previousSessionId },
-        {
-          headers: {
-            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
-          },
-          proxy: false,
-        }
-      )
+      getStub.calledOnceWithExactly(API_ENDPOINTS.START, {
+        headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
+        proxy: false,
+      })
     ).to.be.true;
   });
 });

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -24,8 +24,7 @@ export interface AuthorizeServiceInterface {
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    reauthenticate?: string,
-    previousSessionId?: string
+    reauthenticate?: string
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 


### PR DESCRIPTION
Reverts govuk-one-login/authentication-frontend#2006