### PR TITLE
AUT-3546: Removed DesiredCount from the ECS service definition

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -254,7 +254,6 @@ Resources:
     Properties:
       Cluster: !Ref FrontendECSCluster
       LaunchType: FARGATE
-      DesiredCount: 2
       HealthCheckGracePeriodSeconds: 15
       DeploymentConfiguration: !If
         - UseECSCanaryDeploymentStack


### PR DESCRIPTION
## What

Removed DesiredCount from the ECS service definition

Based on recommendation https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3410329629/ECS+AutoScaling+Services

Issue: [AUT-3546]

<!-- Describe what you have changed and why -->

## How to review

Run perf tests in staging, and concurrently run a deployment

[AUT-3546]: https://govukverify.atlassian.net/browse/AUT-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ