### PR TITLE
BAU: Pin node version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+  node: 20.17.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
## What

On some systems the correct node version to use for pre-commit work is not automatically selected, even when it is apparently the default on the developer terminal.

Here we explicitly pin the correct version.

## How to review

1. Code Review