### PR TITLE
[DFC-661]: Remove the Beta Banner from Strategic App view

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -59,12 +59,15 @@
 
 {% block main %}
     <div class="govuk-width-container {{ containerClasses }}">
+        {% if strategicAppChannel === true %}
+        {% else %}
         {{ govukPhaseBanner({
             tag: {
                 text: 'general.phaseBanner.tag' | translate
             },
             html: phaseBannerText
         }) }}
+        {% endif %}
         {% block beforeContent %}{% endblock %}
         {% if languageToggleEnabled %}
         {{ languageSelect({

--- a/src/components/common/layout/tests/base-integration.test.ts
+++ b/src/components/common/layout/tests/base-integration.test.ts
@@ -1,0 +1,69 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { expect } from "chai";
+import * as cheerio from "cheerio";
+import { sinon } from "../../../../../test/utils/test-utils";
+import nock = require("nock");
+import decache from "decache";
+import { PATH_NAMES, CHANNEL } from "../../../../app.constants";
+
+describe("Integration:: base page ", () => {
+  let app: any;
+
+  const setupApp = async (channel: string) => {
+    decache("../../../../app");
+    decache("../../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../../middleware/session-middleware");
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        if (channel === CHANNEL.WEB) {
+          res.locals.webChannel = true;
+        } else if (channel === CHANNEL.STRATEGIC_APP) {
+          res.locals.strategicAppChannel = true;
+        }
+
+        req.session.client = {
+          serviceType: "MANDATORY",
+        };
+        req.session.user = {
+          email: "test@test.com",
+
+          phoneNumber: "7867",
+          journey: {
+            nextPath: PATH_NAMES.SIGN_IN_OR_CREATE,
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../../app").createApp();
+  };
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("The beta banner should appear on the page when the channel is set to 'web'", async () => {
+    await setupApp(CHANNEL.WEB);
+    const response = await request(app).get(PATH_NAMES.SIGN_IN_OR_CREATE);
+    expect(response.status).to.equal(200);
+    const $ = cheerio.load(response.text);
+    expect($(".govuk-phase-banner").length).to.equal(1);
+  });
+
+  it("The beta banner should not appear on the page when the channel is set to 'strategic_app'", async () => {
+    await setupApp(CHANNEL.STRATEGIC_APP);
+    const response = await request(app).get(PATH_NAMES.SIGN_IN_OR_CREATE);
+    expect(response.status).to.equal(200);
+    const $ = cheerio.load(response.text);
+    expect($(".govuk-phase-banner").length).to.equal(0);
+  });
+});


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Implemented conditional rendering of the beta banner in the base.njk file to ensure it is only visible in web view. Also, added integration tests to verify the functionality.

## How to review

<!-- Describe the steps required to review this PR.
For example:
-->

1. Code Review
2. Set DEFAULT_CHANNEL in a local frontend .env file to either 'web' or 'strategic_app' and start the application.
3. Verify if the beta banner correctly shows or hides based on the selected view.

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [x] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->

[DFC-661](https://govukverify.atlassian.net/browse/DFC-661)


[DFC-661]: https://govukverify.atlassian.net/browse/DFC-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ