### PR TITLE
AUT-3772 - auth encryption key policy allows cross account decrypt permission

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -41,6 +41,7 @@ cloudfront_auth_dns_enabled      = true
 
 alb_idle_timeout = 30
 
+new_auth_account_id               = 975050272416
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENB3csRUIdoaTHNn079Jl7JpiXzxF\n0p2ZIddCErxtIhGMTTqtbQZJCPesSKUVE/DQbpIko3mLoisuFgmQfFouCw==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -46,6 +46,7 @@ cloudfront_auth_dns_enabled      = true
 
 alb_idle_timeout = 30
 
+new_auth_account_id               = 975050272416
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUm\nBhnWynwAkE/YZlskX+N7VmwIjupla7O6hczlIOqkmPdQ1ayDqI8yY2QOiw==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -31,6 +31,7 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
+new_auth_account_id               = 058264536367
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr\nCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/dev.tfvars
+++ b/ci/terraform/dev.tfvars
@@ -33,6 +33,7 @@ no_photo_id_contact_forms                           = "1"
 
 logging_endpoint_arns = []
 
+new_auth_account_id               = 975050272416
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHzG8IFx1jE1+Ul44jQk96efPknCX\nVxWS4PqLrKfR/31UQovFQLfyxA46uiMOvr7+0hRwFX1fQhagsIK+dfB5PA==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/kms.tf
+++ b/ci/terraform/kms.tf
@@ -7,6 +7,59 @@ resource "aws_kms_key" "authentication_encryption_key" {
   tags = local.default_tags
 }
 
+resource "aws_kms_key_policy" "authentication_encryption_key_access_policy" {
+  key_id = aws_kms_key.authentication_encryption_key.id
+  policy = data.aws_iam_policy_document.authentication_encryption_key_access_policy_document.json
+}
+
+data "aws_iam_policy_document" "authentication_encryption_key_access_policy_document" {
+  #checkov:skip=CKV_AWS_109:Root requires all kms:* actions access
+  #checkov:skip=CKV_AWS_111:Root requires all kms:* actions access
+  #checkov:skip=CKV_AWS_356:Policy cannot self-reference the kms key, so resources wildcard is required
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    actions = [
+      "kms:*"
+    ]
+    principals {
+      type = "AWS"
+      identifiers = [
+        format(
+          "arn:%s:iam::%s:root",
+          data.aws_partition.current.partition,
+          data.aws_caller_identity.current.account_id
+        )
+      ]
+    }
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.new_auth_account_id == "" ? [] : [1]
+
+    content {
+      sid    = "AllowAccessToAuthenticationKmsEncryptionKey"
+      effect = "Allow"
+
+      actions = [
+        "kms:Decrypt*"
+      ]
+      principals {
+        type = "AWS"
+        identifiers = [
+          format(
+            "arn:%s:iam::%s:root",
+            data.aws_partition.current.partition,
+            var.new_auth_account_id
+          )
+        ]
+      }
+      resources = ["*"]
+    }
+  }
+}
+
 resource "aws_kms_alias" "authentication_encryption_key_alias" {
   name          = "alias/${var.environment}-authentication-encryption-key-alias"
   target_key_id = aws_kms_key.authentication_encryption_key.key_id

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -37,6 +37,7 @@ logging_endpoint_arns = [
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
+new_auth_account_id               = 851725205974
 new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+\nKKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg==\n-----END PUBLIC KEY-----"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -190,6 +190,11 @@ variable "basic_auth_bypass_cidr_blocks" {
   description = "The list of CIDR blocks allowed to bypass basic auth (if enabled)"
 }
 
+variable "new_auth_account_id" {
+  description = "New Auth account id for equivalent environment"
+  default     = ""
+}
+
 variable "new_auth_protectedsub_cidr_blocks" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
## What

The auth encryption key policy allows cross account decrypt permission.
- Default implict kms key policy is overwritten with an explicit policy, with identical permission for root account
- dynamic statement to add another statement to give `kms:Decrypt*` to new_auth_account_id root

<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
