### PR TITLE
AUT-3685: Update re-auth email address screen

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -218,9 +218,9 @@
       }
     },
     "reEnterEmailAccount": {
-      "title": "Rhowch eich manylion mewngofnodi i mewn eto i barhau",
-      "header": "Rhowch eich manylion mewngofnodi i mewn eto i barhau",
-      "paragraph1": "Er diogelwch, mewngofnodwch gyda GOV.UK One Login eto.",
+      "title": "Rhowch eich manylion mewngofnodi ar gyfer GOV.UK One Login eto",
+      "header": "Rhowch eich manylion mewngofnodi ar gyfer GOV.UK One Login eto",
+      "paragraph1": "Er mwyn cadw’ch gwybodaeth yn ddiogel, mae angen i chi roi eich manylion mewngofnodi eto. Bydd hyn yn ein helpu i sicrhau mai chi sydd yna.",
       "enterYourEmailAddress": "Rhowch eich cyfeiriad e-bost",
       "enterYourEmailAddressError": "Rhowch yr un cyfeiriad e-bost rydych wedi’i ddefnyddio i fewngofnodi"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -218,9 +218,9 @@
       }
     },
     "reEnterEmailAccount": {
-      "title": "Re-enter your sign-in details to continue",
-      "header": "Re-enter your sign-in details to continue",
-      "paragraph1": "For security, sign in with GOV.UK One Login again.",
+      "title": "Enter your sign in details for GOV.UK One Login again",
+      "header": "Enter your sign in details for GOV.UK One Login again",
+      "paragraph1": "To keep your information safe, you need to enter your sign in details again. This will help us make sure it’s you.",
       "enterYourEmailAddress": "Enter your email address",
       "enterYourEmailAddressError": "Enter the same email address you used to sign in"
     },


### PR DESCRIPTION
## What

Content updates to re-auth email address screen. 

### Screenshots for UCD review 

<details>
<summary>English</summary>

![Enter your sign in details again (English)](https://github.com/user-attachments/assets/9c4018bb-530e-4604-90f6-cc104f97082f)

</details>

<details>
<summary>Welsh</summary>

![Enter your sign in details again (Welsh)](https://github.com/user-attachments/assets/3a0fa6d0-d1fe-4b40-ab7e-22195d1f2646)

</details>

## How to review

1. Code review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made (see related PRs below).

## Related PRs

https://github.com/govuk-one-login/authentication-acceptance-tests/pull/419 updates the acceptance tests to reflect this change
