### PR TITLE
BAU: Prevent Sass mixed declaration warnings

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -134,7 +134,6 @@
 }
 
 .govuk-show-password__toggle {
-  @include govuk-font(19);
   z-index: 0;
   display: table-cell; // IE fallback
   padding: govuk-spacing(1) govuk-spacing(3);
@@ -145,6 +144,8 @@
   border: solid 2px $govuk-input-border-colour;
   white-space: nowrap;
   cursor: pointer;
+
+  @include govuk-font(19);
 
   @include govuk-media-query($until: mobile) {
     padding: govuk-spacing(1);


### PR DESCRIPTION
## What

The CSS Working Group has changed the way CSS handles declarations mixed with nested rules. Sass has been updated to reflect this change and any declarations that appear after nested rules are deprecated in Dart Sass distributions > 1.77.7 (See [Sass documentation](https://sass-lang.com/documentation/breaking-changes/mixed-decls/))

As a result of this we have been seeing multiple deprecation warnings when compiling our Sass. 

> _Deprecation Warning: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version_

This commit simply changes the code in a block that is specific to the password entry component so that a nested rule appears after declarations in the same block.

<details>

<summary>Screenshot after change</summary>

![Screenshot of password creation screen](https://github.com/user-attachments/assets/0bb94a93-b47c-4610-92c7-5b909e749b33)



</details>

## How to review

1. Code review
2. Run the branch locally and - with the browser cache disabled - proceed through a sign in or account creation journey until you encounter a password entry field. Check that it looks OK in all its states (empty, not empty, password shown, password hidden) and at different media query breakpoints.

