### PR TITLE
BAU: Upgrade dompurify to 2.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "cookie-parser": "^1.4.5",
     "copyfiles": "^2.4.1",
     "csurf": "^1.11.0",
-    "dompurify": "^2.3.4",
+    "dompurify": "^2.5.4",
     "ecdsa-sig-formatter": "^1.0.11",
     "express": "^4.20.0",
     "express-session": "^1.17.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,10 +2879,10 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.npmjs.org/dompurify/-/dompurify-2.3.4.tgz"
-  integrity sha512-6BVcgOAVFXjI0JTjEvZy901Rghm+7fDQOrNIcxB4+gdhj6Kwp6T9VBhBY/AbagKHJocRkDYGd6wvI+p4/10xtQ==
+dompurify@^2.5.4:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.6.tgz#8402b501611eaa7fb3786072297fcbe2787f8592"
+  integrity sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==
 
 domutils@^3.0.1:
   version "3.1.0"


### PR DESCRIPTION
## What

Upgrade dompurify to 2.5.4.

To keep dompurify current.

Tested in a local environment.

## How to review

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a` or test locally.
