### PR TITLE
feat(DFC-663): Add Channel Middleware

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -89,6 +89,7 @@ import { setGTM } from "./middleware/analytics-middleware";
 import { setCurrentUrlMiddleware } from "./middleware/current-url-middleware";
 import { getRedisConfig } from "./utils/redis";
 import { csrfMissingHandler } from "./handlers/csrf-missing-handler";
+import { channelMiddleware } from "./middleware/channel-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -201,6 +202,7 @@ async function createApp(): Promise<express.Application> {
   app.use(cookieParser());
   app.use(csurf({ cookie: getCSRFCookieOptions(isProduction) }));
 
+  app.use(channelMiddleware);
   app.use(getSessionIdMiddleware);
   app.post("*", sanitizeRequestMiddleware);
   app.use(csrfMiddleware);

--- a/src/middleware/channel-middleware.ts
+++ b/src/middleware/channel-middleware.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response } from "express";
+import { CHANNEL } from "../app.constants";
+
+export function channelMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  res.locals.strategicAppChannel =
+    req.session?.user?.channel === CHANNEL.STRATEGIC_APP;
+  res.locals.webChannel = req.session?.user?.channel === CHANNEL.WEB;
+  next();
+}

--- a/src/middleware/tests/channel-middleware.test.ts
+++ b/src/middleware/tests/channel-middleware.test.ts
@@ -1,0 +1,54 @@
+import chai, { expect } from "chai";
+import { Request, Response } from "express";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { channelMiddleware } from "../channel-middleware";
+import { describe } from "mocha";
+import { mockRequest, mockResponse } from "mock-req-res";
+
+chai.use(sinonChai);
+
+describe("session-middleware", () => {
+  let next: sinon.SinonSpy;
+  let res: Response;
+
+  describe("createSessionMiddleware", () => {
+    beforeEach(() => {
+      res = mockResponse();
+      next = sinon.fake();
+    });
+
+    it("should set strategicAppChannel to true for strategic app clients", () => {
+      const req = mockRequest({
+        session: { client: {}, user: { channel: "strategic_app" } },
+      });
+      channelMiddleware(req as Request, res as Response, next);
+
+      expect(res.locals.strategicAppChannel).to.equal(true);
+      expect(res.locals.webChannel).to.equal(false);
+      expect(next).to.be.calledOnce;
+    });
+
+    it("should set webChannel to true for web clients", () => {
+      const req = mockRequest({
+        session: { client: {}, user: { channel: "web" } },
+      });
+      channelMiddleware(req as Request, res as Response, next);
+
+      expect(res.locals.strategicAppChannel).to.equal(false);
+      expect(res.locals.webChannel).to.equal(true);
+      expect(next).to.be.calledOnce;
+    });
+
+    it("should set no channel to true if provided an unrecognised channel", () => {
+      const req = mockRequest({
+        session: { client: {}, user: { channel: "unknown" } },
+      });
+      channelMiddleware(req as Request, res as Response, next);
+
+      expect(res.locals.strategicAppChannel).to.equal(false);
+      expect(res.locals.webChannel).to.equal(false);
+      expect(next).to.be.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a new middleware to expose the active channel to nunjucks components. This is a continuation of the work found in https://github.com/govuk-one-login/authentication-frontend/pull/2080

## How to review

1. Code Review
2. Confirm the middleware correctly exposes the channel value to nunjucks templates