### PR TITLE
[DFC-653] - Add missing OPL script to required pages

### DIFF
--- a/src/components/account-intervention/password-reset-required/index.njk
+++ b/src/components/account-intervention/password-reset-required/index.njk
@@ -20,6 +20,6 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2: "account intervention", contentId: "", loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/account-intervention/permanently-blocked/index.njk
+++ b/src/components/account-intervention/permanently-blocked/index.njk
@@ -15,6 +15,6 @@
 
     <p class="govuk-body">{{'pages.permanentlyLockedScreen.section2.paragraph2' | translate }}</p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2: "account intervention", contentId: "", loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/account-intervention/temporarily-blocked/index.njk
+++ b/src/components/account-intervention/temporarily-blocked/index.njk
@@ -16,6 +16,6 @@
 
     <p class="govuk-body">{{'pages.suspendedPageScreen.section2.paragraph2' | translate }}</p>
 
-    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "accounts", taxonomyLevel2: "account intervention", contentId: "895deac9-e21d-4991-b1f7-9509c2d8c10e", loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/account-intervention/temporarily-blocked/index.njk
+++ b/src/components/account-intervention/temporarily-blocked/index.njk
@@ -16,4 +16,6 @@
 
     <p class="govuk-body">{{'pages.suspendedPageScreen.section2.paragraph2' | translate }}</p>
 
+    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+
 {% endblock %}

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -505,4 +505,6 @@
 
     </form>
 
+    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+
 {% endblock %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -143,4 +143,6 @@
         {% include 'contact-us/questions/_proving-identity-problem-with-national-insurance-number.njk' %}
     {% endif %}
 
+    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "", contentId: "", loggedInStatus: false, dynamic: false })}}
+
 {% endblock %}


### PR DESCRIPTION
## What

Adds the OPL script to the pages:
- Temporarily Blocked
- Contact Us/Questions
- Cookies

## How to review

This will need to be tested using the Google Tag Assistant extension
