### PR TITLE
DFC-660 Remove footer from strategic app journey

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -235,3 +235,7 @@
   margin-bottom: 30px;
   margin-top: 30px;
 }
+
+.govuk-template__mobile {
+  background-color: $govuk-body-background-colour;
+}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -4,7 +4,9 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "frontend-language-toggle/macro.njk" import languageSelect %}
-
+{% if strategicAppChannel == true %}
+  {% set htmlClasses = 'govuk-template__mobile' %}
+{% endif %}
 {% block head %}
 
     <!--[if !IE 8]><!-->
@@ -21,6 +23,9 @@
     <!--[if lt IE 9]>
     <script src="/html5-shiv/html5shiv.js"></script>
     <![endif]-->
+
+
+
 
     {% block headMetaData %}{% endblock %}
 
@@ -108,6 +113,9 @@
 {% endblock %}
 
 {% block footer %}
+{% if strategicAppChannel === true %}
+
+{% else %}
     {{ govukFooter({
         meta: {
             items: [
@@ -141,6 +149,7 @@
             text: 'general.footer.copyright.linkText' | translate
         }
     }) }}
+{% endif %}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/src/components/common/layout/tests/base-integration.test.ts
+++ b/src/components/common/layout/tests/base-integration.test.ts
@@ -51,6 +51,27 @@ describe("Integration:: base page ", () => {
     app = undefined;
   });
 
+  it("should return the sign in or create page", async () => {
+    await setupApp(CHANNEL.WEB);
+    await request(app).get(PATH_NAMES.SIGN_IN_OR_CREATE).expect(200);
+  });
+
+  it("The footer should appear on the page when the channel is set to 'web'", async () => {
+    await setupApp(CHANNEL.WEB);
+    const response = await request(app).get(PATH_NAMES.SIGN_IN_OR_CREATE);
+    expect(response.status).to.equal(200);
+    const $ = cheerio.load(response.text);
+    expect($(".govuk-footer").length).to.equal(1);
+  });
+
+  it("The footer should not appear on the page when the channel is set to 'strategic_app'", async () => {
+    await setupApp(CHANNEL.STRATEGIC_APP);
+    const response = await request(app).get(PATH_NAMES.SIGN_IN_OR_CREATE);
+    expect(response.status).to.equal(200);
+    const $ = cheerio.load(response.text);
+    expect($(".govuk-footer").length).to.equal(0);
+  });
+
   it("The beta banner should appear on the page when the channel is set to 'web'", async () => {
     await setupApp(CHANNEL.WEB);
     const response = await request(app).get(PATH_NAMES.SIGN_IN_OR_CREATE);


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Implemented conditional rendering of the footer in the base.njk file to ensure it is only visible in web view. Also, added integration tests to verify the functionality.

## How to review

<!-- Describe the steps required to review this PR.
For example:
-->
1. Code Review
2. Set DEFAULT_CHANNEL in a local frontend .env file to either 'web' or 'strategic_app' and start the application.
3. Verify if the footer correctly shows or hides based on the selected view.## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [x] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.



This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
[DFC-660](https://govukverify.atlassian.net/browse/DFC-660)

[DFC-660]: https://govukverify.atlassian.net/browse/DFC-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ