### PR TITLE
AUT-3544 Integration env cross-account redis sg group rules and auth kms share

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -35,6 +35,9 @@ logging_endpoint_arns = [
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
+new_auth_account_id               = "211125600642"
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
+
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7\nppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.integration.account.gov.uk/"


### PR DESCRIPTION
## What

Integration env cross-account redis sg group rules and auth kms share
Issue: [AUT-3544]

## How to review

Env specific change for integration. Similar changes applied to lower envs recently, for [AUT-3768] and [AUT-3772]


[AUT-3544]: https://govukverify.atlassian.net/browse/AUT-3544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-3768]: https://govukverify.atlassian.net/browse/AUT-3768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-3772]: https://govukverify.atlassian.net/browse/AUT-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ