### PR TITLE
ATO-980: Send `authenticated` claim to backend

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -66,10 +66,13 @@ export function authorizeGet(
       clientSessionId,
       persistentSessionId,
       req,
-      claims.authenticated,
-      claims.reauthenticate,
-      claims.previous_session_id,
-      claims.previous_govuk_signin_journey_id
+      {
+        authenticated: claims.authenticated,
+        previous_session_id: claims.previous_session_id,
+        previous_govuk_signin_journey_id:
+          claims.previous_govuk_signin_journey_id,
+        reauthenticate: claims.reauthenticate,
+      }
     );
 
     if (!startAuthResponse.success) {

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -66,6 +66,7 @@ export function authorizeGet(
       clientSessionId,
       persistentSessionId,
       req,
+      claims.authenticated,
       claims.reauthenticate,
       claims.previous_session_id,
       claims.previous_govuk_signin_journey_id

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -18,6 +18,7 @@ export function authorizeService(
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
+    authenticated: boolean,
     reauthenticate?: string,
     previousSessionId?: string,
     previousGovukSigninJourneyId?: string
@@ -29,6 +30,7 @@ export function authorizeService(
     const response = await axios.client.post<StartAuthResponse>(
       API_ENDPOINTS.START,
       createStartBody(
+        authenticated,
         previousSessionId,
         reauthenticate,
         previousGovukSigninJourneyId
@@ -54,11 +56,14 @@ export function authorizeService(
 }
 
 function createStartBody(
+  authenticated: boolean,
   previousSessionId?: string,
   reauthenticate?: string,
   previousGovukSigninJourneyId?: string
 ) {
   const body: { [key: string]: any } = {};
+
+  body["authenticated"] = authenticated;
 
   if (previousSessionId !== undefined)
     body["previous-session-id"] = previousSessionId;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -47,6 +47,7 @@ export type Claims = {
   previous_session_id?: string;
   previous_govuk_signin_journey_id: string;
   channel?: string;
+  authenticated: boolean;
 };
 
 export const requiredClaimsKeys = [
@@ -66,4 +67,5 @@ export const requiredClaimsKeys = [
   "client_id",
   "redirect_uri",
   "rp_sector_host",
+  "authenticated",
 ];

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -19,7 +19,7 @@ import {
   KmsDecryptionServiceInterface,
 } from "../types";
 import { BadRequestError } from "../../../utils/error";
-import { createmockclaims } from "./test-data";
+import { createMockClaims } from "./test-data";
 import { Claims } from "../claims-config";
 import { getOrchToAuthExpectedClientId } from "../../../config";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
@@ -36,7 +36,7 @@ describe("authorize controller", () => {
   let mockClaims: Claims;
 
   beforeEach(() => {
-    mockClaims = createmockclaims();
+    mockClaims = createMockClaims();
     req = createMockRequest(PATH_NAMES.AUTHORIZE);
     req.query = {
       client_id: getOrchToAuthExpectedClientId(),

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -13,7 +13,7 @@ import { createApiResponse } from "../../../utils/http";
 import { AxiosResponse } from "axios";
 import {
   createJwt,
-  createmockclaims,
+  createMockClaims,
   getPrivateKey,
   getPublicKey,
 } from "./test-data";
@@ -34,7 +34,7 @@ describe("Integration:: authorize", () => {
     const jwtService = require("../jwt-service");
     const publicKey = getPublicKey();
     const privateKey = await getPrivateKey();
-    const jwt = await createJwt(createmockclaims(), privateKey);
+    const jwt = await createJwt(createMockClaims(), privateKey);
 
     sinon
       .stub(authorizeService, "authorizeService")

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -43,14 +43,10 @@ describe("authorize service", () => {
   it("sends a request with the correct headers set to true when reauth is requested and the feature flag is set", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
 
-    service.start(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      isAuthenticated,
-      "123456"
-    );
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: "123456",
+    });
 
     expect(
       postStub.calledOnceWithExactly(
@@ -72,14 +68,10 @@ describe("authorize service", () => {
 
   it("sends a request without a reauth header when reauth is requested but the feature flag is not set", () => {
     process.env.SUPPORT_REAUTHENTICATION = "0";
-    service.start(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      isAuthenticated,
-      "123456"
-    );
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: "123456",
+    });
 
     expect(
       postStub.calledOnceWithExactly(
@@ -95,13 +87,9 @@ describe("authorize service", () => {
 
   it("sends a request without a reauth header when reauth is not requested", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
-    service.start(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      isAuthenticated
-    );
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+    });
 
     expect(
       postStub.calledOnceWithExactly(
@@ -117,15 +105,11 @@ describe("authorize service", () => {
 
   it("sends a request with previous session ID in the body when given", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
-    service.start(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      isAuthenticated,
-      undefined,
-      previousSessionId
-    );
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: undefined,
+      previous_session_id: previousSessionId,
+    });
 
     expect(
       postStub.calledOnceWithExactly(
@@ -146,16 +130,12 @@ describe("authorize service", () => {
 
   it("sends a request with the pairwise id for reauth and previous journey id in the body when present", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
-    service.start(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      isAuthenticated,
-      "123456",
-      undefined,
-      "previous-journey-id"
-    );
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: "123456",
+      previous_session_id: undefined,
+      previous_govuk_signin_journey_id: "previous-journey-id",
+    });
 
     expect(
       postStub.calledOnceWithExactly(

--- a/src/components/authorize/tests/jwt-service.test.ts
+++ b/src/components/authorize/tests/jwt-service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe } from "mocha";
 import { assert, expect } from "chai";
 import { JwtService } from "../jwt-service";
 import { JwtValidationError, JwtClaimsValueError } from "../../../utils/error";
-import { getKnownClaims } from "../claims-config";
+import { Claims, getKnownClaims } from "../claims-config";
 import {
   createJwt,
   createMockClaims,
@@ -18,7 +18,7 @@ import {
 } from "jose";
 
 describe("JWT service", () => {
-  let claims: any;
+  let claims: Claims;
   let publicKey: string;
   let privateKey: KeyLike;
   let wrongPrivateKey: KeyLike;
@@ -174,7 +174,7 @@ describe("JWT service", () => {
         Object.keys(claims).forEach(async (claim) => {
           const withoutClaim = { ...claims };
           try {
-            delete withoutClaim[claim];
+            delete withoutClaim[claim as keyof Claims];
             const jwtMissingClaim = await createJwt(withoutClaim, privateKey);
             jwtService.getPayloadWithValidation(jwtMissingClaim);
             assert.fail("Expected error to be thrown");

--- a/src/components/authorize/tests/jwt-service.test.ts
+++ b/src/components/authorize/tests/jwt-service.test.ts
@@ -5,7 +5,7 @@ import { JwtValidationError, JwtClaimsValueError } from "../../../utils/error";
 import { getKnownClaims } from "../claims-config";
 import {
   createJwt,
-  createmockclaims,
+  createMockClaims,
   getPrivateKey,
   getWrongPrivateKey,
   getPublicKey,
@@ -26,22 +26,22 @@ describe("JWT service", () => {
   let jwtService: JwtService;
 
   beforeEach(async () => {
-    claims = createmockclaims();
+    claims = createMockClaims();
     publicKey = getPublicKey();
     privateKey = await getPrivateKey();
     wrongPrivateKey = await getWrongPrivateKey();
-    validJwt = await createJwt(createmockclaims(), privateKey);
+    validJwt = await createJwt(createMockClaims(), privateKey);
     jwtService = new JwtService(publicKey);
   });
 
   describe("getPayloadWithValidation", () => {
     it("should return payload from valid JWT", async () => {
       const result = await jwtService.getPayloadWithValidation(validJwt);
-      expect(result).to.deep.equal(createmockclaims());
+      expect(result).to.deep.equal(createMockClaims());
     });
 
     it("should consider a jwt with a reautheticate claim as valid", async () => {
-      const jwtWithReautheticateClaim = createmockclaims();
+      const jwtWithReautheticateClaim = createMockClaims();
       jwtWithReautheticateClaim.reauthenticate = "123456";
       const jwt = await createJwt(jwtWithReautheticateClaim, privateKey);
 
@@ -60,21 +60,21 @@ describe("JWT service", () => {
       });
 
       it("should accept payloads signed by the stub", async () => {
-        const jwt = await createJwt(createmockclaims(), stubKeyPair.privateKey);
+        const jwt = await createJwt(createMockClaims(), stubKeyPair.privateKey);
 
         const result = await jwtService.getPayloadWithValidation(jwt);
 
-        expect(result).to.deep.equal(createmockclaims());
+        expect(result).to.deep.equal(createMockClaims());
       });
 
       it("should accept standard payloads when a stub key is present", async () => {
         const result = await jwtService.getPayloadWithValidation(validJwt);
 
-        expect(result).to.deep.equal(createmockclaims());
+        expect(result).to.deep.equal(createMockClaims());
       });
 
       it("should reject invalid payloads when a stub key is present", async () => {
-        const jwt = await createJwt(createmockclaims(), wrongPrivateKey);
+        const jwt = await createJwt(createMockClaims(), wrongPrivateKey);
 
         try {
           await jwtService.getPayloadWithValidation(jwt);
@@ -124,7 +124,7 @@ describe("JWT service", () => {
 
       it("should throw error when jwt isn't signed with the correct public key", async () => {
         const JwtWrongSig = await createJwt(
-          createmockclaims(),
+          createMockClaims(),
           wrongPrivateKey
         );
         jwtService = new JwtService(publicKey);
@@ -139,7 +139,7 @@ describe("JWT service", () => {
       });
 
       it("should throw error when jwt contains invalid claim object", async () => {
-        const claims = createmockclaims();
+        const claims = createMockClaims();
         claims["claim"] = "not a json";
 
         const jwtWithInvalidClaimObject = await createJwt(claims, privateKey);
@@ -157,7 +157,7 @@ describe("JWT service", () => {
       });
 
       it("should pass validation when jwt does not contain claim object", async () => {
-        const claims = createmockclaims();
+        const claims = createMockClaims();
         delete claims["claim"];
 
         const jwtWithoutClaimObject = await createJwt(claims, privateKey);
@@ -239,7 +239,7 @@ describe("JWT service", () => {
     describe("validateCustomClaims", () => {
       let claims: any;
       beforeEach(() => {
-        claims = createmockclaims();
+        claims = createMockClaims();
       });
 
       it("should return claims if correctly supplied", () => {

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -4,7 +4,7 @@ import {
   getOrchToAuthExpectedClientId,
 } from "../../../config";
 
-export function createmockclaims(): any {
+export function createMockClaims(): any {
   const timestamp = Math.floor(new Date().getTime() / 1000);
   return {
     confidence: "Cl.Cm",

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -29,6 +29,7 @@ export function createMockClaims(): Claims {
     previous_govuk_signin_journey_id: "a7349515-9154-4d20-b282-c42d2d35ac10",
     claim:
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
+    authenticated: false,
   };
 }
 

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -3,8 +3,9 @@ import {
   getOrchToAuthExpectedAudience,
   getOrchToAuthExpectedClientId,
 } from "../../../config";
+import { Claims } from "../claims-config";
 
-export function createMockClaims(): any {
+export function createMockClaims(): Claims {
   const timestamp = Math.floor(new Date().getTime() / 1000);
   return {
     confidence: "Cl.Cm",
@@ -15,7 +16,6 @@ export function createMockClaims(): any {
     service_type: "MANDATORY",
     nbf: timestamp,
     cookie_consent_shared: true,
-    scope: "openid email phone",
     state: "WLUNPYv0RPdVjhBsG4QMHYYMhGaOc8X-t83Y1XsVh1w",
     redirect_uri: "UNKNOWN",
     exp: timestamp + 1000,
@@ -24,6 +24,9 @@ export function createMockClaims(): any {
     is_one_login_service: false,
     rp_sector_host: "https://rp.sector.uri",
     jti: "fvvMWAladDtl35O_xyBTRLwwojA",
+    rp_redirect_uri: "https://rp.service.gov.uk/redirect/",
+    rp_state: "baeb1828-131f-40ef-9574-eee677d1cdd7",
+    previous_govuk_signin_journey_id: "a7349515-9154-4d20-b282-c42d2d35ac10",
     claim:
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
   };

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -32,10 +32,7 @@ export interface AuthorizeServiceInterface {
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    authenticated: boolean,
-    reauthenticate?: string,
-    previousSessionId?: string,
-    previousGovukSigninJourneyId?: string
+    startRequestParameters: StartRequestParameters
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -2,6 +2,14 @@ import { ApiResponseResult, DefaultApiResponse } from "../../types";
 import { Claims } from "./claims-config";
 import { Request } from "express";
 
+export interface StartRequestParameters {
+  authenticated: boolean;
+  previous_session_id?: string;
+  rp_pairwise_id_for_reauth?: string;
+  previous_govuk_signin_journey_id?: string;
+  reauthenticate?: string;
+}
+
 export interface StartAuthResponse extends DefaultApiResponse {
   user: UserSessionInfo;
   featureFlags?: Record<string, unknown>;

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -24,6 +24,7 @@ export interface AuthorizeServiceInterface {
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
+    authenticated: boolean,
     reauthenticate?: string,
     previousSessionId?: string,
     previousGovukSigninJourneyId?: string


### PR DESCRIPTION
## What
- As [part of previous work](https://github.com/govuk-one-login/authentication-api/pull/5310/files), Orchestration now pass the `authenticated` claim to Auth as part of the `/authorize` request. We now need to pass this further to the backend so it can be stored in the new session store
- This PR pulls this claim out of the JAR and adds it to the body of the of the POST request to the start handler
- There are also some BAU commits which do some light refactoring in places:
   - Renames a test helper to use camel case
   - Updates the test helper return type to reflect more accurately the claims passed from Orchestration to Auth
   - Updates the authorize service interface for start to cut down on the number of method arguments, moving these into 
     an object.  
## How to review
- Code review commit-by-commit
- Deploy to an auth dev environment and run through a journey to test
   - Deployed to sandpit and ran through log in journey 
   - Nothing really to see, as we're not doing anything with this field yet. But as this affects the interface between Orch and 
      Auth, being successfully handed over confirms this works fine 

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs
- [PR which established Orch sending the authenticated claim](https://github.com/govuk-one-login/authentication-api/pull/5310/files)
