### PR TITLE
Aut 3596/add extra info to start call

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -63,7 +63,8 @@ export function authorizeGet(
       persistentSessionId,
       req,
       claims.reauthenticate,
-      claims.previous_session_id
+      claims.previous_session_id,
+      claims.previous_govuk_signin_journey_id
     );
 
     if (!startAuthResponse.success) {

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -25,12 +25,9 @@ export function authorizeService(
     if (supportReauthentication() && reauthenticate) {
       reauthenticateOption = reauthenticate !== "";
     }
-    const body = previousSessionId
-      ? { "previous-session-id": previousSessionId }
-      : {};
     const response = await axios.client.post<StartAuthResponse>(
       API_ENDPOINTS.START,
-      body,
+      createStartBody(previousSessionId, reauthenticate),
       getInternalRequestConfigWithSecurityHeaders(
         {
           sessionId: sessionId,
@@ -49,4 +46,14 @@ export function authorizeService(
   return {
     start,
   };
+}
+
+function createStartBody(previousSessionId?: string, reauthenticate?: string) {
+  const body: { [key: string]: any } = {};
+
+  if (previousSessionId !== undefined)
+    body["previous-session-id"] = previousSessionId;
+  if (reauthenticate !== undefined && supportReauthentication())
+    body["rp-pairwise-id-for-reauth"] = reauthenticate;
+  return body;
 }

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -19,7 +19,8 @@ export function authorizeService(
     persistentSessionId: string,
     req: Request,
     reauthenticate?: string,
-    previousSessionId?: string
+    previousSessionId?: string,
+    previousGovukSigninJourneyId?: string
   ): Promise<ApiResponseResult<StartAuthResponse>> {
     let reauthenticateOption = undefined;
     if (supportReauthentication() && reauthenticate) {
@@ -27,7 +28,11 @@ export function authorizeService(
     }
     const response = await axios.client.post<StartAuthResponse>(
       API_ENDPOINTS.START,
-      createStartBody(previousSessionId, reauthenticate),
+      createStartBody(
+        previousSessionId,
+        reauthenticate,
+        previousGovukSigninJourneyId
+      ),
       getInternalRequestConfigWithSecurityHeaders(
         {
           sessionId: sessionId,
@@ -48,12 +53,18 @@ export function authorizeService(
   };
 }
 
-function createStartBody(previousSessionId?: string, reauthenticate?: string) {
+function createStartBody(
+  previousSessionId?: string,
+  reauthenticate?: string,
+  previousGovukSigninJourneyId?: string
+) {
   const body: { [key: string]: any } = {};
 
   if (previousSessionId !== undefined)
     body["previous-session-id"] = previousSessionId;
   if (reauthenticate !== undefined && supportReauthentication())
     body["rp-pairwise-id-for-reauth"] = reauthenticate;
+  if (previousGovukSigninJourneyId !== undefined && supportReauthentication())
+    body["previous-govuk-signin-journey-id"] = previousGovukSigninJourneyId;
   return body;
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -34,6 +34,7 @@ export type Claims = {
   reauthenticate?: string;
   claim?: string;
   previous_session_id?: string;
+  previous_govuk_signin_journey_id: string;
 };
 
 export const requiredClaimsKeys = [

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -127,20 +127,25 @@ describe("authorize service", () => {
     ).to.be.true;
   });
 
-  it("sends a request with the pairwise id for reauth in the body when present", () => {
+  it("sends a request with the pairwise id for reauth and previous journey id in the body when present", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(
       sessionId,
       clientSessionId,
       diPersistentSessionId,
       req,
-      "123456"
+      "123456",
+      undefined,
+      "previous-journey-id"
     );
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { "rp-pairwise-id-for-reauth": "123456" },
+        {
+          "rp-pairwise-id-for-reauth": "123456",
+          "previous-govuk-signin-journey-id": "previous-journey-id",
+        },
         {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -52,7 +52,7 @@ describe("authorize service", () => {
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        {},
+        { "rp-pairwise-id-for-reauth": "123456" },
         {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,
@@ -120,6 +120,31 @@ describe("authorize service", () => {
         {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,
+          },
+          proxy: false,
+        }
+      )
+    ).to.be.true;
+  });
+
+  it("sends a request with the pairwise id for reauth in the body when present", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    service.start(
+      sessionId,
+      clientSessionId,
+      diPersistentSessionId,
+      req,
+      "123456"
+    );
+
+    expect(
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        { "rp-pairwise-id-for-reauth": "123456" },
+        {
+          headers: {
+            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
+            Reauthenticate: true,
           },
           proxy: false,
         }

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -25,7 +25,8 @@ export interface AuthorizeServiceInterface {
     persistentSessionId: string,
     req: Request,
     reauthenticate?: string,
-    previousSessionId?: string
+    previousSessionId?: string,
+    previousGovukSigninJourneyId?: string
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 


### PR DESCRIPTION
## What

Adds two extra reauth fields to the request body sent to the start handler:

* rp pairwise id for reauthentication
* previous govuk signin journey id

This is so that the start handler can use this information when it emits the "AUTH_REAUTH_REQUESTED" audit event, in the case of a reauth journey.

The previous govuk signin journey id has recently been added to the claims orchestration send through to us, to facilitate this.

## How to review

1. Code Review



## Related PRs

[PR](https://github.com/govuk-one-login/authentication-api/pull/5228) that introduced reading these request params in and using them in the audit event in the start handler
[Orchestration PR](https://github.com/govuk-one-login/authentication-api/pull/5223) that started passing the previous signin journey id through to us as a claim
