### PR TITLE
⚠️ DO NOT APPROVE:  AUT-3665: Demonstrate shared pages approach.

### DIFF
--- a/src/components/common/layout/mobile/base.njk
+++ b/src/components/common/layout/mobile/base.njk
@@ -1,0 +1,134 @@
+{% extends "govuk/template.njk" %}
+{% from "ga4-opl/macro.njk" import ga4OnPageLoad %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "frontend-language-toggle/macro.njk" import languageSelect %}
+
+{% block head %}
+
+    <!--[if !IE 8]><!-->
+    <link href="/public/style.css" rel="stylesheet">
+    <!--<![endif]-->
+
+    {# For Internet Explorer 8, you need to compile specific stylesheet #}
+    {# see https://frontend.design-system.service.gov.uk/supporting-ie8/#support-internet-explorer-8 #}
+    <!--[if IE 8]>
+    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet">
+    <![endif]-->
+
+    {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
+    <!--[if lt IE 9]>
+    <script src="/html5-shiv/html5shiv.js"></script>
+    <![endif]-->
+
+    {% block headMetaData %}{% endblock %}
+
+{% endblock %}
+
+{% block pageTitle %}
+    {% if error or errors %}
+        {{ 'general.errorTitlePrefix' | translate }}
+        -
+    {% endif %}
+    {% if pageTitleName %}
+        {{ pageTitleName }}
+        -
+    {% endif %}
+    {{ 'general.serviceNameTitle' | translate }}
+{% endblock %}
+
+{% block bodyStart %}
+    {% include 'common/layout/banner.njk' %}
+{% endblock %}
+
+{% block header %}
+    <header class="govuk-header" data-module="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+            <div class="govuk-header__logo">
+                    <svg
+                            focusable="false"
+                            role="img"
+                            class="govuk-header__logotype"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 148 30"
+                            height="30"
+                            fill="#fff"
+                            width="148"
+                            aria-label="GOV.UK">
+                        <title>GOV.UK</title>
+                        <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+                    </svg>
+            </div>
+        </div>
+    </header>
+{% endblock %}
+
+{% block main %}
+    <div class="govuk-width-container {{ containerClasses }}">
+        {% block beforeContent %}{% endblock %}
+        {% if languageToggleEnabled %}
+        {{ languageSelect({
+            ariaLabel: 'general.languageToggle.ariaLabel' | translate,
+            activeLanguage: htmlLang,
+            url: currentUrl,
+            languages: [
+                {
+                    code: 'en',
+                    text: 'English',
+                    visuallyHidden: 'general.languageToggle.visuallyHiddenChangeLanguage' | translate
+                },
+                {
+                    code:'cy',
+                    text: 'Cymraeg',
+                    visuallyHidden: 'general.languageToggle.visuallyHiddenChangeLanguage' | translate
+                }]
+        })
+        }}
+        {% endif %}
+
+
+        {% if showBack %}
+            {{ govukBackLink({
+                text: "general.back" | translate,
+                href: hrefBack
+            }) }}
+        {% endif %}
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content"
+              role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds {{ rowClasses }}">
+                    {% block content %}{% endblock %}
+                </div>
+            </div>
+        </main>
+    </div>
+{% endblock %}
+
+{% block footer %}
+
+{% endblock %}
+
+{% block bodyEnd %}
+    {% block scripts %}{% endblock %}
+    <script type="text/javascript" src="/public/scripts/cookies.js"></script>
+    <script type="text/javascript" src="/public/scripts/application.js"></script>
+    <script type="text/javascript" src="/public/scripts/all.js"></script>
+    <script type="text/javascript" src="/public/scripts/analytics.js"></script>
+    <script type="text/javascript" {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
+        if (window.DI) {
+            if (window.DI.appInit) {
+                window
+                    .DI
+                    .appInit({
+                        ga4ContainerId: "{{ga4ContainerId}}",
+                        uaContainerId: "{{uaContainerId}}"
+                    }, {
+                        isDataSensitive: false,
+                        disableGa4Tracking: {{isGa4Disabled}},
+                        disableUaTracking: {{isUaDisabled}},
+                        cookieDomain: "{{analyticsCookieDomain}}"
+                    });
+            }
+        }
+    </script>
+{% endblock %}

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -1,10 +1,17 @@
-{% extends "common/layout/base.njk" %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% if mobileContext === true %}
+    {% extends "common/layout/mobile/base.njk" %}
+{% else %}
+    {% extends "common/layout/base.njk" %}
+{% endif %}
 
-{% set pageTitleVariableName = 'pages.signInOrCreate.mandatory.title' %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% if mobileContext === true %}
+    {% set pageTitleVariableName = 'pages.signInOrCreate.mandatory.titleMobile' %}
+{% else %}
+    {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+    {% set pageTitleVariableName = 'pages.signInOrCreate.mandatory.title' %}
+{% endif %}
 
 {% set pageTitleName = pageTitleVariableName | translate %}
 
@@ -17,8 +24,11 @@
 {% block content %}
     {% include "common/errors/errorSummary.njk" %}
 
+    {% if mobileContext === true %}
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.headerMobile' | translate | striptags | safe }} </h1>
+        <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph1Mobile' | translate }}</p>
+    {% else %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.signInOrCreate.mandatory.header' | translate | striptags | safe }} </h1>
-
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph1' | translate }}</p>
 
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph2' | translate }}</p>
@@ -26,49 +36,61 @@
     <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph3' | translate }}</p>
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
-          <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
+        <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
     </ul>
-    {% set altLangInsetHtml %}
-        {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
-        <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
-            {{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
-            <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
-    {% endset %}
-    {{ govukInsetText({
-        html: altLangInsetHtml
-    }) }}
+
+        {% set altLangInsetHtml %}
+            {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
+            <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link"
+               rel="noreferrer">
+                {{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
+                <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
+        {% endset %}
+        {{ govukInsetText({
+            html: altLangInsetHtml
+        }) }}
+    {% endif %}
 
     <form action="/sign-in-or-create" method="post" novalidate="novalidate">
 
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
         <input type="hidden" name="supportInternationalNumbers" value="{{ supportInternationalNumbers }}" />
 
-        {{ govukButton({
-            text: 'pages.signInOrCreate.createButtonText' | translate,
-            value: "create",
-            name: "optionSelected",
-            classes: "govuk-!-margin-right-3",
-            attributes: {
-                "id": "create-account-link"
-            }
-        }) }}
-        <div>
+            {% if mobileContext === true %}
+                {% set buttonClass = 'govuk-button--primary' %}
+            {% else %}
+                <div>
+                    {{ govukButton({
+                        text: 'pages.signInOrCreate.createButtonText' | translate,
+                        value: "create",
+                        name: "optionSelected",
+                        classes: "govuk-!-margin-right-3",
+                        attributes: {
+                            "id": "create-account-link"
+                        }
+                    }) }}
+                </div>
+
+                {% set buttonClass = 'govuk-button--secondary' %}
+            {% endif %}
+
             {{ govukButton({
                 text: 'pages.signInOrCreate.signInText' | translate,
-                classes: "govuk-button--secondary",
+                classes: buttonClass,
                 attributes: {
                     "id": "sign-in-button"
                 }
             }) }}
-        </div>
 
     </form>
+    {% if not mobileContext %}
+        <p class="govuk-body">
+            <a href="{{ 'pages.signInOrCreate.aboutLink' | translate }}" class="govuk-link" rel="noreferrer noopener"
+               target="_blank">
+                {{ 'pages.signInOrCreate.aboutLinkText' | translate }}
+            </a>
+        </p>
+    {% endif %}
 
-    <p class="govuk-body">
-        <a href="{{ 'pages.signInOrCreate.aboutLink' | translate }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-            {{ 'pages.signInOrCreate.aboutLinkText' | translate }}
-        </a>
-    </p>
-
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true })}}
+    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true }) }}
 {% endblock %}

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -12,8 +12,12 @@ export async function signInOrCreateGet(
   if (req.query.redirectPost) {
     return await signInOrCreatePost(req, res);
   }
+
   res.render("sign-in-or-create/index.njk", {
     serviceType: req.session.client.serviceType,
+    // Do not approve a PR with  the following line
+    // ============================================
+    mobileContext: true,
   });
 }
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -164,13 +164,16 @@
     "signInOrCreate": {
       "mandatory": {
         "title": "Creu eich GOV.UK One Login neu fewngofnodi",
-        "header": "Creu eich GOV.UK One&nbsp;Login neu fewngofnodi"
+        "titleMobile": "Mewngofnodwch gyda GOV.UK One Login",
+        "header": "Creu eich GOV.UK One&nbsp;Login neu fewngofnodi",
+        "headerMobile": "Mewngofnodwch gyda GOV.UK One Login"
       },
       "optional": {
         "title": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd",
         "header": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd"
       },
       "paragraph1": "Gallwch ddefnyddio eich GOV.UK One Login i gael mynediad at rai gwasanaethau’r llywodraeth.",
+      "paragraph1Mobile": "\nGallwch ddefnyddio eich GOV.UK One Login i brofi pwy ydych a chael mynediad at rai o wasanaethau’r llywodraeth",
       "paragraph2": "Yn y dyfodol, gallwch ei ddefnyddio i gael mynediad i bob gwasanaeth ar GOV.UK.",
       "paragraph3": "Byddwch angen:",
       "bullet1": "cyfeiriad e-bost",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -173,7 +173,7 @@
         "header": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd"
       },
       "paragraph1": "Gallwch ddefnyddio eich GOV.UK One Login i gael mynediad at rai gwasanaethau’r llywodraeth.",
-      "paragraph1Mobile": "\nGallwch ddefnyddio eich GOV.UK One Login i brofi pwy ydych a chael mynediad at rai o wasanaethau’r llywodraeth",
+      "paragraph1Mobile": "\nGallwch ddefnyddio eich GOV.UK One Login i brofi pwy ydych a chael mynediad at rai o wasanaethau'r llywodraeth",
       "paragraph2": "Yn y dyfodol, gallwch ei ddefnyddio i gael mynediad i bob gwasanaeth ar GOV.UK.",
       "paragraph3": "Byddwch angen:",
       "bullet1": "cyfeiriad e-bost",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -164,13 +164,16 @@
     "signInOrCreate": {
       "mandatory": {
         "title": "Create your GOV.UK One Login or sign in",
-        "header": "Create your GOV.UK One&nbsp;Login or sign&nbsp;in"
+        "titleMobile": "Sign in with GOV.UK One Login",
+        "header": "Create your GOV.UK One&nbsp;Login or sign&nbsp;in",
+        "headerMobile": "Sign in with GOV.UK One Login"
       },
       "optional": {
         "title": "Create a GOV.UK One Login or sign in to save your progress",
         "header": "Create a GOV.UK One Login or sign in to save your progress"
       },
       "paragraph1": "You can use your GOV.UK One Login to access some government services.",
+      "paragraph1Mobile": "You can use your GOV.UK One Login to prove your identity and access some government services.",
       "paragraph2": "In the future, you’ll be able to use it to access all services on GOV.UK.",
       "paragraph3": "You’ll need:",
       "bullet1": "an email address",


### PR DESCRIPTION
## What

Shows how approach 2 might be implemented. This is achieved by: 

* Introducing a mobile specific layout (See commit 4c05d3bd0a219ea58caed86cee1ab346845c37bb)
* Adding content to translation files for the mobile state (See commit 57f9d6f8dbab3e4d342f44381c826051ae81813f)
* Supplying a 'mobileContext` variable to the view. This will be used by conditions in the template (See commit ffffc534)
* Updating the existing template to include conditions so that only the mobile content will be shown where `mobileContext === true` (See commit f66219b2)

I've also added an [additional commit to break the unit tests](c0734170d8fb39df768a1461ad2a6b9e32755988) (just as an extra precaution should this accidentally be approved and merged somehow). 