### PR TITLE
AUT-3760: Broaden taxonomy match regex

### DIFF
--- a/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -17,6 +17,6 @@ Object {
 exports[`Integration:: resend SMS mfa code (account creation variant) should return resend mfa code page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/authorize/tests/__snapshots__/authorize-integration.test.ts.snap
+++ b/src/components/authorize/tests/__snapshots__/authorize-integration.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Integration:: authorize should redirect to /sign-in-or-create with Google Analytics tag if 'result' query exists 1`] = `
 Object {
   "taxonomyLevel1": "accounts",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
+++ b/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration:: check your email should return error page when when incorrect code entered more than 5 times 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
@@ -52,6 +52,6 @@ Object {
 exports[`Integration:: check your email should return verify email page 1`] = `
 Object {
   "taxonomyLevel1": "accounts",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
+++ b/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration:: check your phone should render the "you requested too many codes" pages when incorrect code has requested more than 5 times 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
@@ -17,7 +17,7 @@ Object {
 exports[`Integration:: check your phone should return check your phone page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
@@ -31,34 +31,34 @@ Object {
 exports[`Integration:: check your phone should return validation error when code entered contains letters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration:: check your phone should return validation error when code is greater than 6 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration:: check your phone should return validation error when code is less than 6 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration:: check your phone should return validation error when code not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration:: check your phone should return validation error when incorrect code entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
+++ b/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration::register create password should return create password page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
@@ -17,41 +17,41 @@ Object {
 exports[`Integration::register create password should return validation error when no numbers present in password 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration::register create password should return validation error when password all numeric 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration::register create password should return validation error when password is amongst most common passwords 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration::register create password should return validation error when password less than 8 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration::register create password should return validation error when password not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
 exports[`Integration::register create password should return validation error when passwords don't match 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Integration:: enter authenticator app code following a validation error it should not include link to change security codes where account recovery is not permitted 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter authenticator app code should return enter authenticator app security code 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
@@ -24,34 +24,34 @@ Object {
 exports[`Integration:: enter authenticator app code should return validation error when code entered contains letters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter authenticator app code should return validation error when code is greater than 6 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter authenticator app code should return validation error when code is less than 6 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter authenticator app code should return validation error when code not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter authenticator app code should return validation error when incorrect code entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration::enter email should return enter email page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Integration:: enter mfa following a validation error it should not include link to change security codes where account recovery is not permitted 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter mfa should return check your phone page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
@@ -24,34 +24,34 @@ Object {
 exports[`Integration:: enter mfa should return validation error when code entered contains letters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter mfa should return validation error when code is greater than 6 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter mfa should return validation error when code is less than 6 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter mfa should return validation error when code not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: enter mfa should return validation error when incorrect code entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;

--- a/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration::enter password should return enter password page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
@@ -17,13 +17,13 @@ Object {
 exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration::enter password should return validation error when password not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration::enter password should return enter password page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
@@ -17,13 +17,13 @@ Object {
 exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration::enter password should return validation error when password not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;

--- a/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
+++ b/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
@@ -10,7 +10,7 @@ Object {
 exports[`Integration::enter phone number should return enter phone number page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 

--- a/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
+++ b/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Integration::prove identity should redirect when account interventions flags user is blocked 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
+++ b/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Integration:: resend email code should redirect to /security-code-requested-too-many-times when exceeded OTP request limit 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: resend email code should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
@@ -31,6 +31,6 @@ Object {
 exports[`Integration:: resend email code should return resend email code page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`Integration:: resend mfa code should include the last three digits of the user's telephone number 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: resend mfa code should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
@@ -38,20 +38,20 @@ Object {
 exports[`Integration:: resend mfa code should return resend mfa code page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: resend mfa code should state reauthenticating user could be logged out 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;
 
 exports[`Integration:: resend mfa code should state user could be locked out 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "sign in",
 }
 `;

--- a/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Integration::2fa auth app (in reset password flow) should return updated check auth app page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
@@ -3,6 +3,6 @@
 exports[`Integration::reset password check email  should return reset password check email page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
@@ -38,6 +38,6 @@ Object {
 exports[`Integration::reset password check email  should return reset password check email page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;

--- a/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
@@ -10,62 +10,62 @@ Object {
 exports[`Integration::reset password (in 6 digit code flow) should return error when new password is the same as existing password 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return reset password page when someone has a reset password intervention 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return reset password page when there are no interventions on a user 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when no numbers present in password 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password all numeric 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password is amongst most common passwords 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password less than 8 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when passwords don't match 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;

--- a/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Integration::reset password required should redirect to /auth-code when valid password entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 
@@ -17,55 +17,55 @@ Object {
 exports[`Integration::reset password required should return error when new password is the same as existing password 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return reset password page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return validation error when no numbers present in password 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return validation error when password all numeric 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return validation error when password is amongst most common passwords 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return validation error when password less than 8 characters 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return validation error when password not entered 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;
 
 exports[`Integration::reset password required should return validation error when passwords don't match 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "account recovery",
 }
 `;

--- a/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
+++ b/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
@@ -10,7 +10,7 @@ Object {
 exports[`Integration::select-mfa-options should return get security codes page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 

--- a/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
+++ b/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
@@ -10,7 +10,7 @@ Object {
 exports[`Integration::setup-authenticator-app should return setup authenticator app page 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": undefined,
+  "taxonomyLevel2": "create account",
 }
 `;
 

--- a/test/helpers/expect-taxonomy-helpers.ts
+++ b/test/helpers/expect-taxonomy-helpers.ts
@@ -4,8 +4,8 @@ import { expect } from "../utils/test-utils";
 export function expectTaxonomyMatchSnapshot(res: request.Response): void {
   if (res.statusCode < 300 || res.statusCode >= 400) {
     expect({
-      taxonomyLevel1: res.text.match(/taxonomy_level1: '(\w*)'/)?.[1],
-      taxonomyLevel2: res.text.match(/taxonomy_level2: '(\w*)'/)?.[1],
+      taxonomyLevel1: res.text.match(/taxonomy_level1: '([\w\d\s]*)'/)?.[1],
+      taxonomyLevel2: res.text.match(/taxonomy_level2: '([\w\d\s]*)'/)?.[1],
     }).toMatchSnapshot();
   }
 }


### PR DESCRIPTION
## What

fe8dba081ad1f14a6eabb1b81a2559c1132a3fd7 introduced a regex that finds GA4 taxonomy levels values in our integration test generated HTML.

This was too restrictive and missed out values with spaces in them. So this adds `\s` as an expected regex character class inside the quotes. Also add `\d` to capture digits for good measure.

<!-- Describe what you have changed and why -->

## How to review

1. Code Review
  - The important change is in `test/helpers/expect-taxonomy-helpers.ts`. 
  - The rest of the commit fixes the snapshots.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2121
