### PR TITLE
DFC-663: Read 'channel' claim if SUPPORT_MULTI_CHANNEL is switched-on

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -165,6 +165,14 @@ locals {
         value = var.support_check_email_fraud
       },
       {
+        name  = "SUPPORT_MULTI_CHANNEL"
+        value = var.support_multi_channel
+      },
+      {
+        name  = "DEFAULT_CHANNEL"
+        value = var.default_channel
+      },
+      {
         name  = "LANGUAGE_TOGGLE_ENABLED"
         value = var.language_toggle_enabled
       },

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -272,6 +272,18 @@ variable "support_check_email_fraud" {
   default     = "1"
 }
 
+variable "support_multi_channel" {
+  description = "Enables different UI rendering per channel"
+  type        = string
+  default     = "0"
+}
+
+variable "default_channel" {
+  description = "To set the default channel."
+  type        = string
+  default     = "web"
+}
+
 variable "prove_identity_welcome_enabled" {
   description = "Do not show the prove identity welcome screen when disabled"
   type        = string

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -568,6 +568,10 @@ Resources:
               Value: 1
             - Name: SUPPORT_CHECK_EMAIL_FRAUD
               Value: 1
+            - Name: SUPPORT_MULTI_CHANNEL
+              Value: 0
+            - Name: DEFAULT_CHANNEL
+              Value: web
             - Name: LANGUAGE_TOGGLE_ENABLED
               Value: 1
             - Name: PROVE_IDENTITY_WELCOME_ENABLED

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -92,6 +92,7 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
             "SUPPORT_REAUTHENTICATION": 1,
             "SUPPORT_2HR_LOCKOUT": 1,
             "SUPPORT_CHECK_EMAIL_FRAUD": 1,
+            "SUPPORT_MULTI_CHANNEL": 0,
             "NO_PHOTO_ID_CONTACT_FORMS": 1,
             "LANGUAGE_TOGGLE_ENABLED": 1,
             "SUPPORT_NEW_IPV_SPINNER": 1,

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -231,6 +231,11 @@ export enum JOURNEY_TYPE {
   REAUTHENTICATION = "REAUTHENTICATION",
 }
 
+export enum CHANNEL {
+  WEB = "web",
+  STRATEGIC_APP = "strategic_app",
+}
+
 export const ENVIRONMENT_NAME = {
   PROD: "production",
   DEV: "development",

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -26,6 +26,9 @@ import {
   getOrchToAuthExpectedClientId,
   supportReauthentication,
   proveIdentityWelcomeEnabled,
+  supportMultiChannel,
+  isValidChannel,
+  getDefaultChannel,
 } from "../../config";
 import { logger } from "../../utils/logger";
 import { Claims } from "./claims-config";
@@ -186,6 +189,11 @@ function setSessionDataFromClaims(req: Request, claims: Claims) {
   req.session.user.reauthenticate = supportReauthentication()
     ? claims.reauthenticate
     : null;
+  req.session.user.channel =
+    supportMultiChannel() && isValidChannel(claims.channel)
+      ? claims.channel
+      : getDefaultChannel();
+  logger.info(`Channel is set to: ${req.session.user.channel}`);
 }
 
 function setSessionDataFromAuthResponse(

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -35,6 +35,7 @@ export type Claims = {
   claim?: string;
   previous_session_id?: string;
   previous_govuk_signin_journey_id: string;
+  channel?: string;
 };
 
 export const requiredClaimsKeys = [

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { CHANNEL } from "./app.constants";
+
 export function getLogLevel(): string {
   return process.env.LOGS_LEVEL || "debug";
 }
@@ -146,6 +148,19 @@ export function supportCheckEmailFraud(): boolean {
   return process.env.SUPPORT_CHECK_EMAIL_FRAUD === "1";
 }
 
+export function supportMultiChannel(): boolean {
+  return process.env.SUPPORT_MULTI_CHANNEL === "1";
+}
+
+export function getDefaultChannel(): string {
+  const configuredChannel = process.env.DEFAULT_CHANNEL;
+  if (isValidChannel(configuredChannel)) {
+    return configuredChannel;
+  } else {
+    return CHANNEL.WEB;
+  }
+}
+
 export function getLanguageToggleEnabled(): boolean {
   return process.env.LANGUAGE_TOGGLE_ENABLED === "1";
 }
@@ -178,4 +193,8 @@ export function supportNewIpvSpinner(): boolean {
 }
 export function supportHttpKeepAlive(): boolean {
   return process.env.SUPPORT_HTTP_KEEP_ALIVE === "1";
+}
+
+export function isValidChannel(channel: string): boolean {
+  return channel === CHANNEL.WEB || channel === CHANNEL.STRATEGIC_APP;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export interface UserSession {
   isPasswordResetJourney?: boolean;
   isSignInJourney?: boolean;
   isVerifyEmailCodeResendRequired?: boolean;
+  channel?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
 ## What

Read 'channel' claim if SUPPORT_MULTI_CHANNEL is switched-on and assign to session variable.

- Adds a feature switch SUPPORT_MULTI_CHANNEL
- Adds a configurable default channel DEFAULT_CHANNEL, which defaults to 'web'.

This is to support rendering the UI differently per channel.  The Strategic App will run the authentication sign-in flow in a webview, which needs to be rendered differently.  The session variable can be used to determine how to render the UI.

There are two config values because the orchestration and orchestration stub changes are not yet available to supply the new claim to authentication, but the code is there to support this when it arrives.  In the meantime developers can vary the DEFAULT_CHANNEL in order to test rendering for both channels.  

## How to review

1. Code Review
1. Set DEFAULT_CHANNEL in a local frontend .env file to either 'web' or 'strategic_app' and start the application.
1. Run a journey and check log messages "Channel is set to:" to see that the channel is set appropriately, and make sure there is no impact when starting a journey.
