### PR TITLE
AUT-3760: Create baseline GA4 taxonomy tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "husky": "^9.0.10",
     "mocha": "10.7.3",
+    "mocha-chai-jest-snapshot": "^1.1.6",
     "mock-req-res": "^1.2.0",
     "nock": "^13.5.1",
     "nodemon": "3.1.4",

--- a/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: resend SMS mfa code (account creation variant) should return 500 error screen when API call fails 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: resend SMS mfa code (account creation variant) should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend SMS mfa code (account creation variant) should return resend mfa code page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../../test/utils/test-utils";
+import { sinon, request } from "../../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -40,13 +39,15 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
     app = await require("../../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL as string;
 
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION),
+      { expectTaxonomyMatchSnapshot: false }
+    ).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -59,19 +60,21 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
   });
 
   it("should return resend mfa code page", async () => {
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
-      .expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should redirect to /check-your-phone when new code requested", async () => {
@@ -80,16 +83,18 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        isResendCodeRequest: true,
-      })
-      .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          isResendCodeRequest: true,
+        })
+        .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
+        .expect(302)
+    );
   });
 
   it("should return 500 error screen when API call fails", async () => {
@@ -97,13 +102,15 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
       errorCode: "1234",
     });
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(500);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(500)
+    );
   });
 });

--- a/src/components/account-recovery/check-your-email-security-codes/tests/__snapshots__/check-your-email-security-codes-integration.test.ts.snap
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/__snapshots__/check-your-email-security-codes-integration.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: check your email security codes should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your email security codes should return validation error when code entered contains letters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email security codes should return validation error when code is greater than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email security codes should return validation error when code is less than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email security codes should return validation error when code not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email security codes should return validation error when incorrect code entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email security codes should return verify email page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
@@ -1,7 +1,6 @@
-import request from "supertest";
 import { describe } from "mocha";
 import { AxiosResponse } from "axios";
-import { expect, sinon } from "../../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -94,13 +93,15 @@ describe("Integration:: check your email security codes", () => {
     app = await require("../../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL || "";
 
-    await request(app)
-      .get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES),
+      { expectTaxonomyMatchSnapshot: false }
+    ).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -113,90 +114,100 @@ describe("Integration:: check your email security codes", () => {
   });
 
   it("should return verify email page", async () => {
-    await request(app)
-      .get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when code not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the code");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains("Enter the code");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is less than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "2",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "2",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is greater than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "1234567",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "1234567",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code entered contains letters", async () => {
     process.env.SUPPORT_ACCOUNT_RECOVERY = "1";
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "12ert-",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "12ert-",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /get-security-codes when valid code entered", async () => {
@@ -206,16 +217,18 @@ describe("Integration:: check your email security codes", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123456",
-      })
-      .expect("Location", PATH_NAMES.GET_SECURITY_CODES)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123456",
+        })
+        .expect("Location", PATH_NAMES.GET_SECURITY_CODES)
+        .expect(302)
+    );
   });
 
   it("should return validation error when incorrect code entered", async () => {
@@ -224,21 +237,23 @@ describe("Integration:: check your email security codes", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "The code you entered is not correct, or may have expired, try entering it again or request a new code"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "The code you entered is not correct, or may have expired, try entering it again or request a new code"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return error page when when incorrect code entered more than 5 times", async () => {
@@ -247,18 +262,20 @@ describe("Integration:: check your email security codes", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.EmailMaxRetries}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.EmailMaxRetries}`
+        )
+        .expect(302)
+    );
   });
 });

--- a/src/components/authorize/tests/__snapshots__/authorize-integration.test.ts.snap
+++ b/src/components/authorize/tests/__snapshots__/authorize-integration.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: authorize should redirect to /sign-in-or-create with Google Analytics tag if 'result' query exists 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { sinon, request } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import decache from "decache";
 import { HTTP_STATUS_CODES, PATH_NAMES } from "../../../app.constants";
@@ -92,27 +91,34 @@ describe("Integration:: authorize", () => {
   });
 
   it("should redirect to /sign-in-or-create", async () => {
-    await request(app)
-      .get(PATH_NAMES.AUTHORIZE)
-      .query({
-        client_id: getOrchToAuthExpectedClientId(),
-        response_type: "code",
-        request: "SomeJWE",
-      })
-      .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.AUTHORIZE)
+        .query({
+          client_id: getOrchToAuthExpectedClientId(),
+          response_type: "code",
+          request: "SomeJWE",
+        })
+        .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
+        .expect(302)
+    );
   });
 
   it("should redirect to /sign-in-or-create with Google Analytics tag if 'result' query exists", async () => {
-    await request(app)
-      .get(PATH_NAMES.AUTHORIZE)
-      .query({
-        client_id: getOrchToAuthExpectedClientId(),
-        response_type: "code",
-        request: "SomeJWE",
-        result: "test-result",
-      })
-      .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE + "?result=test-result")
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.AUTHORIZE)
+        .query({
+          client_id: getOrchToAuthExpectedClientId(),
+          response_type: "code",
+          request: "SomeJWE",
+          result: "test-result",
+        })
+        .expect(
+          "Location",
+          PATH_NAMES.SIGN_IN_OR_CREATE + "?result=test-result"
+        )
+        .expect(302)
+    );
   });
 });

--- a/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
+++ b/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: check your email should return error page when when incorrect code entered more than 5 times 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your email should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your email should return validation error when code entered contains letters 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email should return validation error when code is greater than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email should return validation error when code is less than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email should return validation error when code not entered 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email should return validation error when incorrect code entered 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your email should return verify email page 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -41,13 +40,13 @@ describe("Integration:: check your email", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .then((res) => {
+    await request(app, (test) => test.get(PATH_NAMES.CHECK_YOUR_EMAIL)).then(
+      (res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
-      });
+      }
+    );
   });
 
   beforeEach(() => {
@@ -61,87 +60,99 @@ describe("Integration:: check your email", () => {
   });
 
   it("should return verify email page", async () => {
-    await request(app).get(PATH_NAMES.CHECK_YOUR_EMAIL).expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.CHECK_YOUR_EMAIL).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when code not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the code");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains("Enter the code");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is less than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "2",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "2",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is greater than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "1234567",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "1234567",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code entered contains letters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "12ert-",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "12ert-",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /create-password when valid code entered", async () => {
@@ -158,16 +169,18 @@ describe("Integration:: check your email", () => {
         isBlockedStatus: "Pending",
       });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123456",
-      })
-      .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123456",
+        })
+        .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .expect(302)
+    );
   });
 
   it("should return validation error when incorrect code entered", async () => {
@@ -184,21 +197,23 @@ describe("Integration:: check your email", () => {
         isBlockedStatus: "Pending",
       });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "The code you entered is not correct, or may have expired, try entering it again or request a new code"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "The code you entered is not correct, or may have expired, try entering it again or request a new code"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return error page when when incorrect code entered more than 5 times", async () => {
@@ -215,18 +230,20 @@ describe("Integration:: check your email", () => {
         isBlockedStatus: "Pending",
       });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_EMAIL)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.EmailMaxRetries}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_EMAIL)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.EmailMaxRetries}`
+        )
+        .expect(302)
+    );
   });
 });

--- a/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
+++ b/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: check your phone should render the "you requested too many codes" pages when incorrect code has requested more than 5 times 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should render the "you requested too many codes" pages when incorrect code has requested more than 5 times 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: check your phone should return check your phone page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should return validation error when code entered contains letters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should return validation error when code is greater than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should return validation error when code is less than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should return validation error when code not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: check your phone should return validation error when incorrect code entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import cheerio from "cheerio";
 import decache from "decache";
@@ -42,13 +41,13 @@ describe("Integration:: check your phone", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.CHECK_YOUR_PHONE)
-      .then((res) => {
+    await request(app, (test) => test.get(PATH_NAMES.CHECK_YOUR_PHONE)).then(
+      (res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
-      });
+      }
+    );
   });
 
   beforeEach(() => {
@@ -62,87 +61,99 @@ describe("Integration:: check your phone", () => {
   });
 
   it("should return check your phone page", async () => {
-    await request(app).get(PATH_NAMES.CHECK_YOUR_PHONE).expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.CHECK_YOUR_PHONE).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when code not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the code");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains("Enter the code");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is less than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "2",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "2",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is greater than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "1234567",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "1234567",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code entered contains letters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "12ert-",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "12ert-",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /create-password when valid code entered", async () => {
@@ -154,16 +165,18 @@ describe("Integration:: check your phone", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123456",
-      })
-      .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123456",
+        })
+        .expect("Location", PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL)
+        .expect(302)
+    );
   });
 
   it("should return validation error when incorrect code entered", async () => {
@@ -172,21 +185,23 @@ describe("Integration:: check your phone", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "The code you entered is not correct, or may have expired, try entering it again or request a new code"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "The code you entered is not correct, or may have expired, try entering it again or request a new code"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to security code expired when incorrect code has been entered 5 times", async () => {
@@ -195,19 +210,21 @@ describe("Integration:: check your phone", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.OtpMaxRetries}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.OtpMaxRetries}`
+        )
+        .expect(302)
+    );
   });
 
   it('should render the "you requested too many codes" pages when incorrect code has requested more than 5 times', async () => {
@@ -216,25 +233,29 @@ describe("Integration:: check your phone", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CHECK_YOUR_PHONE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.OtpBlocked}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CHECK_YOUR_PHONE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.OtpBlocked}`
+        )
+        .expect(302)
+    );
 
-    await request(app)
-      .get(PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect((res) => {
-        res.text.includes("Wait 2 hours");
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.CHECK_YOUR_PHONE)
+        .expect((res) => {
+          res.text.includes("Wait 2 hours");
+        })
+        .expect(200)
+    );
   });
 });

--- a/src/components/common/cookies/tests/cookies-controller-integration.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../../test/utils/test-utils";
 import cheerio from "cheerio";
 import decache from "decache";
 import { PATH_NAMES, ANALYTICS_COOKIES } from "../../../../app.constants";
@@ -16,9 +15,8 @@ describe("Integration:: cookies controller", () => {
 
     app = await require("../../../../app").createApp();
 
-    await request(app)
-      .get(PATH_NAMES.COOKIES_POLICY)
-      .then((res) => {
+    await request(app, (test) => test.get(PATH_NAMES.COOKIES_POLICY)).then(
+      (res) => {
         $ = cheerio.load(res.text);
         $("table#analytics-cookies tbody td:first-child").each(
           (i: any, elem: any) => {
@@ -26,7 +24,8 @@ describe("Integration:: cookies controller", () => {
             analyticsCookieNamesListedInCookieNotice.push(cookieName);
           }
         );
-      });
+      }
+    );
   });
 
   after(() => {

--- a/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
+++ b/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
@@ -1,0 +1,274 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: contact us - public user should return contact us further information account creation page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us further information signing in page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page including valid referer url 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page including valid referer url 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page including valid referer url 3`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page including valid referer url 4`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page including valid referer url 5`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page including valid referer url 6`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 3`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 4`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 3`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 4`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 5`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 6`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page removing invalid referer queryparam url 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page removing invalid referer queryparam url 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page removing invalid referer queryparam url 3`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page with a theme and a subtheme 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user should return contact us questions page with only a theme 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when issue description are not entered on the contact-us-questions page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when no radio boxes are selected on the proving_identity contact-us-further-information page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when no radio boxes are selected on the signing in contact-us-further-information page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when user has not selected how the security code was sent whilst creating an account 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when user selected Text message to a phone number from another country and left the Which country field empty 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when user selected yes to contact for feedback and left email field empty 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user should return validation error when user selected yes to contact for feedback but email is in an invalid format 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem taking a photo of your identity document using the GOV.UK ID Check app should return validation error when user has not selected which identity document they were using 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem with their bank or building society details should return validation error when user has not selected which problem they had 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem with their identity document should return validation error when user has not selected which identity document they were using 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem with their national insurance number should return validation error when user has not described which problem they had 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem with their phone number when creating an account should return validation error when user has not entered country the phone number is from 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem with their phone number when creating an account should return validation error when user has not entered what happened 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user had a problem with their phone number when creating an account should return validation error when user has not entered what they were trying to do 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -30,14 +29,15 @@ describe("Integration:: contact us - public user", () => {
     app = await require("../../../app").createApp();
     smartAgentApiUrl = process.env.SMARTAGENT_API_URL;
 
-    await request(app)
-      .get(PATH_NAMES.CONTACT_US)
-      .query("supportType=PUBLIC")
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.CONTACT_US).query("supportType=PUBLIC"),
+      { expectTaxonomyMatchSnapshot: false }
+    ).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -55,23 +55,24 @@ describe("Integration:: contact us - public user", () => {
     errorElement: string,
     errorDescription: string
   ) => {
-    await request(app)
-      .post(url)
-      .type("form")
-      .set("Cookie", cookies)
-      .send(data)
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($(errorElement).text()).to.contains(errorDescription);
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(url)
+        .type("form")
+        .set("Cookie", cookies)
+        .send(data)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($(errorElement).text()).to.contains(errorDescription);
+        })
+        .expect(400)
+    );
   };
 
   it("should return contact us page", async () => {
-    await request(app)
-      .get(PATH_NAMES.CONTACT_US)
-      .query("supportType=PUBLIC")
-      .expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.CONTACT_US).query("supportType=PUBLIC").expect(200)
+    );
   });
 
   [
@@ -81,18 +82,20 @@ describe("Integration:: contact us - public user", () => {
     "<script>alert(123);</script>",
   ].forEach(function (referer) {
     it("should return contact us page removing invalid referer url", async () => {
-      await request(app)
-        .get(PATH_NAMES.CONTACT_US)
-        .query("supportType=PUBLIC")
-        .set("referer", referer)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("input[name = referer]").val()).to.not.contains(referer);
-          expect($("input[name = referer]").val()).to.not.contains(
-            encodeURIComponent(referer)
-          );
-        })
-        .expect(200);
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.CONTACT_US)
+          .query("supportType=PUBLIC")
+          .set("referer", referer)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($("input[name = referer]").val()).to.not.contains(referer);
+            expect($("input[name = referer]").val()).to.not.contains(
+              encodeURIComponent(referer)
+            );
+          })
+          .expect(200)
+      );
     });
   });
 
@@ -105,17 +108,19 @@ describe("Integration:: contact us - public user", () => {
     "https://localhost/scenario/page",
   ].forEach(function (referer) {
     it("should return contact us page including valid referer url", async () => {
-      await request(app)
-        .get(PATH_NAMES.CONTACT_US)
-        .query("supportType=PUBLIC")
-        .set("referer", referer)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("input[name = referer]").val()).to.contains(
-            encodeURIComponent(referer)
-          );
-        })
-        .expect(200);
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.CONTACT_US)
+          .query("supportType=PUBLIC")
+          .set("referer", referer)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($("input[name = referer]").val()).to.contains(
+              encodeURIComponent(referer)
+            );
+          })
+          .expect(200)
+      );
     });
   });
 
@@ -125,19 +130,21 @@ describe("Integration:: contact us - public user", () => {
     "<script>alert(123);</script>",
   ].forEach(function (referer) {
     it("should return contact us questions page removing invalid referer queryparam url", async () => {
-      await request(app)
-        .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
-        .query("theme=account_creation")
-        .query("subtheme=sign_in_phone_number_issue")
-        .query("referer=" + referer)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("input[name = referer]").val()).to.not.contains(referer);
-          expect($("input[name = referer]").val()).to.not.contains(
-            encodeURIComponent(referer)
-          );
-        })
-        .expect(200);
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
+          .query("theme=account_creation")
+          .query("subtheme=sign_in_phone_number_issue")
+          .query("referer=" + referer)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($("input[name = referer]").val()).to.not.contains(referer);
+            expect($("input[name = referer]").val()).to.not.contains(
+              encodeURIComponent(referer)
+            );
+          })
+          .expect(200)
+      );
     });
   });
 
@@ -150,64 +157,76 @@ describe("Integration:: contact us - public user", () => {
     "http://localhost:3000/enter-email",
   ].forEach(function (referer) {
     it("should return contact us questions page including valid referer queryparam url", async () => {
-      await request(app)
-        .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
-        .query("theme=account_creation")
-        .query("referer=" + referer)
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("input[name = referer]").val()).to.contains(
-            encodeURIComponent(referer)
-          );
-        })
-        .expect(200);
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
+          .query("theme=account_creation")
+          .query("referer=" + referer)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($("input[name = referer]").val()).to.contains(
+              encodeURIComponent(referer)
+            );
+          })
+          .expect(200)
+      );
     });
   });
 
   it("should return contact us further information signing in page", async () => {
-    await request(app)
-      .get("/contact-us-further-information")
-      .query("theme=signing_in")
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get("/contact-us-further-information")
+        .query("theme=signing_in")
+        .expect(200)
+    );
   });
 
   it("should return contact us further information account creation page", async () => {
-    await request(app)
-      .get("/contact-us-further-information")
-      .query("theme=account_creation")
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get("/contact-us-further-information")
+        .query("theme=account_creation")
+        .expect(200)
+    );
   });
 
   it("should return contact us questions page with only a theme", async () => {
-    await request(app)
-      .get("/contact-us-questions")
-      .query("theme=email_subscriptions")
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get("/contact-us-questions")
+        .query("theme=email_subscriptions")
+        .expect(200)
+    );
   });
 
   it("should return contact us questions page with a theme and a subtheme", async () => {
-    await request(app)
-      .get("/contact-us-questions")
-      .query("theme=signing_in")
-      .query("subtheme=no_security_code")
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get("/contact-us-questions")
+        .query("theme=signing_in")
+        .query("subtheme=no_security_code")
+        .expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.CONTACT_US)
-      .query("supportType=PUBLIC")
-      .type("form")
-      .send({})
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CONTACT_US)
+        .query("supportType=PUBLIC")
+        .type("form")
+        .send({})
+        .expect(403)
+    );
   });
 
-  it("should return validation error when no radio boxes are selected on the signing in contact-us-further-information page", () => {
+  it("should return validation error when no radio boxes are selected on the signing in contact-us-further-information page", async () => {
     const data = {
       _csrf: token,
       theme: "signing_in",
     };
-    expectValidationErrorOnPost(
+    await expectValidationErrorOnPost(
       "/contact-us-further-information",
       data,
       "#subtheme-error",
@@ -215,12 +234,12 @@ describe("Integration:: contact us - public user", () => {
     );
   });
 
-  it("should return validation error when no radio boxes are selected on the proving_identity contact-us-further-information page", () => {
+  it("should return validation error when no radio boxes are selected on the proving_identity contact-us-further-information page", async () => {
     const data = {
       _csrf: token,
       theme: "proving_identity",
     };
-    expectValidationErrorOnPost(
+    await expectValidationErrorOnPost(
       "/contact-us-further-information",
       data,
       "#subtheme-error",
@@ -228,14 +247,14 @@ describe("Integration:: contact us - public user", () => {
     );
   });
 
-  it("should return validation error when issue description are not entered on the contact-us-questions page", () => {
+  it("should return validation error when issue description are not entered on the contact-us-questions page", async () => {
     const data = {
       _csrf: token,
       issueDescription: "",
       theme: "signing_in",
       subtheme: "technical_error",
     };
-    expectValidationErrorOnPost(
+    await expectValidationErrorOnPost(
       "/contact-us-questions",
       data,
       "#issueDescription-error",
@@ -243,7 +262,7 @@ describe("Integration:: contact us - public user", () => {
     );
   });
 
-  it("should return validation error when user selected yes to contact for feedback and left email field empty", () => {
+  it("should return validation error when user selected yes to contact for feedback and left email field empty", async () => {
     const data = {
       _csrf: token,
       theme: "signing_in",
@@ -252,7 +271,7 @@ describe("Integration:: contact us - public user", () => {
       additionalDescription: "additional",
       contact: "true",
     };
-    expectValidationErrorOnPost(
+    await expectValidationErrorOnPost(
       "/contact-us-questions",
       data,
       "#email-error",
@@ -261,29 +280,31 @@ describe("Integration:: contact us - public user", () => {
   });
 
   it("should return validation error when user selected Text message to a phone number from another country and left the Which country field empty", async () => {
-    await request(app)
-      .post("/contact-us-questions?radio_buttons=true")
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        theme: "account_creation",
-        subtheme: "invalid_security_code",
-        additionalDescription: "additional",
-        contact: "false",
-        securityCodeSentMethod: "text_message_international_number",
-        country: " ",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#country-error").text()).to.contains(
-          "Enter which country your phone number is from"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post("/contact-us-questions?radio_buttons=true")
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          theme: "account_creation",
+          subtheme: "invalid_security_code",
+          additionalDescription: "additional",
+          contact: "false",
+          securityCodeSentMethod: "text_message_international_number",
+          country: " ",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#country-error").text()).to.contains(
+            "Enter which country your phone number is from"
+          );
+        })
+        .expect(400)
+    );
   });
 
-  it("should return validation error when user selected yes to contact for feedback but email is in an invalid format", () => {
+  it("should return validation error when user selected yes to contact for feedback but email is in an invalid format", async () => {
     const data = {
       _csrf: token,
       theme: "signing_in",
@@ -293,7 +314,7 @@ describe("Integration:: contact us - public user", () => {
       contact: "true",
       email: "test",
     };
-    expectValidationErrorOnPost(
+    await expectValidationErrorOnPost(
       "/contact-us-questions",
       data,
       "#email-error",
@@ -301,7 +322,7 @@ describe("Integration:: contact us - public user", () => {
     );
   });
 
-  it("should return validation error when user has not selected how the security code was sent whilst creating an account", () => {
+  it("should return validation error when user has not selected how the security code was sent whilst creating an account", async () => {
     const data = {
       _csrf: token,
       theme: "account_creation",
@@ -310,7 +331,7 @@ describe("Integration:: contact us - public user", () => {
       formType: "noSecurityCode",
       contact: "false",
     };
-    expectValidationErrorOnPost(
+    await expectValidationErrorOnPost(
       "/contact-us-questions?radio_buttons=true",
       data,
       "#securityCodeSentMethod-error",
@@ -319,14 +340,14 @@ describe("Integration:: contact us - public user", () => {
   });
 
   describe("when a user had a problem with their identity document", () => {
-    it("should return validation error when user has not selected which identity document they were using", () => {
+    it("should return validation error when user has not selected which identity document they were using", async () => {
       const data = {
         _csrf: token,
         theme: "proving_identity",
         subtheme: "proving_identity_problem_with_identity_document",
         contact: "false",
       };
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#identityDocumentUsed-error",
@@ -336,14 +357,14 @@ describe("Integration:: contact us - public user", () => {
   });
 
   describe("when a user had a problem with their bank or building society details", () => {
-    it("should return validation error when user has not selected which problem they had", () => {
+    it("should return validation error when user has not selected which problem they had", async () => {
       const data = {
         _csrf: token,
         theme: "proving_identity",
         subtheme: "proving_identity_problem_with_bank_building_society_details",
         contact: "false",
       };
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#problemWith-error",
@@ -353,7 +374,7 @@ describe("Integration:: contact us - public user", () => {
   });
 
   describe("when a user had a problem taking a photo of your identity document using the GOV.UK ID Check app", () => {
-    it("should return validation error when user has not selected which identity document they were using", () => {
+    it("should return validation error when user has not selected which identity document they were using", async () => {
       const data = {
         _csrf: token,
         theme: "id_check_app",
@@ -361,7 +382,7 @@ describe("Integration:: contact us - public user", () => {
         moreDetailDescription: "There was a problem",
         contact: "false",
       };
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions?radio_buttons=true",
         data,
         "#identityDocumentUsed-error",
@@ -371,14 +392,14 @@ describe("Integration:: contact us - public user", () => {
   });
 
   describe("when a user had a problem with their national insurance number", () => {
-    it("should return validation error when user has not described which problem they had", () => {
+    it("should return validation error when user has not described which problem they had", async () => {
       const data = {
         _csrf: token,
         theme: "proving_identity",
         subtheme: "proving_identity_problem_with_national_insurance_number",
         contact: "false",
       };
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#problemWithNationalInsuranceNumber-error",
@@ -406,9 +427,9 @@ describe("Integration:: contact us - public user", () => {
       };
     };
 
-    it("should return validation error when user has not entered what they were trying to do", () => {
+    it("should return validation error when user has not entered what they were trying to do", async () => {
       const data = phoneNumberIssueData("", "additional detail", "UK");
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#issueDescription-error",
@@ -416,9 +437,9 @@ describe("Integration:: contact us - public user", () => {
       );
     });
 
-    it("should return validation error when user has not entered what happened", () => {
+    it("should return validation error when user has not entered what happened", async () => {
       const data = phoneNumberIssueData("more detail", "", "UK");
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#additionalDescription-error",
@@ -426,9 +447,9 @@ describe("Integration:: contact us - public user", () => {
       );
     });
 
-    it("should return validation error when user has not entered country the phone number is from", () => {
+    it("should return validation error when user has not entered country the phone number is from", async () => {
       const data = phoneNumberIssueData("more detail", "additional detail", "");
-      expectValidationErrorOnPost(
+      await expectValidationErrorOnPost(
         "/contact-us-questions",
         data,
         "#countryPhoneNumberFrom-error",
@@ -439,77 +460,87 @@ describe("Integration:: contact us - public user", () => {
     it("should redirect to success page when valid form submitted", async () => {
       nock(smartAgentApiUrl).post("/").once().reply(200);
 
-      await request(app)
-        .post("/contact-us-questions")
-        .type("form")
-        .set("Cookie", cookies)
-        .send(phoneNumberIssueData("detail", "description", "UK"))
-        .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
-        .expect(302);
+      await request(app, (test) =>
+        test
+          .post("/contact-us-questions")
+          .type("form")
+          .set("Cookie", cookies)
+          .send(phoneNumberIssueData("detail", "description", "UK"))
+          .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
+          .expect(302)
+      );
     });
   });
 
   it("should redirect to success page when form submitted", async () => {
     nock(smartAgentApiUrl).post("/").once().reply(200);
 
-    await request(app)
-      .post("/contact-us-questions")
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        theme: "signing_in",
-        subtheme: "no_security_code",
-        optionalDescription: "issue",
-        contact: "true",
-        email: "test@test.com",
-        formType: "noSecurityCode",
-        referer: "https://gov.uk/sign-in",
-      })
-      .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post("/contact-us-questions")
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          theme: "signing_in",
+          subtheme: "no_security_code",
+          optionalDescription: "issue",
+          contact: "true",
+          email: "test@test.com",
+          formType: "noSecurityCode",
+          referer: "https://gov.uk/sign-in",
+        })
+        .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
+        .expect(302)
+    );
   });
 
   it("should redirect to success page when authenticator app problem form submitted", async () => {
     nock(smartAgentApiUrl).post("/").once().reply(200);
 
-    await request(app)
-      .post("/contact-us-questions")
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        theme: "account_creation",
-        subtheme: "authenticator_app_problem",
-        issueDescription: "issue",
-        additionalDescription: "additional information",
-        contact: "true",
-        email: "test@test.com",
-        formType: "authenticatorApp",
-        referer: "https://gov.uk/sign-in",
-      })
-      .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post("/contact-us-questions")
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          theme: "account_creation",
+          subtheme: "authenticator_app_problem",
+          issueDescription: "issue",
+          additionalDescription: "additional information",
+          contact: "true",
+          email: "test@test.com",
+          formType: "authenticatorApp",
+          referer: "https://gov.uk/sign-in",
+        })
+        .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
+        .expect(302)
+    );
   });
 
   describe("Links to /contact-us-from-triage-page", () => {
     it("should redirect to /contact-us", async () => {
-      await request(app)
-        .get("/contact-us-from-triage-page")
-        .query("fromURL=http//localhost/sign-in-or-create")
-        .expect("Location", `${PATH_NAMES.CONTACT_US}?`)
-        .expect(302);
+      await request(app, (test) =>
+        test
+          .get("/contact-us-from-triage-page")
+          .query("fromURL=http//localhost/sign-in-or-create")
+          .expect("Location", `${PATH_NAMES.CONTACT_US}?`)
+          .expect(302)
+      );
     });
 
     it("should redirect to /contact-us-further-information", async () => {
-      await request(app)
-        .get("/contact-us-from-triage-page")
-        .query(`theme=${CONTACT_US_THEMES.ID_CHECK_APP}`)
-        .expect(
-          "Location",
-          `${PATH_NAMES.CONTACT_US_FURTHER_INFORMATION}?theme=${CONTACT_US_THEMES.ID_CHECK_APP}`
-        )
-        .expect(302);
+      await request(app, (test) =>
+        test
+          .get("/contact-us-from-triage-page")
+          .query(`theme=${CONTACT_US_THEMES.ID_CHECK_APP}`)
+          .expect(
+            "Location",
+            `${PATH_NAMES.CONTACT_US_FURTHER_INFORMATION}?theme=${CONTACT_US_THEMES.ID_CHECK_APP}`
+          )
+          .expect(302)
+      );
     });
   });
 });

--- a/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
+++ b/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::register create password should return create password page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return validation error when no numbers present in password 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return validation error when password all numeric 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return validation error when password is amongst most common passwords 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return validation error when password less than 8 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return validation error when password not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::register create password should return validation error when passwords don't match 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { after, describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -39,13 +38,15 @@ describe("Integration::register create password", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD),
+      { expectTaxonomyMatchSnapshot: false }
+    ).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -58,114 +59,130 @@ describe("Integration::register create password", () => {
   });
 
   it("should return create password page", async () => {
-    await request(app).get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD).expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .send({
-        email: "test@test.com",
-        password: "test@test.com",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .send({
+          email: "test@test.com",
+          password: "test@test.com",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when password not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "",
-        "confirm-password": "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains("Enter your password");
-        expect($("#confirm-password-error").text()).to.contains(
-          "Re-type your password"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "",
+          "confirm-password": "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter your password"
+          );
+          expect($("#confirm-password-error").text()).to.contains(
+            "Re-type your password"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when passwords don't match", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "sadsadasd33da",
-        "confirm-password": "sdnnsad99d",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#confirm-password-error").text()).to.contains(
-          "Enter the same password in both fields"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "sadsadasd33da",
+          "confirm-password": "sdnnsad99d",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#confirm-password-error").text()).to.contains(
+            "Enter the same password in both fields"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password less than 8 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "dad",
-        "confirm-password": "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "dad",
+          "confirm-password": "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when no numbers present in password", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "testpassword",
-        "confirm-password": "testpassword",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "testpassword",
+          "confirm-password": "testpassword",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password all numeric", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "222222222222222",
-        "confirm-password": "222222222222222",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "222222222222222",
+          "confirm-password": "222222222222222",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password is amongst most common passwords", async () => {
@@ -174,22 +191,24 @@ describe("Integration::register create password", () => {
       .once()
       .reply(400, { code: 1040 });
 
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password123",
-        "confirm-password": "password123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password123",
+          "confirm-password": "password123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to get security codes when valid password entered", async () => {
@@ -198,16 +217,18 @@ describe("Integration::register create password", () => {
       .once()
       .reply(HTTP_STATUS_CODES.OK, {});
 
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "testpassword1",
-        "confirm-password": "testpassword1",
-      })
-      .expect("Location", PATH_NAMES.GET_SECURITY_CODES)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "testpassword1",
+          "confirm-password": "testpassword1",
+        })
+        .expect("Location", PATH_NAMES.GET_SECURITY_CODES)
+        .expect(302)
+    );
   });
 });

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: enter authenticator app code following a validation error it should not include link to change security codes where account recovery is not permitted 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return enter authenticator app security code 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return validation error when code entered contains letters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return validation error when code is greater than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return validation error when code is less than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return validation error when code not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return validation error when incorrect code entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/enter-email/tests/__snapshots__/enter-email-create-account-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-create-account-integration.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::enter email (create account) should redirect to /security-code-invalid-request when request OTP more than 5 times 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter email (create account) should return enter email page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account",
+}
+`;
+
+exports[`Integration::enter email (create account) should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter email (create account) should return internal server error when /user-exists API call response is 500 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter email (create account) should return validation error when email not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account",
+}
+`;
+
+exports[`Integration::enter email (create account) should return validation error when invalid email entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account",
+}
+`;
+
+exports[`Integration::enter email (create account) should return validation error when invalid email entered 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account",
+}
+`;
+
+exports[`Integration::enter email (create account) should return validation error when invalid email entered 3`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account",
+}
+`;

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::enter email should return enter email page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter email should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter email should return internal server error when /user-exists API call response is 500 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter email should return validation error when email not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter email should return validation error when invalid email entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter email should return validation error when invalid email entered 2`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter email should return validation error when invalid email entered 3`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { afterEach, describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, sinon, request } from "../../../../test/utils/test-utils";
 import * as cheerio from "cheerio";
 import decache from "decache";
 import {
@@ -47,13 +46,13 @@ describe("Integration::enter email", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(app, (test) => test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN), {
+      expectTaxonomyMatchSnapshot: false,
+    }).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -72,85 +71,97 @@ describe("Integration::enter email", () => {
   });
 
   it("should return enter email page", (done) => {
-    request(app).get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done);
+    request(app, (test) =>
+      test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .send({
-        email: "test@test.com",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .send({
+          email: "test@test.com",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when email not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#email-error").text()).to.contains(
-          "Enter your email address"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#email-error").text()).to.contains(
+            "Enter your email address"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when invalid email entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test.tµrn@example.com",
-      })
-      .expect(function (res) {
-        const page = cheerio.load(res.text);
-        expect(page("#email-error").text()).to.contains(
-          "Enter an email address in the correct format, like name@example.com\n"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test.tµrn@example.com",
+        })
+        .expect(function (res) {
+          const page = cheerio.load(res.text);
+          expect(page("#email-error").text()).to.contains(
+            "Enter an email address in the correct format, like name@example.com\n"
+          );
+        })
+        .expect(400)
+    );
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test.trnexample.com",
-      })
-      .expect(function (res) {
-        const page = cheerio.load(res.text);
-        expect(page("#email-error").text()).to.contains(
-          "Enter an email address in the correct format, like name@example.com\n"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test.trnexample.com",
+        })
+        .expect(function (res) {
+          const page = cheerio.load(res.text);
+          expect(page("#email-error").text()).to.contains(
+            "Enter an email address in the correct format, like name@example.com\n"
+          );
+        })
+        .expect(400)
+    );
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test.trn@examplecom",
-      })
-      .expect(function (res) {
-        const page = cheerio.load(res.text);
-        expect(page("#email-error").text()).to.contains(
-          "Enter an email address in the correct format, like name@example.com\n"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test.trn@examplecom",
+        })
+        .expect(function (res) {
+          const page = cheerio.load(res.text);
+          expect(page("#email-error").text()).to.contains(
+            "Enter an email address in the correct format, like name@example.com\n"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /enter-password page when email address exists", async () => {
@@ -162,16 +173,18 @@ describe("Integration::enter email", () => {
         doesUserExist: true,
       });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test@test.com",
-      })
-      .expect("Location", PATH_NAMES.ENTER_PASSWORD)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test@test.com",
+        })
+        .expect("Location", PATH_NAMES.ENTER_PASSWORD)
+        .expect(302)
+    );
   });
 
   it("should redirect to /account-not-found when email address not found", async () => {
@@ -183,16 +196,18 @@ describe("Integration::enter email", () => {
         doesUserExist: false,
       });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test@test.com",
-      })
-      .expect("Location", PATH_NAMES.ACCOUNT_NOT_FOUND)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test@test.com",
+        })
+        .expect("Location", PATH_NAMES.ACCOUNT_NOT_FOUND)
+        .expect(302)
+    );
   });
 
   it("should return internal server error when /user-exists API call response is 500", async () => {
@@ -206,15 +221,17 @@ describe("Integration::enter email", () => {
       .once()
       .reply(200, {});
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test@test.com",
-      })
-      .expect(500);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test@test.com",
+        })
+        .expect(500)
+    );
   });
 
   it("should redirect to /enter-password page when email address exists and check re-auth users api call is successfully", async () => {
@@ -233,16 +250,18 @@ describe("Integration::enter email", () => {
         doesUserExist: true,
       });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test@test.com",
-      })
-      .expect("Location", PATH_NAMES.ENTER_PASSWORD)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test@test.com",
+        })
+        .expect("Location", PATH_NAMES.ENTER_PASSWORD)
+        .expect(302)
+    );
   });
 
   it("should redirect to /signed-out with login_required error when user fails re-auth", async () => {
@@ -263,15 +282,17 @@ describe("Integration::enter email", () => {
         doesUserExist: true,
       });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        email: "test@test.com",
-      })
-      .expect("Location", REDIRECT_URI.concat("?error=login_required"))
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          email: "test@test.com",
+        })
+        .expect("Location", REDIRECT_URI.concat("?error=login_required"))
+        .expect(302)
+    );
   });
 });

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: enter mfa following a validation error it should not include link to change security codes where account recovery is not permitted 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return check your phone page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return validation error when code entered contains letters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return validation error when code is greater than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return validation error when code is less than 6 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return validation error when code not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: enter mfa should return validation error when incorrect code entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -67,13 +66,13 @@ describe("Integration:: enter mfa", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL || "";
 
-    await request(app)
-      .get(PATH_NAMES.ENTER_MFA)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA), {
+      expectTaxonomyMatchSnapshot: false,
+    }).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -87,111 +86,123 @@ describe("Integration:: enter mfa", () => {
   });
 
   it("should return check your phone page", async () => {
-    await request(app).get(PATH_NAMES.ENTER_MFA).expect(200);
+    await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA).expect(200));
   });
 
   it("following a validation error it should not include link to change security codes where account recovery is not permitted", async () => {
-    await request(app)
-      .get(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123456",
-        phoneNumber: PHONE_NUMBER,
-        supportAccountRecovery: false,
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("body").text()).to.not.contains(
-          "You can securely change how you get security codes"
-        );
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123456",
+          phoneNumber: PHONE_NUMBER,
+          supportAccountRecovery: false,
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("body").text()).to.not.contains(
+            "You can securely change how you get security codes"
+          );
+        })
+        .expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when code not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "",
-        phoneNumber: PHONE_NUMBER,
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains("Enter the code");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "",
+          phoneNumber: PHONE_NUMBER,
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains("Enter the code");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is less than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "2",
-        phoneNumber: PHONE_NUMBER,
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "2",
+          phoneNumber: PHONE_NUMBER,
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code is greater than 6 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "1234567",
-        phoneNumber: PHONE_NUMBER,
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "1234567",
+          phoneNumber: PHONE_NUMBER,
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when code entered contains letters", async () => {
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "12ert-",
-        phoneNumber: PHONE_NUMBER,
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          "Enter the code using only 6 digits"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "12ert-",
+          phoneNumber: PHONE_NUMBER,
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /auth-code when valid code entered", async () => {
@@ -200,17 +211,19 @@ describe("Integration:: enter mfa", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123456",
-        phoneNumber: PHONE_NUMBER,
-      })
-      .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123456",
+          phoneNumber: PHONE_NUMBER,
+        })
+        .expect("Location", PATH_NAMES.AUTH_CODE)
+        .expect(302)
+    );
   });
 
   it("should return validation error when incorrect code entered", async () => {
@@ -219,22 +232,24 @@ describe("Integration:: enter mfa", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-        phoneNumber: PHONE_NUMBER,
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#code-error").text()).to.contains(
-          " The code you entered is not correct, or may have expired, try entering it again or request a new code"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+          phoneNumber: PHONE_NUMBER,
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            " The code you entered is not correct, or may have expired, try entering it again or request a new code"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to security code expired when incorrect code has been entered 5 times", async () => {
@@ -244,19 +259,21 @@ describe("Integration:: enter mfa", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.MfaMaxRetries}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.MfaMaxRetries}`
+        )
+        .expect(302)
+    );
   });
 
   it("should redirect to security code requests blocked when exceeded request limit", async () => {
@@ -265,19 +282,21 @@ describe("Integration:: enter mfa", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_WAIT}?actionType=${SecurityCodeErrorType.MfaBlocked}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_WAIT}?actionType=${SecurityCodeErrorType.MfaBlocked}`
+        )
+        .expect(302)
+    );
   });
 
   it("should redirect to security code requested too many times when exceed request limit", async () => {
@@ -286,19 +305,21 @@ describe("Integration:: enter mfa", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.MfaMaxCodesSent}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.MfaMaxCodesSent}`
+        )
+        .expect(302)
+    );
   });
 
   it("should lock user if he entered 6 incorrect codes in the reauth journey and the logout switch is turned off", async () => {
@@ -308,18 +329,20 @@ describe("Integration:: enter mfa", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.ENTER_MFA)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        code: "123455",
-      })
-      .expect(
-        "Location",
-        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.MfaMaxRetries}`
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.ENTER_MFA)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "123455",
+        })
+        .expect(
+          "Location",
+          `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.MfaMaxRetries}`
+        )
+        .expect(302)
+    );
   });
 });

--- a/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::enter password should return enter password page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter password should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter password should return validation error when password not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::enter password should return enter password page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter password should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter password should return validation error when password not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -46,13 +45,13 @@ describe("Integration::enter password", () => {
 
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(ENDPOINT)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(app, (test) => test.get(ENDPOINT), {
+      expectTaxonomyMatchSnapshot: false,
+    }).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   after(() => {
@@ -65,69 +64,79 @@ describe("Integration::enter password", () => {
   });
 
   it("should return enter password page", async () => {
-    await request(app).get(ENDPOINT).expect(200);
+    await request(app, (test) => test.get(ENDPOINT).expect(200));
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .send({
-        password: "password",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .send({
+          password: "password",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when password not entered", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains("Enter your password");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter your password"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password is incorrect", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(401);
     process.env.SUPPORT_2HR_LOCKOUT = "0";
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "pasasd",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Enter the correct password"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "pasasd",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter the correct password"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /auth-code when password is correct (VTR Cm)", async () => {
     nock(baseApi).post(API_ENDPOINTS.LOG_IN_USER).once().reply(200);
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password",
-      })
-      .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password",
+        })
+        .expect("Location", PATH_NAMES.AUTH_CODE)
+        .expect(302)
+    );
   });
 
   it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is not required", async () => {
@@ -139,16 +148,18 @@ describe("Integration::enter password", () => {
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password",
-      })
-      .expect("Location", PATH_NAMES.RESET_PASSWORD_REQUIRED)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password",
+        })
+        .expect("Location", PATH_NAMES.RESET_PASSWORD_REQUIRED)
+        .expect(302)
+    );
   });
 
   it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is required", async () => {
@@ -160,16 +171,18 @@ describe("Integration::enter password", () => {
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password",
-      })
-      .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_SMS)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password",
+        })
+        .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_SMS)
+        .expect(302)
+    );
   });
 
   it("should redirect to /account-locked from sign-in flow when incorrect password entered 5 times", async () => {
@@ -177,15 +190,17 @@ describe("Integration::enter password", () => {
       code: ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED,
     });
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password",
-      })
-      .expect("Location", PATH_NAMES.ACCOUNT_LOCKED)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password",
+        })
+        .expect("Location", PATH_NAMES.ACCOUNT_LOCKED)
+        .expect(302)
+    );
   });
 });

--- a/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
+++ b/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::enter phone number should render 2hr lockout "You asked for too many codes" error page when request OTP more than 5 times 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return enter phone number page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter phone number should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when international phone number entered contains text 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when international phone number entered greater than 16 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when international phone number entered is not valid 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when international phone number entered less than 8 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when international phone number not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when uk phone number entered contains text 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when uk phone number entered greater than 12 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when uk phone number entered is not valid 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when uk phone number entered less than 12 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::enter phone number should return validation error when uk phone number not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import cheerio from "cheerio";
 import decache from "decache";
 import { HTTP_STATUS_CODES, PATH_NAMES } from "../../../app.constants";
@@ -39,13 +38,15 @@ describe("Integration::enter phone number", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER),
+      { expectTaxonomyMatchSnapshot: false }
+    ).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -59,109 +60,121 @@ describe("Integration::enter phone number", () => {
   });
 
   it("should return enter phone number page", async () => {
-    await request(app)
-      .get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .send({
-        phoneNumber: "123456789",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .send({
+          phoneNumber: "123456789",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when uk phone number not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK mobile phone number"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#phoneNumber-error").text()).to.contains(
+            "Enter a UK mobile phone number"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when uk phone number entered is not valid", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "123456789",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK mobile phone number"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "123456789",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#phoneNumber-error").text()).to.contains(
+            "Enter a UK mobile phone number"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when uk phone number entered contains text", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "123456789dd",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK mobile phone number using only numbers or the + symbol"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "123456789dd",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#phoneNumber-error").text()).to.contains(
+            "Enter a UK mobile phone number using only numbers or the + symbol"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when uk phone number entered less than 12 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK mobile phone number, like 07700 900000"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#phoneNumber-error").text()).to.contains(
+            "Enter a UK mobile phone number, like 07700 900000"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when uk phone number entered greater than 12 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "123123123123123123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a UK mobile phone number, like 07700 900000"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "123123123123123123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#phoneNumber-error").text()).to.contains(
+            "Enter a UK mobile phone number, like 07700 900000"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /check-your-phone page when valid UK phone number entered", async () => {
@@ -170,116 +183,128 @@ describe("Integration::enter phone number", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "07738394991",
-      })
-      .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "07738394991",
+        })
+        .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
+        .expect(302)
+    );
   });
 
   it("should return validation error when international phone number not entered", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a mobile phone number"
-        );
-        expect($("#phoneNumber-error").text()).to.contains("");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          hasInternationalPhoneNumber: true,
+          internationalPhoneNumber: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#internationalPhoneNumber-error").text()).to.contains(
+            "Enter a mobile phone number"
+          );
+          expect($("#phoneNumber-error").text()).to.contains("");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when international phone number entered is not valid", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "123456789",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a mobile phone number in the correct format, including the country code"
-        );
-        expect($("#phoneNumber-error").text()).to.contains("");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          hasInternationalPhoneNumber: true,
+          internationalPhoneNumber: "123456789",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#internationalPhoneNumber-error").text()).to.contains(
+            "Enter a mobile phone number in the correct format, including the country code"
+          );
+          expect($("#phoneNumber-error").text()).to.contains("");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when international phone number entered contains text", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "123456789dd",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a mobile phone number using only numbers or the + symbol"
-        );
-        expect($("#phoneNumber-error").text()).to.contains("");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          hasInternationalPhoneNumber: true,
+          internationalPhoneNumber: "123456789dd",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#internationalPhoneNumber-error").text()).to.contains(
+            "Enter a mobile phone number using only numbers or the + symbol"
+          );
+          expect($("#phoneNumber-error").text()).to.contains("");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when international phone number entered less than 8 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "1234567",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a mobile phone number in the correct format, including the country code"
-        );
-        expect($("#phoneNumber-error").text()).to.contains("");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          hasInternationalPhoneNumber: true,
+          internationalPhoneNumber: "1234567",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#internationalPhoneNumber-error").text()).to.contains(
+            "Enter a mobile phone number in the correct format, including the country code"
+          );
+          expect($("#phoneNumber-error").text()).to.contains("");
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when international phone number entered greater than 16 characters", async () => {
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "12345678901234567",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a mobile phone number in the correct format, including the country code"
-        );
-        expect($("#phoneNumber-error").text()).to.contains("");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          hasInternationalPhoneNumber: true,
+          internationalPhoneNumber: "12345678901234567",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#internationalPhoneNumber-error").text()).to.contains(
+            "Enter a mobile phone number in the correct format, including the country code"
+          );
+          expect($("#phoneNumber-error").text()).to.contains("");
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /check-your-phone page when valid international phone number entered", async () => {
@@ -288,17 +313,19 @@ describe("Integration::enter phone number", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        hasInternationalPhoneNumber: true,
-        internationalPhoneNumber: "+33645453322",
-      })
-      .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          hasInternationalPhoneNumber: true,
+          internationalPhoneNumber: "+33645453322",
+        })
+        .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
+        .expect(302)
+    );
   });
 
   it('should render 2hr lockout "You asked for too many codes" error page when request OTP more than 5 times', async () => {
@@ -307,23 +334,25 @@ describe("Integration::enter phone number", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "07738394991",
-      })
-      .expect((res) => {
-        res.text.includes(
-          "You asked to resend the security code too many times"
-        );
-      })
-      .expect((res) => {
-        res.text.includes("You will not be able to continue for 2 hours.");
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "07738394991",
+        })
+        .expect((res) => {
+          res.text.includes(
+            "You asked to resend the security code too many times"
+          );
+        })
+        .expect((res) => {
+          res.text.includes("You will not be able to continue for 2 hours.");
+        })
+        .expect(200)
+    );
   });
 
   it('should redirect to SECURITY_CODE_REQUEST_EXCEEDED and render the 2hr lockout "you cannot create" error page when user has exceeded the OTP request limit', async () => {
@@ -332,28 +361,30 @@ describe("Integration::enter phone number", () => {
       success: false,
     });
 
-    await request(app)
-      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        phoneNumber: "07738394991",
-      })
-      .expect((res) => {
-        res.text.includes("You cannot create a GOV.UK One Login");
-      })
-      .expect((res) => {
-        res.text.includes("Wait 2 hours");
-      })
-      .expect(
-        "Location",
-        pathWithQueryParam(
-          PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
-          "actionType",
-          "otpBlocked"
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          phoneNumber: "07738394991",
+        })
+        .expect((res) => {
+          res.text.includes("You cannot create a GOV.UK One Login");
+        })
+        .expect((res) => {
+          res.text.includes("Wait 2 hours");
+        })
+        .expect(
+          "Location",
+          pathWithQueryParam(
+            PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
+            "actionType",
+            "otpBlocked"
+          )
         )
-      )
-      .expect(302);
+        .expect(302)
+    );
   });
 });

--- a/src/components/healthcheck/tests/__snapshots__/healthcheck-integration.test.ts.snap
+++ b/src/components/healthcheck/tests/__snapshots__/healthcheck-integration.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::healthcheck healthcheck should return 200 OK 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { request, sinon } from "../../../../test/utils/test-utils";
 import { PATH_NAMES } from "../../../app.constants";
 import decache from "decache";
 
@@ -22,6 +21,6 @@ describe("Integration::healthcheck", () => {
   });
 
   it("healthcheck should return 200 OK", async () => {
-    await request(app).get(PATH_NAMES.HEALTHCHECK).expect(200);
+    await request(app, (test) => test.get(PATH_NAMES.HEALTHCHECK).expect(200));
   });
 });

--- a/src/components/landing/tests/landing-integration.test.ts
+++ b/src/components/landing/tests/landing-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import decache from "decache";
 import { PATH_NAMES } from "../../../app.constants";
@@ -38,9 +37,11 @@ describe("Integration:: landing", () => {
   });
 
   it("should redirect to /sign-in-or-create", async () => {
-    await request(app)
-      .get(PATH_NAMES.ROOT)
-      .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.ROOT)
+        .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
+        .expect(302)
+    );
   });
 });

--- a/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
+++ b/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::prove identity should redirect when account interventions flags user is blocked 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/prove-identity/tests/prove-identity-integration.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import decache from "decache";
 import {
@@ -47,11 +46,11 @@ describe("Integration::prove identity", () => {
 
     app = await require("../../../app").createApp();
 
-    await request(app)
-      .get(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
-      .then((res) => {
+    await request(app, (test) => test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN)).then(
+      (res) => {
         cookies = res.headers["set-cookie"];
-      });
+      }
+    );
   });
 
   beforeEach(() => {
@@ -116,6 +115,8 @@ describe("Integration::prove identity", () => {
   });
 
   const makeRequestToProveIdentityEndpoint = async () => {
-    return request(app).get(PATH_NAMES.PROVE_IDENTITY).set("Cookie", cookies);
+    return request(app, (test) =>
+      test.get(PATH_NAMES.PROVE_IDENTITY).set("Cookie", cookies)
+    );
   };
 });

--- a/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
+++ b/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: resend email code should redirect to /security-code-requested-too-many-times when exceeded OTP request limit 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend email code should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend email code should return 500 error screen when API call fails 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: resend email code should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend email code should return resend email code page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils";
+import { request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -41,13 +40,13 @@ describe("Integration:: resend email code", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.RESEND_EMAIL_CODE)
-      .then((res) => {
+    await request(app, (test) => test.get(PATH_NAMES.RESEND_EMAIL_CODE)).then(
+      (res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
-      });
+      }
+    );
   });
 
   beforeEach(() => {
@@ -60,17 +59,21 @@ describe("Integration:: resend email code", () => {
   });
 
   it("should return resend email code page", async () => {
-    await request(app).get(PATH_NAMES.RESEND_EMAIL_CODE).expect(200);
+    await request(app, (test) =>
+      test.get(PATH_NAMES.RESEND_EMAIL_CODE).expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.RESEND_EMAIL_CODE)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_EMAIL_CODE)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should redirect to /check-your-email when new code requested as part of account creation journey", async () => {
@@ -79,25 +82,29 @@ describe("Integration:: resend email code", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_EMAIL_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect("Location", PATH_NAMES.CHECK_YOUR_EMAIL)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_EMAIL_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect("Location", PATH_NAMES.CHECK_YOUR_EMAIL)
+        .expect(302)
+    );
   });
 
   it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", async () => {
     const testSpecificCookies = cookies + "; re=true";
-    await request(app)
-      .get(PATH_NAMES.RESEND_EMAIL_CODE)
-      .set("Cookie", testSpecificCookies)
-      .expect((res) => {
-        res.text.includes("You cannot get a new security code at the moment");
-      });
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_EMAIL_CODE)
+        .set("Cookie", testSpecificCookies)
+        .expect((res) => {
+          res.text.includes("You cannot get a new security code at the moment");
+        })
+    );
   });
 
   it("should return 500 error screen when API call fails", async () => {
@@ -105,14 +112,16 @@ describe("Integration:: resend email code", () => {
       errorCode: "1234",
     });
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_EMAIL_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(500);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_EMAIL_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(500)
+    );
   });
 
   it("should redirect to /security-code-invalid-request when request OTP more than 5 times", async () => {
@@ -121,18 +130,20 @@ describe("Integration:: resend email code", () => {
       .times(6)
       .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT });
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_EMAIL_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(
-        "Location",
-        "/security-code-invalid-request?actionType=emailMaxCodesSent"
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_EMAIL_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(
+          "Location",
+          "/security-code-invalid-request?actionType=emailMaxCodesSent"
+        )
+        .expect(302)
+    );
   });
 
   it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", async () => {
@@ -141,17 +152,19 @@ describe("Integration:: resend email code", () => {
       .once()
       .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_CODE_REQUEST_BLOCKED });
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_EMAIL_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(
-        "Location",
-        "/security-code-requested-too-many-times?actionType=emailBlocked"
-      )
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_EMAIL_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(
+          "Location",
+          "/security-code-requested-too-many-times?actionType=emailBlocked"
+        )
+        .expect(302)
+    );
   });
 });

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: resend mfa code should include the last three digits of the user's telephone number 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend mfa code should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend mfa code should return 400 error screen when API call fails 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: resend mfa code should return 500 error screen when API call fails 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration:: resend mfa code should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend mfa code should return resend mfa code page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend mfa code should state reauthenticating user could be logged out 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: resend mfa code should state user could be locked out 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
@@ -47,13 +46,13 @@ describe("Integration:: resend mfa code", () => {
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE)
-      .then((res) => {
+    await request(app, (test) => test.get(PATH_NAMES.RESEND_MFA_CODE)).then(
+      (res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
         cookies = res.headers["set-cookie"];
-      });
+      }
+    );
   });
 
   beforeEach(() => {
@@ -70,56 +69,66 @@ describe("Integration:: resend mfa code", () => {
   });
 
   it("should return resend mfa code page", async () => {
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE)
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("title").text()).to.contain("Get security code");
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_MFA_CODE)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("title").text()).to.contain("Get security code");
+        })
+        .expect(200)
+    );
   });
 
   it("should include the last three digits of the user's telephone number", async () => {
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE)
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($.text()).to.contain(testRedactedPhoneNumber.slice(-3));
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_MFA_CODE)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($.text()).to.contain(testRedactedPhoneNumber.slice(-3));
+        })
+        .expect(200)
+    );
   });
 
   it("should state user could be locked out", async () => {
     process.env.SUPPORT_2HR_LOCKOUT = "1";
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE)
-      .expect((res) => {
-        const $ = cheerio.load(res.text);
-        expect($.text()).to.contain("you will be locked out for 2 hours.");
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_MFA_CODE)
+        .expect((res) => {
+          const $ = cheerio.load(res.text);
+          expect($.text()).to.contain("you will be locked out for 2 hours.");
+        })
+        .expect(200)
+    );
   });
 
   it("should state reauthenticating user could be logged out", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     process.env.SUPPORT_2HR_LOCKOUT = "1";
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE)
-      .expect((res) => {
-        const $ = cheerio.load(res.text);
-        expect($.text()).to.contain("you will be signed out");
-      })
-      .expect(200);
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_MFA_CODE)
+        .expect((res) => {
+          const $ = cheerio.load(res.text);
+          expect($.text()).to.contain("you will be signed out");
+        })
+        .expect(200)
+    );
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .send({
-        code: "123456",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .send({
+          code: "123456",
+        })
+        .expect(403)
+    );
   });
 
   it("should redirect to /enter-code when new code requested as part of sign in journey", async () => {
@@ -128,15 +137,17 @@ describe("Integration:: resend mfa code", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect("Location", PATH_NAMES.ENTER_MFA)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect("Location", PATH_NAMES.ENTER_MFA)
+        .expect(302)
+    );
   });
 
   it("should redirect to /check-your-phone when new code requested as part of account creation journey", async () => {
@@ -145,26 +156,30 @@ describe("Integration:: resend mfa code", () => {
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT);
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        isResendCodeRequest: true,
-      })
-      .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          isResendCodeRequest: true,
+        })
+        .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
+        .expect(302)
+    );
   });
 
   it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", async () => {
     const testSpecificCookies = cookies + "; re=true";
-    await request(app)
-      .get(PATH_NAMES.RESEND_MFA_CODE)
-      .set("Cookie", testSpecificCookies)
-      .expect((res) => {
-        res.text.includes("You cannot get a new security code at the moment");
-      });
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_MFA_CODE)
+        .set("Cookie", testSpecificCookies)
+        .expect((res) => {
+          res.text.includes("You cannot get a new security code at the moment");
+        })
+    );
   });
 
   it("should return 500 error screen when API call fails", async () => {
@@ -172,14 +187,16 @@ describe("Integration:: resend mfa code", () => {
       errorCode: "1234",
     });
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(500);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(500)
+    );
   });
 
   it("should return 400 error screen when API call fails", async () => {
@@ -187,14 +204,16 @@ describe("Integration:: resend mfa code", () => {
       errorCode: "1015",
     });
 
-    await request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(500);
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(500)
+    );
   });
 
   it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", async () => {
@@ -205,18 +224,20 @@ describe("Integration:: resend mfa code", () => {
       .times(6)
       .reply(400, { code: ERROR_CODES.MFA_SMS_MAX_CODES_SENT });
 
-    request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(
-        "Location",
-        "/security-code-requested-too-many-times?actionType=mfaMaxCodesSent"
-      )
-      .expect(302);
+    request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(
+          "Location",
+          "/security-code-requested-too-many-times?actionType=mfaMaxCodesSent"
+        )
+        .expect(302)
+    );
   });
 
   it("should redirect to /security-code-invalid-request when exceeded OTP request limit", async () => {
@@ -227,17 +248,19 @@ describe("Integration:: resend mfa code", () => {
       .once()
       .reply(400, { code: ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED });
 
-    request(app)
-      .post(PATH_NAMES.RESEND_MFA_CODE)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-      })
-      .expect(
-        "Location",
-        "/security-code-invalid-request?actionType=mfaBlocked"
-      )
-      .expect(302);
+    request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESEND_MFA_CODE)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+        })
+        .expect(
+          "Location",
+          "/security-code-invalid-request?actionType=mfaBlocked"
+        )
+        .expect(302)
+    );
   });
 });

--- a/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::2fa auth app (in reset password flow) should return updated check auth app page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::2fa sms (in reset password flow) should render index-security-code-entered-exceeded.njk when user is locked out due to too many incorrect codes 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::2fa sms (in reset password flow) should return check your phone page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::reset password check email  should return reset password check email page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::reset password check email  should redisplay page with error 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::reset password check email  should return 2hr error page when 6 incorrect codes entered and flag is turned on 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::reset password check email  should return error page when 6 password reset codes requested 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::reset password check email  should return error page when blocked from requesting codes 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::reset password check email  should return internal server error when /reset-password-request API call response is 500 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::reset password check email  should return reset password check email page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::reset password (in 6 digit code flow) should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return error when new password is the same as existing password 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return reset password page when someone has a reset password intervention 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return reset password page when there are no interventions on a user 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return validation error when no numbers present in password 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return validation error when password all numeric 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return validation error when password is amongst most common passwords 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return validation error when password less than 8 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return validation error when password not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password (in 6 digit code flow) should return validation error when passwords don't match 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::reset password required should redirect to /auth-code when valid password entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return error when new password is the same as existing password 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return reset password page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return validation error when no numbers present in password 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return validation error when password all numeric 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return validation error when password is amongst most common passwords 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return validation error when password less than 8 characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return validation error when password not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::reset password required should return validation error when passwords don't match 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import { PATH_NAMES } from "../../../app.constants";
@@ -43,13 +42,13 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL;
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    await request(app)
-      .get(ENDPOINT)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(app, (test) => test.get(ENDPOINT), {
+      expectTaxonomyMatchSnapshot: false,
+    }).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -65,7 +64,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
   it("should return reset password page when there are no interventions on a user", (done) => {
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    request(app).get(ENDPOINT).expect(200, done);
+    request(app, (test) => test.get(ENDPOINT).expect(200, done));
   });
 
   it("should return the blocked screen when someone has a blocked intervention", (done) => {
@@ -76,12 +75,14 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       reproveIdentity: false,
     });
 
-    request(app)
-      .get(ENDPOINT)
-      .expect(function (res) {
-        expect(res.headers.location).to.eq("/unavailable-permanent");
-      })
-      .expect(302, done);
+    request(app, (test) =>
+      test
+        .get(ENDPOINT)
+        .expect(function (res) {
+          expect(res.headers.location).to.eq("/unavailable-permanent");
+        })
+        .expect(302, done)
+    );
   });
 
   it("should return the suspended screen when someone has a suspended intervention", (done) => {
@@ -92,12 +93,14 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       reproveIdentity: false,
     });
 
-    request(app)
-      .get(ENDPOINT)
-      .expect(function (res) {
-        expect(res.headers.location).to.eq("/unavailable-temporary");
-      })
-      .expect(302, done);
+    request(app, (test) =>
+      test
+        .get(ENDPOINT)
+        .expect(function (res) {
+          expect(res.headers.location).to.eq("/unavailable-temporary");
+        })
+        .expect(302, done)
+    );
   });
 
   it("should return reset password page when someone has a reset password intervention", (done) => {
@@ -108,152 +111,170 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       reproveIdentity: false,
     });
 
-    request(app).get(ENDPOINT).expect(200, done);
+    request(app, (test) => test.get(ENDPOINT).expect(200, done));
   });
 
   it("should return error when csrf not present", (done) => {
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .send({
-        password: "password",
-      })
-      .expect(403, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .send({
+          password: "password",
+        })
+        .expect(403, done)
+    );
   });
 
   it("should return validation error when password not entered", (done) => {
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "",
-        "confirm-password": "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains("Enter your password");
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "",
+          "confirm-password": "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter your password"
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should return validation error when passwords don't match", (done) => {
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "sadsadasd33da",
-        "confirm-password": "sdnnsad99d",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#confirm-password-error").text()).to.contains(
-          "Enter the same password in both fields"
-        );
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "sadsadasd33da",
+          "confirm-password": "sdnnsad99d",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#confirm-password-error").text()).to.contains(
+            "Enter the same password in both fields"
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should return validation error when password less than 8 characters", (done) => {
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "dad",
-        "confirm-password": "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "dad",
+          "confirm-password": "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should return validation error when password is amongst most common passwords", (done) => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1040 });
 
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password123",
-        "confirm-password": "password123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
-        );
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password123",
+          "confirm-password": "password123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should return error when new password is the same as existing password", (done) => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1024 });
 
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "p@ssw0rd-123",
-        "confirm-password": "p@ssw0rd-123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "You are already using that password. Enter a different password"
-        );
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "p@ssw0rd-123",
+          "confirm-password": "p@ssw0rd-123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "You are already using that password. Enter a different password"
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should return validation error when no numbers present in password", (done) => {
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "testpassword",
-        "confirm-password": "testpassword",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "testpassword",
+          "confirm-password": "testpassword",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should return validation error when password all numeric", (done) => {
-    request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "222222222222222",
-        "confirm-password": "222222222222222",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400, done);
+    request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "222222222222222",
+          "confirm-password": "222222222222222",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400, done)
+    );
   });
 
   it("should redirect to /auth-code when valid password entered", async () => {
@@ -261,16 +282,18 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
     nock(baseApi).post("/login").once().reply(200);
     nock(baseApi).post("/mfa").once().reply(204);
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "Testpassword1",
-        "confirm-password": "Testpassword1",
-      })
-      .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "Testpassword1",
+          "confirm-password": "Testpassword1",
+        })
+        .expect("Location", PATH_NAMES.AUTH_CODE)
+        .expect(302)
+    );
   });
 });

--- a/src/components/reset-password/tests/reset-password-required-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-required-integration.test.ts
@@ -1,6 +1,5 @@
-import request from "supertest";
 import { describe } from "mocha";
-import { expect, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../app.constants";
@@ -44,13 +43,13 @@ describe("Integration::reset password required", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL;
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    await request(app)
-      .get(ENDPOINT)
-      .then((res) => {
-        const $ = cheerio.load(res.text);
-        token = $("[name=_csrf]").val();
-        cookies = res.headers["set-cookie"];
-      });
+    await request(app, (test) => test.get(ENDPOINT), {
+      expectTaxonomyMatchSnapshot: false,
+    }).then((res) => {
+      const $ = cheerio.load(res.text);
+      token = $("[name=_csrf]").val();
+      cookies = res.headers["set-cookie"];
+    });
   });
 
   beforeEach(() => {
@@ -65,152 +64,170 @@ describe("Integration::reset password required", () => {
   it("should return reset password page", async () => {
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
-    await request(app).get(ENDPOINT).expect(200);
+    await request(app, (test) => test.get(ENDPOINT).expect(200));
   });
 
   it("should return error when csrf not present", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .send({
-        password: "password",
-      })
-      .expect(403);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .send({
+          password: "password",
+        })
+        .expect(403)
+    );
   });
 
   it("should return validation error when password not entered", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "",
-        "confirm-password": "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains("Enter your password");
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "",
+          "confirm-password": "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter your password"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when passwords don't match", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "sadsadasd33da",
-        "confirm-password": "sdnnsad99d",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#confirm-password-error").text()).to.contains(
-          "Enter the same password in both fields"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "sadsadasd33da",
+          "confirm-password": "sdnnsad99d",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#confirm-password-error").text()).to.contains(
+            "Enter the same password in both fields"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password less than 8 characters", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "dad",
-        "confirm-password": "",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "dad",
+          "confirm-password": "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password is amongst most common passwords", async () => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1040 });
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "password123",
-        "confirm-password": "password123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "password123",
+          "confirm-password": "password123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers."
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return error when new password is the same as existing password", async () => {
     nock(baseApi).post("/reset-password").once().reply(400, { code: 1024 });
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "p@ssw0rd-123",
-        "confirm-password": "p@ssw0rd-123",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "You are already using that password. Enter a different password"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "p@ssw0rd-123",
+          "confirm-password": "p@ssw0rd-123",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "You are already using that password. Enter a different password"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when no numbers present in password", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "testpassword",
-        "confirm-password": "testpassword",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "testpassword",
+          "confirm-password": "testpassword",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should return validation error when password all numeric", async () => {
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "222222222222222",
-        "confirm-password": "222222222222222",
-      })
-      .expect(function (res) {
-        const $ = cheerio.load(res.text);
-        expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include letters and numbers"
-        );
-      })
-      .expect(400);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "222222222222222",
+          "confirm-password": "222222222222222",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#password-error").text()).to.contains(
+            "Your password must be at least 8 characters long and must include letters and numbers"
+          );
+        })
+        .expect(400)
+    );
   });
 
   it("should redirect to /auth-code when valid password entered", async () => {
@@ -218,16 +235,18 @@ describe("Integration::reset password required", () => {
     nock(baseApi).post("/login").once().reply(200);
     nock(baseApi).post("/mfa").once().reply(204);
 
-    await request(app)
-      .post(ENDPOINT)
-      .type("form")
-      .set("Cookie", cookies)
-      .send({
-        _csrf: token,
-        password: "Testpassword1",
-        "confirm-password": "Testpassword1",
-      })
-      .expect("Location", PATH_NAMES.AUTH_CODE)
-      .expect(302);
+    await request(app, (test) =>
+      test
+        .post(ENDPOINT)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          password: "Testpassword1",
+          "confirm-password": "Testpassword1",
+        })
+        .expect("Location", PATH_NAMES.AUTH_CODE)
+        .expect(302)
+    );
   });
 });

--- a/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
+++ b/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::select-mfa-options should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::select-mfa-options should return get security codes page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::select-mfa-options should return validation error when mfa option not selected 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
+++ b/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration::setup-authenticator-app should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::setup-authenticator-app should return setup authenticator app page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration::setup-authenticator-app should return validation error when access code is too long (more than 6 digits) 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::setup-authenticator-app should return validation error when access code not entered 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;
+
+exports[`Integration::setup-authenticator-app should return validation error when code has non-digit characters 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/src/components/updated-terms-conditions/tests/__snapshots__/updated-terms-conditions-integration.test.ts.snap
+++ b/src/components/updated-terms-conditions/tests/__snapshots__/updated-terms-conditions-integration.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: updated-terms-code should return error when csrf not present 1`] = `
+Object {
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+}
+`;
+
+exports[`Integration:: updated-terms-code should return update terms and conditions page 1`] = `
+Object {
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+}
+`;

--- a/test/helpers/expect-taxonomy-helpers.ts
+++ b/test/helpers/expect-taxonomy-helpers.ts
@@ -1,0 +1,11 @@
+import request from "supertest";
+import { expect } from "../utils/test-utils";
+
+export function expectTaxonomyMatchSnapshot(res: request.Response): void {
+  if (res.statusCode < 300 || res.statusCode >= 400) {
+    expect({
+      taxonomyLevel1: res.text.match(/taxonomy_level1: '(\w*)'/)?.[1],
+      taxonomyLevel2: res.text.match(/taxonomy_level2: '(\w*)'/)?.[1],
+    }).toMatchSnapshot();
+  }
+}

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -2,11 +2,29 @@ import chai from "chai";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 import chaiAsPromised from "chai-as-promised";
+import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
+import supertest from "supertest";
+import { expectTaxonomyMatchSnapshot } from "../helpers/expect-taxonomy-helpers";
 
 chai.should();
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
+chai.use(jestSnapshotPlugin());
 
 const expect = chai.expect;
 
-export { expect, sinon };
+const request = (
+  app: any,
+  callback: (test: supertest.SuperTest<supertest.Test>) => supertest.Test,
+  options: {
+    expectTaxonomyMatchSnapshot?: boolean;
+  } = {}
+): supertest.Test => {
+  let test = callback(supertest(app));
+  if (options.expectTaxonomyMatchSnapshot !== false) {
+    test = test.expect(expectTaxonomyMatchSnapshot);
+  }
+  return test;
+};
+
+export { expect, sinon, request };

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,7 +502,7 @@
     "@smithy/types" "^3.4.2"
     tslib "^2.6.2"
 
-"@babel/code-frame@^7.24.7":
+"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.24.7.tgz#882fd9e09e8ee324e496bd040401c6f046ef4465"
   integrity sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==
@@ -515,7 +515,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.25.4.tgz#7d2a80ce229890edcf4cc259d4d696cb4dae2fcb"
   integrity sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==
 
-"@babel/core@^7.23.9":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.23.9":
   version "7.25.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.25.2.tgz#ed8eec275118d7613e77a352894cd12ded8eba77"
   integrity sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==
@@ -536,7 +536,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.25.0", "@babel/generator@^7.25.6":
+"@babel/generator@^7.25.0", "@babel/generator@^7.25.6", "@babel/generator@^7.7.2":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.25.6.tgz#0df1ad8cb32fe4d2b01d8bf437f153d19342a87c"
   integrity sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==
@@ -574,6 +574,11 @@
     "@babel/helper-simple-access" "^7.24.7"
     "@babel/helper-validator-identifier" "^7.24.7"
     "@babel/traverse" "^7.25.2"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.24.7", "@babel/helper-plugin-utils@^7.24.8", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.24.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz#94ee67e8ec0e5d44ea7baeb51e571bd26af07878"
+  integrity sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==
 
 "@babel/helper-simple-access@^7.24.7":
   version "7.24.7"
@@ -616,12 +621,131 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.23.9", "@babel/parser@^7.25.0", "@babel/parser@^7.25.6":
+"@babel/parser@^7.14.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.0", "@babel/parser@^7.25.6":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.25.6.tgz#85660c5ef388cbbf6e3d2a694ee97a38f18afe2f"
   integrity sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==
   dependencies:
     "@babel/types" "^7.25.6"
+
+"@babel/plugin-syntax-async-generators@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
+  integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-bigint@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-class-properties@^7.12.13":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
+  integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-class-static-block@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz#195df89b146b4b78b3bf897fd7a257c84659d406"
+  integrity sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-import-attributes@^7.24.7":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz#6d4c78f042db0e82fd6436cd65fec5dc78ad2bde"
+  integrity sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.24.8"
+
+"@babel/plugin-syntax-import-meta@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz#ee601348c370fa334d2207be158777496521fd51"
+  integrity sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-json-strings@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
+  integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-jsx@^7.7.2":
+  version "7.24.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz#39a1fa4a7e3d3d7f34e2acc6be585b718d30e02d"
+  integrity sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.24.7"
+
+"@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
+  integrity sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-numeric-separator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz#b9b070b3e33570cd9fd07ba7fa91c0dd37b9af97"
+  integrity sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-object-rest-spread@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
+  integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-catch-binding@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
+  integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
+  integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-private-property-in-object@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad"
+  integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-top-level-await@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c"
+  integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.7.2":
+  version "7.25.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz#04db9ce5a9043d9c635e75ae7969a2cd50ca97ff"
+  integrity sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.24.8"
 
 "@babel/runtime@^7.12.0":
   version "7.16.3"
@@ -659,7 +783,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.24.7", "@babel/types@^7.25.0", "@babel/types@^7.25.2", "@babel/types@^7.25.6":
+"@babel/types@^7.24.7", "@babel/types@^7.25.0", "@babel/types@^7.25.2", "@babel/types@^7.25.6", "@babel/types@^7.3.3":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.25.6.tgz#893942ddb858f32ae7a004ec9d3a76b3463ef8e6"
   integrity sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==
@@ -789,6 +913,75 @@
   resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
+"@jest/console@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-29.7.0.tgz#cd4822dbdb84529265c5a2bdb529a3c9cc950ffc"
+  integrity sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    slash "^3.0.0"
+
+"@jest/expect-utils@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.7.0.tgz#023efe5d26a8a70f21677d0a1afc0f0a44e3a1c6"
+  integrity sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==
+  dependencies:
+    jest-get-type "^29.6.3"
+
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
+"@jest/test-result@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-29.7.0.tgz#8db9a80aa1a097bb2262572686734baed9b1657c"
+  integrity sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==
+  dependencies:
+    "@jest/console" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    collect-v8-coverage "^1.0.0"
+
+"@jest/transform@^29.7.0":
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.7.0.tgz#df2dd9c346c7d7768b8a06639994640c642e284c"
+  integrity sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@jest/types" "^29.6.3"
+    "@jridgewell/trace-mapping" "^0.3.18"
+    babel-plugin-istanbul "^6.1.1"
+    chalk "^4.0.0"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.9"
+    jest-haste-map "^29.7.0"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    micromatch "^4.0.4"
+    pirates "^4.0.4"
+    slash "^3.0.0"
+    write-file-atomic "^4.0.2"
+
+"@jest/types@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
+  integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
@@ -831,7 +1024,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -950,6 +1143,11 @@
   version "1.0.5"
   resolved "https://registry.npmjs.org/@redis/time-series/-/time-series-1.0.5.tgz"
   integrity sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==
+
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
 "@sindresorhus/merge-streams@^2.1.0":
   version "2.3.0"
@@ -1536,12 +1734,38 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/graceful-fs@^4.1.3":
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
+  integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/i18next-fs-backend@^1.1.1":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@types/i18next-fs-backend/-/i18next-fs-backend-1.1.5.tgz#39dae6057f4386f6eaacc36e69346d3783834ada"
   integrity sha512-QKKYWkfQ13spBwa+5/lBThkPkMv8svU6a5Z0Bz96IuN+HupJZXVAbP93p5bK7iOcY7Y/g/W9Y6qy5z0i0NpTog==
   dependencies:
     i18next "^21.0.1"
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz#53047614ae72e19fc0401d872de3ae2b4ce350bf"
+  integrity sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
+  integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -1690,6 +1914,11 @@
     "@types/node" "*"
     "@types/ssh2-streams" "*"
 
+"@types/stack-utils@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
+  integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
+
 "@types/superagent@*":
   version "4.1.13"
   resolved "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.13.tgz"
@@ -1704,6 +1933,18 @@
   integrity sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==
   dependencies:
     "@types/superagent" "*"
+
+"@types/yargs-parser@*":
+  version "21.0.3"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
+  integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^17.0.8":
+  version "17.0.33"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.33.tgz#8c32303da83eec050a84b3c7ae7b9f922d13e32d"
+  integrity sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^7.1.0":
   version "7.18.0"
@@ -1921,12 +2162,17 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
-anymatch@~3.1.2:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -2049,6 +2295,38 @@ b4a@^1.6.4:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.6.tgz#a4cc349a3851987c3c4ac2d7785c18744f6da9ba"
   integrity sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==
+
+babel-plugin-istanbul@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz#fa88ec59232fd9b4e36dbbc540a8ec9a9b47da73"
+  integrity sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-instrument "^5.0.4"
+    test-exclude "^6.0.0"
+
+babel-preset-current-node-syntax@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz#9a929eafece419612ef4ae4f60b1862ebad8ef30"
+  integrity sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==
+  dependencies:
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.12.13"
+    "@babel/plugin-syntax-class-static-block" "^7.14.5"
+    "@babel/plugin-syntax-import-attributes" "^7.24.7"
+    "@babel/plugin-syntax-import-meta" "^7.10.4"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.10.4"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+    "@babel/plugin-syntax-top-level-await" "^7.14.5"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2184,6 +2462,13 @@ browserslist@^4.23.1:
     electron-to-chromium "^1.5.4"
     node-releases "^2.0.18"
     update-browserslist-db "^1.1.0"
+
+bser@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
+  integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
+  dependencies:
+    node-int64 "^0.4.0"
 
 buffer-crc32@^1.0.0:
   version "1.0.0"
@@ -2380,6 +2665,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz"
@@ -2423,6 +2713,11 @@ cluster-key-slot@1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz"
   integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
+collect-v8-coverage@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz#c0b29bcd33bcd0779a1344c2136051e6afd3d9e9"
+  integrity sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -2803,6 +3098,11 @@ dezalgo@^1.0.4:
     asap "^2.0.0"
     wrappy "1"
 
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
@@ -2996,6 +3296,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escape-string-regexp@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
@@ -3129,6 +3434,17 @@ events@^3.3.0:
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
+expect@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
+  integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
+  dependencies:
+    "@jest/expect-utils" "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+
 express-session@^1.17.2:
   version "1.17.2"
   resolved "https://registry.npmjs.org/express-session/-/express-session-1.17.2.tgz"
@@ -3219,7 +3535,7 @@ fast-glob@^3.2.9, fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3252,6 +3568,13 @@ fastq@^1.6.0:
   integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
   dependencies:
     reusify "^1.0.4"
+
+fb-watchman@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"
+  integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
+  dependencies:
+    bser "2.1.1"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -3288,6 +3611,11 @@ find-cache-dir@^3.2.0:
     commondir "^1.0.1"
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
+
+find-package-json@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/find-package-json/-/find-package-json-1.2.0.tgz#4057d1b943f82d8445fe52dc9cf456f6b8b58083"
+  integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -3391,6 +3719,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 fsevents@~2.3.2:
   version "2.3.2"
@@ -3564,7 +3897,7 @@ graceful-fs@^4.1.15:
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3905,6 +4238,17 @@ istanbul-lib-hook@^3.0.0:
   dependencies:
     append-transform "^2.0.0"
 
+istanbul-lib-instrument@^5.0.4:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz#d10c8885c2125574e1c231cacadf955675e1ce3d"
+  integrity sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==
+  dependencies:
+    "@babel/core" "^7.12.3"
+    "@babel/parser" "^7.14.7"
+    "@istanbuljs/schema" "^0.1.2"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^6.3.0"
+
 istanbul-lib-instrument@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
@@ -3963,6 +4307,118 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
+
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
+jest-haste-map@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.7.0.tgz#3c2396524482f5a0506376e6c858c3bbcc17b104"
+  integrity sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.6.3"
+    jest-util "^29.7.0"
+    jest-worker "^29.7.0"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
+jest-matcher-utils@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz#ae8fec79ff249fd592ce80e3ee474e83a6c44f12"
+  integrity sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-message-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
+  integrity sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==
+  dependencies:
+    "@babel/code-frame" "^7.12.13"
+    "@jest/types" "^29.6.3"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.9"
+    micromatch "^4.0.4"
+    pretty-format "^29.7.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.3"
+
+jest-regex-util@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
+  integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
+
+jest-snapshot@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"
+  integrity sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==
+  dependencies:
+    "@babel/core" "^7.11.6"
+    "@babel/generator" "^7.7.2"
+    "@babel/plugin-syntax-jsx" "^7.7.2"
+    "@babel/plugin-syntax-typescript" "^7.7.2"
+    "@babel/types" "^7.3.3"
+    "@jest/expect-utils" "^29.7.0"
+    "@jest/transform" "^29.7.0"
+    "@jest/types" "^29.6.3"
+    babel-preset-current-node-syntax "^1.0.0"
+    chalk "^4.0.0"
+    expect "^29.7.0"
+    graceful-fs "^4.2.9"
+    jest-diff "^29.7.0"
+    jest-get-type "^29.6.3"
+    jest-matcher-utils "^29.7.0"
+    jest-message-util "^29.7.0"
+    jest-util "^29.7.0"
+    natural-compare "^1.4.0"
+    pretty-format "^29.7.0"
+    semver "^7.5.3"
+
+jest-util@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
+  integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
+  dependencies:
+    "@jest/types" "^29.6.3"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
+jest-worker@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
+  integrity sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.7.0"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
 
 jose@^5.6.2:
   version "5.8.0"
@@ -4158,6 +4614,13 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+makeerror@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.12.tgz#3e5dd2079a82e812e983cc6610c4a2cb0eaa801a"
+  integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
+  dependencies:
+    tmpl "1.0.5"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
@@ -4167,6 +4630,11 @@ merge-descriptors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
   integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
+
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -4249,6 +4717,19 @@ mkdirp@^1.0.4:
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+mocha-chai-jest-snapshot@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/mocha-chai-jest-snapshot/-/mocha-chai-jest-snapshot-1.1.6.tgz#cba844aeec6e19ef830992eb71817745c75e2e09"
+  integrity sha512-DSPZ5PtY1Rome58XSeS2/mggDJ60BIXDMlh58wsdkGfm1VvqTjjpFkjmR3g1iCtFAtPDXDmR9mYck1MygUEArA==
+  dependencies:
+    "@jest/test-result" "^29.7.0"
+    chalk "^4.1.2"
+    find-package-json "^1.2.0"
+    jest-snapshot "^29.7.0"
+    jest-util "^29.7.0"
+    slash "^3.0.0"
+    yargs "^17.7.2"
+
 mocha@10.7.3:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.3.tgz#ae32003cabbd52b59aece17846056a68eb4b0752"
@@ -4324,6 +4805,11 @@ nock@^13.5.1:
     debug "^4.1.0"
     json-stringify-safe "^5.0.1"
     propagate "^2.0.0"
+
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
+  integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
 node-preload@^0.2.1:
   version "0.2.1"
@@ -4617,7 +5103,7 @@ picocolors@^1.0.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
   integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -4707,6 +5193,11 @@ pino@^8.20.0:
     sonic-boom "^3.7.0"
     thread-stream "^2.6.0"
 
+pirates@^4.0.4:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
+  integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
+
 pkg-dir@^4.1.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz"
@@ -4735,6 +5226,15 @@ prettier@^3.2.5:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -4882,6 +5382,11 @@ raw-body@2.5.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readable-stream@^2.0.5, readable-stream@~2.3.6:
   version "2.3.8"
@@ -5101,7 +5606,7 @@ secure-json-parse@^2.4.0:
   resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.4.0.tgz"
   integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==
 
-semver@^6.0.0, semver@^6.3.1:
+semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -5212,6 +5717,11 @@ signal-exit@^3.0.2:
   version "3.0.6"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+
+signal-exit@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 signal-exit@^4.0.1:
   version "4.1.0"
@@ -5333,6 +5843,13 @@ ssh2@^1.11.0, ssh2@^1.4.0:
   optionalDependencies:
     cpu-features "~0.0.9"
     nan "^2.18.0"
+
+stack-utils@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
+  integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 statuses@2.0.1:
   version "2.0.1"
@@ -5482,7 +5999,7 @@ supports-color@^7, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.1.1:
+supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -5616,6 +6133,11 @@ tmp@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
   integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
+
+tmpl@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
+  integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
 to-data-view@^1.1.0:
   version "1.1.0"
@@ -5878,6 +6400,13 @@ w3c-xmlserializer@^4.0.0:
   dependencies:
     xml-name-validator "^4.0.0"
 
+walker@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
+  integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
+  dependencies:
+    makeerror "1.0.12"
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz"
@@ -5970,6 +6499,14 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+write-file-atomic@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
+  integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.7"
 
 ws@^8.13.0:
   version "8.17.1"


### PR DESCRIPTION
## What
Work will soon be done that introduces more variation of taxonomies based on the URI, template and user session. We currently have very limited testing of existing taxonomies.

We should introduce some baseline testing of what currently exists as the upcoming work will require some refactoring.

This establishes snapshot testing of the rendered HTML on all existing integration tests that make a simulated HTTP request to the server. All pages are checked for taxonomies set and are recorded in `.snap` files.

These files are then compared in integration tests and errors thrown when they no longer match.

The implementation here adds a wrapper around the `supertest` function to run a new `expectTaxonomyMatchSnapshot` test at the end the existing expectations (this can be disabled per test).

The benefit of this means all new integration tests using the new wrapper function will automatically get taxonomy snapshot testing.

Perhaps we can remove or reduce this level of snapshot testing in time as we understand more and centralise the logic of computing taxonomies.

## How to review

1. Code Review, commit by commit and whitespace changes hidden.
