### PR TITLE
AUT-3763: Add support for Orch stub in addition to real Orch

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -97,6 +97,18 @@ locals {
         value = var.orch_to_auth_audience
       },
       {
+        name  = "ORCH_STUB_TO_AUTH_SIGNING_KEY"
+        value = var.orch_stub_to_auth_signing_public_key
+      },
+      {
+        name  = "ORCH_STUB_TO_AUTH_CLIENT_ID"
+        value = var.orch_stub_to_auth_client_id
+      },
+      {
+        name  = "ORCH_STUB_TO_AUTH_AUDIENCE"
+        value = var.orch_stub_to_auth_audience
+      },
+      {
         name  = "SMARTAGENT_API_KEY"
         value = var.smartagent_api_key
       },

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -233,6 +233,24 @@ variable "orch_to_auth_audience" {
   default     = ""
 }
 
+variable "orch_stub_to_auth_signing_public_key" {
+  description = "Public key counterpart for KMS key created in Orchestration/OIDC API"
+  type        = string
+  default     = ""
+}
+
+variable "orch_stub_to_auth_client_id" {
+  description = "Client ID that is used by OIDC API when making authorize redirect to Auth Frontend"
+  type        = string
+  default     = ""
+}
+
+variable "orch_stub_to_auth_audience" {
+  description = "Aud value included in JWT by OIDC API when making authorize redirect to Auth Frontend"
+  type        = string
+  default     = ""
+}
+
 variable "dynatrace_secret_arn" {
 }
 

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -29,6 +29,7 @@ import {
   supportMultiChannel,
   isValidChannel,
   getDefaultChannel,
+  getOrchStubToAuthExpectedClientId,
 } from "../../config";
 import { logger } from "../../utils/logger";
 import { Claims } from "./claims-config";
@@ -217,7 +218,10 @@ function validateQueryParams(clientId: string, responseType: string) {
     throw new QueryParamsError("Response type is not set");
   }
 
-  if (clientId !== getOrchToAuthExpectedClientId()) {
+  if (
+    clientId !== getOrchToAuthExpectedClientId() &&
+    clientId !== getOrchStubToAuthExpectedClientId()
+  ) {
     throw new QueryParamsError("Client ID value is incorrect");
   }
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -1,4 +1,6 @@
 import {
+  getOrchStubToAuthExpectedAudience,
+  getOrchStubToAuthExpectedClientId,
   getOrchToAuthExpectedAudience,
   getOrchToAuthExpectedClientId,
 } from "../../config";
@@ -9,6 +11,15 @@ export function getKnownClaims(): {
   return {
     client_id: getOrchToAuthExpectedClientId(),
     aud: getOrchToAuthExpectedAudience(),
+  };
+}
+
+export function getKnownStubClaims(): {
+  [key: string]: string | boolean | number;
+} {
+  return {
+    client_id: getOrchStubToAuthExpectedClientId(),
+    aud: getOrchStubToAuthExpectedAudience(),
   };
 }
 

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -1,26 +1,29 @@
 import { JwtServiceInterface } from "./types";
-import { getOrchToAuthSigningPublicKey } from "../../config";
+import {
+  getOrchStubToAuthSigningPublicKey,
+  getOrchToAuthSigningPublicKey,
+} from "../../config";
 import { JwtClaimsValueError, JwtValidationError } from "../../utils/error";
 import { Claims, requiredClaimsKeys, getKnownClaims } from "./claims-config";
 import * as jose from "jose";
 
 export class JwtService implements JwtServiceInterface {
   private readonly publicKey;
+  private readonly stubPublicKey;
 
-  constructor(publicKey = getOrchToAuthSigningPublicKey()) {
+  constructor(
+    publicKey = getOrchToAuthSigningPublicKey(),
+    stubPublicKey = getOrchStubToAuthSigningPublicKey()
+  ) {
     this.publicKey = publicKey;
+    this.stubPublicKey = stubPublicKey;
   }
 
   async getPayloadWithValidation(jwt: string): Promise<Claims> {
     let claims: jose.JWTPayload;
+
     try {
-      const tempkey = await jose.importSPKI(this.publicKey, "ES256");
-      claims = (
-        await jose.jwtVerify(jwt, tempkey, {
-          requiredClaims: requiredClaimsKeys,
-          clockTolerance: 30,
-        })
-      ).payload;
+      claims = await this.validate(jwt);
     } catch (error) {
       throw new JwtValidationError(error.message);
     }
@@ -32,11 +35,33 @@ export class JwtService implements JwtServiceInterface {
     return this.validateCustomClaims(claims);
   }
 
-  validateCustomClaims(claims: any): Claims {
-    const requiredclaims = getKnownClaims();
+  async validate(jwt: string): Promise<jose.JWTPayload> {
+    try {
+      return await this.validateUsingKey(jwt, this.publicKey);
+    } catch (error) {
+      if (this.stubPublicKey === "" || this.stubPublicKey === "UNKNOWN") {
+        throw error;
+      }
+      return await this.validateUsingKey(jwt, this.stubPublicKey);
+    }
+  }
 
-    Object.keys(requiredclaims).forEach((claim) => {
-      if (requiredclaims[claim] !== claims[claim]) {
+  async validateUsingKey(jwt: string, key: string): Promise<jose.JWTPayload> {
+    const keyObject = await jose.importSPKI(key, "ES256");
+
+    const result = await jose.jwtVerify(jwt, keyObject, {
+      requiredClaims: requiredClaimsKeys,
+      clockTolerance: 30,
+    });
+
+    return result.payload;
+  }
+
+  validateCustomClaims(claims: any): Claims {
+    const requiredClaims = getKnownClaims();
+
+    Object.keys(requiredClaims).forEach((claim) => {
+      if (requiredClaims[claim] !== claims[claim]) {
         throw new JwtClaimsValueError(`${claim} has incorrect value`);
       }
     });

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -4,7 +4,12 @@ import {
   getOrchToAuthSigningPublicKey,
 } from "../../config";
 import { JwtClaimsValueError, JwtValidationError } from "../../utils/error";
-import { Claims, requiredClaimsKeys, getKnownClaims } from "./claims-config";
+import {
+  Claims,
+  requiredClaimsKeys,
+  getKnownClaims,
+  getKnownStubClaims,
+} from "./claims-config";
 import * as jose from "jose";
 
 export class JwtService implements JwtServiceInterface {
@@ -59,9 +64,13 @@ export class JwtService implements JwtServiceInterface {
 
   validateCustomClaims(claims: any): Claims {
     const requiredClaims = getKnownClaims();
+    const stubClaims = getKnownStubClaims();
 
     Object.keys(requiredClaims).forEach((claim) => {
-      if (requiredClaims[claim] !== claims[claim]) {
+      if (
+        requiredClaims[claim] !== claims[claim] &&
+        stubClaims[claim] !== claims[claim]
+      ) {
         throw new JwtClaimsValueError(`${claim} has incorrect value`);
       }
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,18 @@ export function getOrchToAuthExpectedAudience(): string {
   return process.env.ORCH_TO_AUTH_AUDIENCE || "UNKNOWN";
 }
 
+export function getOrchStubToAuthSigningPublicKey(): string {
+  return process.env.ORCH_STUB_TO_AUTH_SIGNING_KEY || "UNKNOWN";
+}
+
+export function getOrchStubToAuthExpectedClientId(): string {
+  return process.env.ORCH_STUB_TO_AUTH_CLIENT_ID || "UNKNOWN";
+}
+
+export function getOrchStubToAuthExpectedAudience(): string {
+  return process.env.ORCH_STUB_TO_AUTH_AUDIENCE || "UNKNOWN";
+}
+
 export function getAccountManagementUrl(): string {
   return process.env.ACCOUNT_MANAGEMENT_URL || "http://localhost:6001";
 }


### PR DESCRIPTION
## What

In the build environment we want to be able to invoke the frontend using either real orchestration or the orchestration stub. To achieve this, this change allows the frontend to accept authorise requests from two different sources.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
