### PR TITLE
Ato 975/send current credential strength claim to backed

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -68,6 +68,7 @@ export function authorizeGet(
       req,
       {
         authenticated: claims.authenticated,
+        current_credential_strength: claims.current_credential_strength,
         previous_session_id: claims.previous_session_id,
         previous_govuk_signin_journey_id:
           claims.previous_govuk_signin_journey_id,

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -56,6 +56,9 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
 
   body["authenticated"] = startRequestParameters.authenticated;
 
+  if (startRequestParameters.current_credential_strength !== undefined)
+    body["current-credential-strength"] =
+      startRequestParameters.current_credential_strength;
   if (startRequestParameters.previous_session_id !== undefined)
     body["previous-session-id"] = startRequestParameters.previous_session_id;
   if (

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -48,6 +48,7 @@ export type Claims = {
   previous_govuk_signin_journey_id: string;
   channel?: string;
   authenticated: boolean;
+  current_credential_strength?: string;
 };
 
 export const requiredClaimsKeys = [

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -25,6 +25,7 @@ describe("authorize service", () => {
     headers: requestHeadersWithIpAndAuditEncoded,
   });
   const isAuthenticated = false;
+  const currentCredentialStrength = "MEDIUM_LEVEL";
 
   beforeEach(() => {
     setupApiKeyAndBaseUrlEnvVars();
@@ -107,6 +108,7 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
+      current_credential_strength: undefined,
       reauthenticate: undefined,
       previous_session_id: previousSessionId,
     });
@@ -132,6 +134,7 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
+      current_credential_strength: undefined,
       reauthenticate: "123456",
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
@@ -149,6 +152,34 @@ describe("authorize service", () => {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,
             Reauthenticate: true,
+          },
+          proxy: false,
+        }
+      )
+    ).to.be.true;
+  });
+
+  it("sends a request with the current credential strength in the body when present", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      current_credential_strength: currentCredentialStrength,
+      reauthenticate: undefined,
+      previous_session_id: undefined,
+      previous_govuk_signin_journey_id: "previous-journey-id",
+    });
+
+    expect(
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {
+          "current-credential-strength": currentCredentialStrength,
+          "previous-govuk-signin-journey-id": "previous-journey-id",
+          authenticated: isAuthenticated,
+        },
+        {
+          headers: {
+            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
           },
           proxy: false,
         }

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -30,6 +30,7 @@ export function createMockClaims(): Claims {
     claim:
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
     authenticated: false,
+    current_credential_strength: "MEDIUM_LEVEL",
   };
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -4,6 +4,7 @@ import { Request } from "express";
 
 export interface StartRequestParameters {
   authenticated: boolean;
+  current_credential_strength?: string;
   previous_session_id?: string;
   rp_pairwise_id_for_reauth?: string;
   previous_govuk_signin_journey_id?: string;


### PR DESCRIPTION
##What

Take the `currentCredentialStrength` from the authorise request and pass it on to the start handler so it can be set in the auth session. The `currentCredentialStrength` might not exist in the authorise request and therefore wont pass the field through to the start handler. 