### PR TITLE
AUT-3760: Add reauth taxonomies and contentIds

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -78,10 +78,27 @@ export const PATH_NAMES = {
 export const CONTENT_IDS: {
   [path: string]: ContentIdVariants;
 } = {
+  [PATH_NAMES.ENTER_EMAIL_SIGN_IN]: {
+    default: "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
+    reauth: "aff1628e-177d-4afc-825b-56e926b2fc1f",
+  },
+  [PATH_NAMES.ENTER_PASSWORD]: {
+    default: "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
+    reauth: "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
+  },
   [PATH_NAMES.ENTER_MFA]: {
     default: "19601dd7-be55-4ab6-aa44-a6358c4239dc",
     reauth: "c9f09429-b29d-421e-a33a-41149489a0a2",
     upliftRequired: "",
+  },
+  [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE]: {
+    default: "89461417-df3f-46a8-9c37-713b9dd78085",
+    reauth: "6e5cc49f-4770-4089-8547-06149e0f59b1",
+    upliftRequired: "",
+  },
+  [PATH_NAMES.RESEND_MFA_CODE]: {
+    default: "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
+    reauth: "a2776ef7-9ef3-4d8d-bdbc-3f798b15e5d4",
   },
 };
 

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -1,3 +1,5 @@
+import { ContentIdVariants } from "./types";
+
 export enum MFA_METHOD_TYPE {
   SMS = "SMS",
   AUTH_APP = "AUTH_APP",
@@ -71,6 +73,15 @@ export const PATH_NAMES = {
   UNAVAILABLE_PERMANENT: "/unavailable-permanent",
   UNAVAILABLE_TEMPORARY: "/unavailable-temporary",
   RESET_PASSWORD_2FA_AUTH_APP: "/reset-password-2fa-auth-app",
+};
+
+export const CONTENT_IDS: {
+  [path: string]: ContentIdVariants;
+} = {
+  [PATH_NAMES.ENTER_MFA]: {
+    default: "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+    upliftRequired: "",
+  },
 };
 
 export const HREF_BACK = {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -80,6 +80,7 @@ export const CONTENT_IDS: {
 } = {
   [PATH_NAMES.ENTER_MFA]: {
     default: "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+    reauth: "c9f09429-b29d-421e-a33a-41149489a0a2",
     upliftRequired: "",
   },
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -97,7 +97,7 @@ import { channelMiddleware } from "./middleware/channel-middleware";
 import { applyOverloadProtection } from "./middleware/overload-protection-middleware";
 import { frontendVitalSignsInit } from "@govuk-one-login/frontend-vital-signs";
 import { Server } from "node:http";
-import { getRequestTaxonomyMiddleware } from "./middleware/get-request-taxonomy-middleware";
+import { getAnalyticsPropertiesMiddleware } from "./middleware/get-analytics-properties-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -223,7 +223,7 @@ async function createApp(): Promise<express.Application> {
   if (getLanguageToggleEnabled()) {
     app.use(setCurrentUrlMiddleware);
   }
-  app.use(getRequestTaxonomyMiddleware);
+  app.use(getAnalyticsPropertiesMiddleware);
 
   registerRoutes(app);
 

--- a/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: resend SMS mfa code (account creation variant) should return 500 error screen when API call fails 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: resend SMS mfa code (account creation variant) should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: resend SMS mfa code (account creation variant) should return resend mfa code page 1`] = `
 Object {
+  "contentId": "8247477c-3e33-4dae-9528-22e7ed44efb3",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -42,7 +42,7 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/account-recovery/check-your-email-security-codes/tests/__snapshots__/check-your-email-security-codes-integration.test.ts.snap
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/__snapshots__/check-your-email-security-codes-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: check your email security codes should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: check your email security codes should return validation error when code entered contains letters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: check your email security codes should return validation error when code is greater than 6 characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: check your email security codes should return validation error when code is less than 6 characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: check your email security codes should return validation error when code not entered 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: check your email security codes should return validation error when incorrect code entered 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: check your email security codes should return verify email page 1`] = `
 Object {
+  "contentId": "e768e27b-1c4d-48ba-8bcf-4c40274a6441",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/check-your-email-security-codes-integration.test.ts
@@ -96,7 +96,7 @@ describe("Integration:: check your email security codes", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
+++ b/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: check your email should return error page when incorrect code entered more than 5 times 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: check your email should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: check your email should return validation error when code entered contains letters 1`] = `
 Object {
+  "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: check your email should return validation error when code is greater than 6 characters 1`] = `
 Object {
+  "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: check your email should return validation error when code is less than 6 characters 1`] = `
 Object {
+  "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: check your email should return validation error when code not entered 1`] = `
 Object {
+  "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: check your email should return validation error when incorrect code entered 1`] = `
 Object {
+  "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration:: check your email should return verify email page 1`] = `
 Object {
+  "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -41,7 +41,7 @@ describe("Integration:: check your email", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     await request(app, (test) => test.get(PATH_NAMES.CHECK_YOUR_EMAIL), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
+++ b/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: check your phone should render the "you requested too many codes" pages when incorrect code has requested more than 5 times 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: check your phone should render the "you requested too many codes" pages when incorrect code has requested more than 5 times 2`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: check your phone should return check your phone page 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: check your phone should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: check your phone should return validation error when code entered contains letters 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: check your phone should return validation error when code is greater than 6 characters 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: check your phone should return validation error when code is less than 6 characters 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration:: check your phone should return validation error when code not entered 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration:: check your phone should return validation error when incorrect code entered 1`] = `
 Object {
+  "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/common/cookies/tests/cookies-controller-integration.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller-integration.test.ts
@@ -73,7 +73,7 @@ describe("Integration:: cookies controller", () => {
       app = await require("../../../../app").createApp();
 
       await request(app, (test) => test.get(PATH_NAMES.COOKIES_POLICY), {
-        expectTaxonomyMatchSnapshot: false,
+        expectAnalyticsPropertiesMatchSnapshot: false,
       }).then((res) => {
         const $ = cheerio.load(res.text);
         token = $("[name=_csrf]").val();
@@ -83,7 +83,7 @@ describe("Integration:: cookies controller", () => {
 
     it("successfully makes a call to update the cookie policy", async () => {
       await request(app, (test) => test.post(PATH_NAMES.COOKIES_POLICY), {
-        expectTaxonomyMatchSnapshot: false,
+        expectAnalyticsPropertiesMatchSnapshot: false,
       })
         .type("form")
         .set("Cookie", cookies)

--- a/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
+++ b/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: contact us - public user should return contact us further information account creation page 1`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us further information signing in page 1`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page 1`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page including valid referer url 1`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page including valid referer url 2`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page including valid referer url 3`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page including valid referer url 4`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page including valid referer url 5`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page including valid referer url 6`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -65,6 +74,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 1`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -72,6 +82,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 2`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -79,6 +90,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 3`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -86,6 +98,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us page removing invalid referer url 4`] = `
 Object {
+  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -93,6 +106,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 1`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -100,6 +114,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 2`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -107,6 +122,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 3`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -114,6 +130,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 4`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -121,6 +138,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 5`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -128,6 +146,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page including valid referer queryparam url 6`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -135,6 +154,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page removing invalid referer queryparam url 1`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -142,6 +162,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page removing invalid referer queryparam url 2`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -149,6 +170,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page removing invalid referer queryparam url 3`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -156,6 +178,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page with a theme and a subtheme 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -163,6 +186,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return contact us questions page with only a theme 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -170,6 +194,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -177,6 +202,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when issue description are not entered on the contact-us-questions page 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -184,6 +210,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when no radio boxes are selected on the proving_identity contact-us-further-information page 1`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -191,6 +218,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when no radio boxes are selected on the signing in contact-us-further-information page 1`] = `
 Object {
+  "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -198,6 +226,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when user has not selected how the security code was sent whilst creating an account 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -205,6 +234,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when user selected Text message to a phone number from another country and left the Which country field empty 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -212,6 +242,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when user selected yes to contact for feedback and left email field empty 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -219,6 +250,7 @@ Object {
 
 exports[`Integration:: contact us - public user should return validation error when user selected yes to contact for feedback but email is in an invalid format 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -226,6 +258,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem taking a photo of your identity document using the GOV.UK ID Check app should return validation error when user has not selected which identity document they were using 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -233,6 +266,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem with their bank or building society details should return validation error when user has not selected which problem they had 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -240,6 +274,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem with their identity document should return validation error when user has not selected which identity document they were using 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -247,6 +282,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem with their national insurance number should return validation error when user has not described which problem they had 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -254,6 +290,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem with their phone number when creating an account should return validation error when user has not entered country the phone number is from 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -261,6 +298,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem with their phone number when creating an account should return validation error when user has not entered what happened 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }
@@ -268,6 +306,7 @@ Object {
 
 exports[`Integration:: contact us - public user when a user had a problem with their phone number when creating an account should return validation error when user has not entered what they were trying to do 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
 }

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -32,7 +32,7 @@ describe("Integration:: contact us - public user", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.CONTACT_US).query("supportType=PUBLIC"),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
+++ b/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::register create password should return create password page 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::register create password should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::register create password should return validation error when no numbers present in password 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::register create password should return validation error when password all numeric 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::register create password should return validation error when password is amongst most common passwords 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::register create password should return validation error when password less than 8 characters 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration::register create password should return validation error when password not entered 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration::register create password should return validation error when passwords don't match 1`] = `
 Object {
+  "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -41,7 +41,7 @@ describe("Integration::register create password", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -68,6 +68,6 @@
         }) }}
     {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -54,5 +54,5 @@
     }) }}
   {% endif %}
 
-  {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "89461417-df3f-46a8-9c37-713b9dd78085", loggedInStatus: false, dynamic: false })}}
+  {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 {% endblock %}

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -7,7 +7,14 @@ Object {
 }
 `;
 
-exports[`Integration:: enter authenticator app code should return enter authenticator app security code 1`] = `
+exports[`Integration:: enter authenticator app code should return enter authenticator app security code with reauth taxonomy 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
+}
+`;
+
+exports[`Integration:: enter authenticator app code should return enter authenticator app security code with sign in taxonomy 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -10,7 +10,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return enter authenticator app security code with reauth analytics properties 1`] = `
 Object {
-  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
+  "contentId": "6e5cc49f-4770-4089-8547-06149e0f59b1",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: enter authenticator app code following a validation error it should not include link to change security codes where account recovery is not permitted 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return enter authenticator app security code with reauth taxonomy 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return enter authenticator app security code with sign in taxonomy 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return validation error when code entered contains letters 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return validation error when code is greater than 6 characters 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return validation error when code is less than 6 characters 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return validation error when code not entered 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration:: enter authenticator app code should return validation error when incorrect code entered 1`] = `
 Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -8,7 +8,7 @@ Object {
 }
 `;
 
-exports[`Integration:: enter authenticator app code should return enter authenticator app security code with reauth taxonomy 1`] = `
+exports[`Integration:: enter authenticator app code should return enter authenticator app security code with reauth analytics properties 1`] = `
 Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "accounts",
@@ -16,7 +16,7 @@ Object {
 }
 `;
 
-exports[`Integration:: enter authenticator app code should return enter authenticator app security code with sign in taxonomy 1`] = `
+exports[`Integration:: enter authenticator app code should return enter authenticator app security code with sign in analytics properties 1`] = `
 Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -46,6 +46,10 @@ describe("Integration:: enter authenticator app code", () => {
             nextPath: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
           },
         };
+
+        if (process.env.TEST_SETUP_REAUTH_SESSION === "1") {
+          req.session.user.reauthenticate = "reauth";
+        }
         next();
       });
 
@@ -81,6 +85,8 @@ describe("Integration:: enter authenticator app code", () => {
   });
 
   beforeEach(() => {
+    process.env.SUPPORT_REAUTHENTICATION = "0";
+    process.env.TEST_SETUP_REAUTH_SESSION = "0";
     nock.cleanAll();
   });
 
@@ -89,7 +95,16 @@ describe("Integration:: enter authenticator app code", () => {
     app = undefined;
   });
 
-  it("should return enter authenticator app security code", async () => {
+  it("should return enter authenticator app security code with sign in taxonomy", async () => {
+    await request(app, (test) =>
+      test.get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE).expect(200)
+    );
+  });
+
+  it("should return enter authenticator app security code with reauth taxonomy", async () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    process.env.TEST_SETUP_REAUTH_SESSION = "1";
+
     await request(app, (test) =>
       test.get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE).expect(200)
     );

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -95,13 +95,13 @@ describe("Integration:: enter authenticator app code", () => {
     app = undefined;
   });
 
-  it("should return enter authenticator app security code with sign in taxonomy", async () => {
+  it("should return enter authenticator app security code with sign in analytics properties", async () => {
     await request(app, (test) =>
       test.get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE).expect(200)
     );
   });
 
-  it("should return enter authenticator app security code with reauth taxonomy", async () => {
+  it("should return enter authenticator app security code with reauth analytics properties", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     process.env.TEST_SETUP_REAUTH_SESSION = "1";
 

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -76,7 +76,7 @@ describe("Integration:: enter authenticator app code", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -40,5 +40,5 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "d8767bcf-ffb8-4b43-8bda-24c6291590bb", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 {% endblock %}

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -44,6 +44,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/enter-email/tests/__snapshots__/enter-email-create-account-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-create-account-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::enter email (create account) should redirect to /security-code-invalid-request when request OTP more than 5 times 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return enter email page 1`] = `
 Object {
+  "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return internal server error when /user-exists API call response is 500 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return validation error when email not entered 1`] = `
 Object {
+  "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return validation error when invalid email entered 1`] = `
 Object {
+  "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return validation error when invalid email entered 2`] = `
 Object {
+  "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration::enter email (create account) should return validation error when invalid email entered 3`] = `
 Object {
+  "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -1,6 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter email should return enter email page 1`] = `
+exports[`Integration::enter email should return enter email page with reauth taxonomy 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
+}
+`;
+
+exports[`Integration::enter email should return enter email page with sign in taxonomy 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::enter email should return enter email page with reauth taxonomy 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::enter email should return enter email page with sign in taxonomy 1`] = `
 Object {
+  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::enter email should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::enter email should return internal server error when /user-exists API call response is 500 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::enter email should return validation error when email not entered 1`] = `
 Object {
+  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::enter email should return validation error when invalid email entered 1`] = `
 Object {
+  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration::enter email should return validation error when invalid email entered 2`] = `
 Object {
+  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration::enter email should return validation error when invalid email entered 3`] = `
 Object {
+  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration::enter email should return enter email page with reauth analytics properties 1`] = `
 Object {
-  "contentId": "",
+  "contentId": "aff1628e-177d-4afc-825b-56e926b2fc1f",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter email should return enter email page with reauth taxonomy 1`] = `
+exports[`Integration::enter email should return enter email page with reauth analytics properties 1`] = `
 Object {
   "contentId": "",
   "taxonomyLevel1": "accounts",
@@ -8,7 +8,7 @@ Object {
 }
 `;
 
-exports[`Integration::enter email should return enter email page with sign in taxonomy 1`] = `
+exports[`Integration::enter email should return enter email page with sign in analytics properties 1`] = `
 Object {
   "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",

--- a/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
@@ -41,7 +41,7 @@ describe("Integration::enter email (create account)", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -75,17 +75,17 @@ describe("Integration::enter email", () => {
     app = undefined;
   });
 
-  it("should return enter email page with sign in analytics properties", (done) => {
-    request(app, (test) =>
-      test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done)
+  it("should return enter email page with sign in analytics properties", async () => {
+    await request(app, (test) =>
+      test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200)
     );
   });
 
-  it("should return enter email page with reauth analytics properties", (done) => {
+  it("should return enter email page with reauth analytics properties", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     process.env.TEST_SETUP_REAUTH_SESSION = "1";
-    request(app, (test) =>
-      test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done)
+    await request(app, (test) =>
+      test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200)
     );
   });
 

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -50,7 +50,7 @@ describe("Integration::enter email", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     await request(app, (test) => test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -75,13 +75,13 @@ describe("Integration::enter email", () => {
     app = undefined;
   });
 
-  it("should return enter email page with sign in taxonomy", (done) => {
+  it("should return enter email page with sign in analytics properties", (done) => {
     request(app, (test) =>
       test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done)
     );
   });
 
-  it("should return enter email page with reauth taxonomy", (done) => {
+  it("should return enter email page with reauth analytics properties", (done) => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     process.env.TEST_SETUP_REAUTH_SESSION = "1";
     request(app, (test) =>

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -33,8 +33,11 @@ describe("Integration::enter email", () => {
             nextPath: PATH_NAMES.ENTER_EMAIL_SIGN_IN,
             optionalPaths: [PATH_NAMES.SIGN_IN_OR_CREATE],
           },
-          reauthenticate: "12345",
         };
+
+        if (process.env.TEST_SETUP_REAUTH_SESSION === "1") {
+          req.session.user.reauthenticate = "12345";
+        }
 
         req.session.client = {
           redirectUri: REDIRECT_URI,
@@ -58,6 +61,8 @@ describe("Integration::enter email", () => {
   beforeEach(() => {
     nock.cleanAll();
     sinon.restore(); // Restore all stubs before each test
+    process.env.SUPPORT_REAUTHENTICATION = "0";
+    process.env.TEST_SETUP_REAUTH_SESSION = "0";
   });
 
   afterEach(() => {
@@ -70,7 +75,15 @@ describe("Integration::enter email", () => {
     app = undefined;
   });
 
-  it("should return enter email page", (done) => {
+  it("should return enter email page with sign in taxonomy", (done) => {
+    request(app, (test) =>
+      test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done)
+    );
+  });
+
+  it("should return enter email page with reauth taxonomy", (done) => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+    process.env.TEST_SETUP_REAUTH_SESSION = "1";
     request(app, (test) =>
       test.get(PATH_NAMES.ENTER_EMAIL_SIGN_IN).expect(200, done)
     );
@@ -236,6 +249,7 @@ describe("Integration::enter email", () => {
 
   it("should redirect to /enter-password page when email address exists and check re-auth users api call is successfully", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
+    process.env.TEST_SETUP_REAUTH_SESSION = "1";
 
     nock(baseApi)
       .post(API_ENDPOINTS.CHECK_REAUTH_USER)
@@ -266,6 +280,7 @@ describe("Integration::enter email", () => {
 
   it("should redirect to /signed-out with login_required error when user fails re-auth", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
+    process.env.TEST_SETUP_REAUTH_SESSION = "1";
 
     nock(baseApi)
       .post(API_ENDPOINTS.CHECK_REAUTH_USER)

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -72,6 +72,6 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -72,5 +72,5 @@
 
   </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "19601dd7-be55-4ab6-aa44-a6358c4239dc", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 {% endblock %}

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: enter mfa following a validation error it should not include link to change security codes where account recovery is not permitted 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: enter mfa should return check your phone page with sign in taxonomy 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: enter mfa should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: enter mfa should return validation error when code entered contains letters 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: enter mfa should return validation error when code is greater than 6 characters 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: enter mfa should return validation error when code is less than 6 characters 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: enter mfa should return validation error when code not entered 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration:: enter mfa should return validation error when incorrect code entered 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -8,7 +8,7 @@ Object {
 }
 `;
 
-exports[`Integration:: enter mfa should return check your phone page with sign in taxonomy 1`] = `
+exports[`Integration:: enter mfa should return check your phone page with sign in analytics properties 1`] = `
 Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -7,7 +7,7 @@ Object {
 }
 `;
 
-exports[`Integration:: enter mfa should return check your phone page 1`] = `
+exports[`Integration:: enter mfa should return check your phone page with sign in taxonomy 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration:: enter mfa should return check your phone page with reauth taxonomy 1`] = `
 Object {
-  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+  "contentId": "c9f09429-b29d-421e-a33a-41149489a0a2",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration:: enter mfa should return check your phone page with reauth taxonomy 1`] = `
+exports[`Integration:: enter mfa should return check your phone page with reauth analytics properties 1`] = `
 Object {
   "contentId": "c9f09429-b29d-421e-a33a-41149489a0a2",
   "taxonomyLevel1": "accounts",

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: enter mfa should return check your phone page with reauth taxonomy 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
+}
+`;

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: enter mfa should return check your phone page with reauth taxonomy 1`] = `
 Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -85,7 +85,7 @@ describe("Integration:: enter mfa", () => {
     app = undefined;
   });
 
-  it("should return check your phone page", async () => {
+  it("should return check your phone page with sign in taxonomy", async () => {
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA).expect(200));
   });
 

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -85,7 +85,7 @@ describe("Integration:: enter mfa", () => {
     app = undefined;
   });
 
-  it("should return check your phone page with sign in taxonomy", async () => {
+  it("should return check your phone page with sign in analytics properties", async () => {
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA).expect(200));
   });
 

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -67,7 +67,7 @@ describe("Integration:: enter mfa", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL || "";
 
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
@@ -69,6 +69,7 @@ describe("Integration:: enter mfa", () => {
 
     app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL || "";
+    process.env.SUPPORT_REAUTHENTICATION = "1";
 
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA), {
       expectTaxonomyMatchSnapshot: false,
@@ -89,9 +90,11 @@ describe("Integration:: enter mfa", () => {
     app = undefined;
   });
 
-  it("should redirect to rp if user entered 6 incorrect codes in the reauth journey", async () => {
-    process.env.SUPPORT_REAUTHENTICATION = "1";
+  it("should return check your phone page with reauth taxonomy", async () => {
+    await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA).expect(200));
+  });
 
+  it("should redirect to rp if user entered 6 incorrect codes in the reauth journey", async () => {
     nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).times(6).reply(400, {
       code: ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES,
       success: false,

--- a/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
@@ -72,7 +72,7 @@ describe("Integration:: enter mfa", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
 
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
@@ -90,7 +90,7 @@ describe("Integration:: enter mfa", () => {
     app = undefined;
   });
 
-  it("should return check your phone page with reauth taxonomy", async () => {
+  it("should return check your phone page with reauth analytics properties", async () => {
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA).expect(200));
   });
 

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -45,7 +45,7 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2", loggedInStatus: false, dynamic: true })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
 {% endblock %}
 
 {% block scripts %}

--- a/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter password should return enter password page with sign in taxonomy 1`] = `
+exports[`Integration::enter password should return enter password page with sign in analytics properties 1`] = `
 Object {
   "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",

--- a/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::enter password should return enter password page with sign in taxonomy 1`] = `
 Object {
+  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::enter password should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
 Object {
+  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::enter password should return validation error when password not entered 1`] = `
 Object {
+  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }

--- a/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter password should return enter password page 1`] = `
+exports[`Integration::enter password should return enter password page with sign in taxonomy 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::enter password should return enter password page with reauth taxonomy 1`] = `
 Object {
+  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::enter password should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
 Object {
+  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::enter password should return validation error when password not entered 1`] = `
 Object {
+  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration::enter password should return enter password page with reauth analytics properties 1`] = `
 Object {
-  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
+  "contentId": "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -18,7 +18,7 @@ Object {
 
 exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
 Object {
-  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
+  "contentId": "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -26,7 +26,7 @@ Object {
 
 exports[`Integration::enter password should return validation error when password not entered 1`] = `
 Object {
-  "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
+  "contentId": "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter password should return enter password page with reauth taxonomy 1`] = `
+exports[`Integration::enter password should return enter password page with reauth analytics properties 1`] = `
 Object {
   "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "accounts",

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter password should return enter password page 1`] = `
+exports[`Integration::enter password should return enter password page with reauth taxonomy 1`] = `
 Object {
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "sign in",
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
 }
 `;
 
@@ -16,14 +16,14 @@ Object {
 
 exports[`Integration::enter password should return validation error when password is incorrect 1`] = `
 Object {
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "sign in",
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
 }
 `;
 
 exports[`Integration::enter password should return validation error when password not entered 1`] = `
 Object {
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "sign in",
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
 }
 `;

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -63,7 +63,7 @@ describe("Integration::enter password", () => {
     nock.cleanAll();
   });
 
-  it("should return enter password page", async () => {
+  it("should return enter password page with sign in taxonomy", async () => {
     await request(app, (test) => test.get(ENDPOINT).expect(200));
   });
 

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -63,7 +63,7 @@ describe("Integration::enter password", () => {
     nock.cleanAll();
   });
 
-  it("should return enter password page with sign in taxonomy", async () => {
+  it("should return enter password page with sign in analytics properties", async () => {
     await request(app, (test) => test.get(ENDPOINT).expect(200));
   });
 

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -46,7 +46,7 @@ describe("Integration::enter password", () => {
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     await request(app, (test) => test.get(ENDPOINT), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -46,6 +46,7 @@ describe("Integration::enter password", () => {
     app = await require("../../../app").createApp();
 
     baseApi = process.env.FRONTEND_API_BASE_URL;
+    process.env.SUPPORT_REAUTHENTICATION = "1";
 
     await request(app, (test) => test.get(ENDPOINT), {
       expectTaxonomyMatchSnapshot: false,
@@ -65,7 +66,7 @@ describe("Integration::enter password", () => {
     nock.cleanAll();
   });
 
-  it("should return enter password page", async () => {
+  it("should return enter password page with reauth taxonomy", async () => {
     await request(app, (test) => test.get(ENDPOINT).expect(200));
   });
 

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -49,7 +49,7 @@ describe("Integration::enter password", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
 
     await request(app, (test) => test.get(ENDPOINT), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -66,7 +66,7 @@ describe("Integration::enter password", () => {
     nock.cleanAll();
   });
 
-  it("should return enter password page with reauth taxonomy", async () => {
+  it("should return enter password page with reauth analytics properties", async () => {
     await request(app, (test) => test.get(ENDPOINT).expect(200));
   });
 

--- a/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
+++ b/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::enter phone number should render 2hr lockout "You asked for too many codes" error page when request OTP more than 5 times 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::enter phone number should return enter phone number page 1`] = `
 Object {
+  "contentId": "0f519eb6-5cd4-476f-968f-d847b3c4c034",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::enter phone number should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when international phone number entered contains text 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when international phone number entered greater than 16 characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when international phone number entered is not valid 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when international phone number entered less than 8 characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when international phone number not entered 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when uk phone number entered contains text 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -65,6 +74,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when uk phone number entered greater than 12 characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -72,6 +82,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when uk phone number entered is not valid 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -79,6 +90,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when uk phone number entered less than 12 characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -86,6 +98,7 @@ Object {
 
 exports[`Integration::enter phone number should return validation error when uk phone number not entered 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -39,7 +39,7 @@ describe("Integration::enter phone number", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/healthcheck/tests/__snapshots__/healthcheck-integration.test.ts.snap
+++ b/src/components/healthcheck/tests/__snapshots__/healthcheck-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::healthcheck healthcheck should return 200 OK 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }

--- a/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
+++ b/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::prove identity should redirect when account interventions flags user is blocked 1`] = `
 Object {
+  "contentId": "3104ec55-1a4e-4811-b927-0531fb315480",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
+++ b/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: resend email code should redirect to /security-code-requested-too-many-times when exceeded OTP request limit 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: resend email code should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active 1`] = `
 Object {
+  "contentId": "3104ec55-1a4e-4811-b927-0531fb315480",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: resend email code should return 500 error screen when API call fails 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: resend email code should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: resend email code should return resend email code page 1`] = `
 Object {
+  "contentId": "3104ec55-1a4e-4811-b927-0531fb315480",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -39,5 +39,5 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200",englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "f463a280-31f1-43c0-a2f5-6b46b1e2bb15", loggedInStatus: false, dynamic: false })}}
+{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200",englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 {% endblock %}

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -35,7 +35,14 @@ Object {
 }
 `;
 
-exports[`Integration:: resend mfa code should return resend mfa code page 1`] = `
+exports[`Integration:: resend mfa code should return resend mfa code page with reauth taxonomy 1`] = `
+Object {
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
+}
+`;
+
+exports[`Integration:: resend mfa code should return resend mfa code page with sign in taxonomy 1`] = `
 Object {
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
@@ -44,8 +51,8 @@ Object {
 
 exports[`Integration:: resend mfa code should state reauthenticating user could be logged out 1`] = `
 Object {
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "sign in",
+  "taxonomyLevel1": "accounts",
+  "taxonomyLevel2": "re auth",
 }
 `;
 

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -40,7 +40,7 @@ Object {
 }
 `;
 
-exports[`Integration:: resend mfa code should return resend mfa code page with reauth taxonomy 1`] = `
+exports[`Integration:: resend mfa code should return resend mfa code page with reauth analytics properties 1`] = `
 Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "accounts",
@@ -48,7 +48,7 @@ Object {
 }
 `;
 
-exports[`Integration:: resend mfa code should return resend mfa code page with sign in taxonomy 1`] = `
+exports[`Integration:: resend mfa code should return resend mfa code page with sign in analytics properties 1`] = `
 Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -42,7 +42,7 @@ Object {
 
 exports[`Integration:: resend mfa code should return resend mfa code page with reauth analytics properties 1`] = `
 Object {
-  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
+  "contentId": "a2776ef7-9ef3-4d8d-bdbc-3f798b15e5d4",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -58,7 +58,7 @@ Object {
 
 exports[`Integration:: resend mfa code should state reauthenticating user could be logged out 1`] = `
 Object {
-  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
+  "contentId": "a2776ef7-9ef3-4d8d-bdbc-3f798b15e5d4",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: resend mfa code should include the last three digits of the user's telephone number 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: resend mfa code should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration:: resend mfa code should return 400 error screen when API call fails 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration:: resend mfa code should return 500 error screen when API call fails 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration:: resend mfa code should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration:: resend mfa code should return resend mfa code page with reauth taxonomy 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration:: resend mfa code should return resend mfa code page with sign in taxonomy 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration:: resend mfa code should state reauthenticating user could be logged out 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration:: resend mfa code should state user could be locked out 1`] = `
 Object {
+  "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
 }

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -69,7 +69,7 @@ describe("Integration:: resend mfa code", () => {
     app = undefined;
   });
 
-  it("should return resend mfa code page with sign in taxonomy", async () => {
+  it("should return resend mfa code page with sign in analytics properties", async () => {
     await request(app, (test) =>
       test
         .get(PATH_NAMES.RESEND_MFA_CODE)
@@ -81,7 +81,7 @@ describe("Integration:: resend mfa code", () => {
     );
   });
 
-  it("should return resend mfa code page with reauth taxonomy", async () => {
+  it("should return resend mfa code page with reauth analytics properties", async () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     await request(app, (test) =>
       test

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -56,6 +56,7 @@ describe("Integration:: resend mfa code", () => {
   });
 
   beforeEach(() => {
+    process.env.SUPPORT_REAUTHENTICATION = "0";
     nock.cleanAll();
   });
 
@@ -68,7 +69,20 @@ describe("Integration:: resend mfa code", () => {
     app = undefined;
   });
 
-  it("should return resend mfa code page", async () => {
+  it("should return resend mfa code page with sign in taxonomy", async () => {
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.RESEND_MFA_CODE)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("title").text()).to.contain("Get security code");
+        })
+        .expect(200)
+    );
+  });
+
+  it("should return resend mfa code page with reauth taxonomy", async () => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
     await request(app, (test) =>
       test
         .get(PATH_NAMES.RESEND_MFA_CODE)

--- a/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::2fa auth app (in reset password flow) should return updated check auth app page 1`] = `
 Object {
+  "contentId": "943b41f4-8262-417f-8866-c0639319ccf0",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
@@ -44,7 +44,7 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::2fa sms (in reset password flow) should render index-security-code-entered-exceeded.njk when user is locked out due to too many incorrect codes 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::2fa sms (in reset password flow) should return check your phone page 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
@@ -42,7 +42,7 @@ describe("Integration::2fa sms (in reset password flow)", () => {
     nock(baseApi).persist().post("/mfa").reply(204);
 
     await request(app, (test) => test.get(PATH_NAMES.RESET_PASSWORD_2FA_SMS), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::reset password check email  should return reset password check email page 1`] = `
 Object {
+  "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::reset password check email  should redisplay page with error 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::reset password check email  should return 2hr error page when 6 incorrect codes entered and flag is turned on 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::reset password check email  should return error page when 6 password reset codes requested 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::reset password check email  should return error page when blocked from requesting codes 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::reset password check email  should return internal server error when /reset-password-request API call response is 500 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::reset password check email  should return reset password check email page 1`] = `
 Object {
+  "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -50,7 +50,7 @@ describe("Integration::reset password check email ", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -47,7 +47,7 @@ describe("Integration::reset password check email ", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::reset password (in 6 digit code flow) should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return error when new password is the same as existing password 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return reset password page when someone has a reset password intervention 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return reset password page when there are no interventions on a user 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when no numbers present in password 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password all numeric 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password is amongst most common passwords 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password less than 8 characters 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when password not entered 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -65,6 +74,7 @@ Object {
 
 exports[`Integration::reset password (in 6 digit code flow) should return validation error when passwords don't match 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::reset password required should redirect to /auth-code when valid password entered 1`] = `
 Object {
+  "contentId": "95e26313-bc2f-49bc-bc62-fd715476c1d9",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::reset password required should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::reset password required should return error when new password is the same as existing password 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::reset password required should return reset password page 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::reset password required should return validation error when no numbers present in password 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -37,6 +42,7 @@ Object {
 
 exports[`Integration::reset password required should return validation error when password all numeric 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -44,6 +50,7 @@ Object {
 
 exports[`Integration::reset password required should return validation error when password is amongst most common passwords 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -51,6 +58,7 @@ Object {
 
 exports[`Integration::reset password required should return validation error when password less than 8 characters 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -58,6 +66,7 @@ Object {
 
 exports[`Integration::reset password required should return validation error when password not entered 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }
@@ -65,6 +74,7 @@ Object {
 
 exports[`Integration::reset password required should return validation error when passwords don't match 1`] = `
 Object {
+  "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
 }

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -43,7 +43,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
     await request(app, (test) => test.get(ENDPOINT), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/reset-password/tests/reset-password-required-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-required-integration.test.ts
@@ -44,7 +44,7 @@ describe("Integration::reset password required", () => {
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
     await request(app, (test) => test.get(ENDPOINT), {
-      expectTaxonomyMatchSnapshot: false,
+      expectAnalyticsPropertiesMatchSnapshot: false,
     }).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
+++ b/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::select-mfa-options should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::select-mfa-options should return get security codes page 1`] = `
 Object {
+  "contentId": "95e26313-bc2f-49bc-bc62-fd715476c1d9",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::select-mfa-options should return validation error when mfa option not selected 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
 }

--- a/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
+++ b/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration::setup-authenticator-app should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration::setup-authenticator-app should return setup authenticator app page 1`] = `
 Object {
+  "contentId": "5bc82db9-2012-44bf-9a7d-34d1d22fb035",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
 }
@@ -16,6 +18,7 @@ Object {
 
 exports[`Integration::setup-authenticator-app should return validation error when access code is too long (more than 6 digits) 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
 }
@@ -23,6 +26,7 @@ Object {
 
 exports[`Integration::setup-authenticator-app should return validation error when access code not entered 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
 }
@@ -30,6 +34,7 @@ Object {
 
 exports[`Integration::setup-authenticator-app should return validation error when code has non-digit characters 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
 }

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -45,7 +45,7 @@ describe("Integration::setup-authenticator-app", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/components/updated-terms-conditions/tests/__snapshots__/updated-terms-conditions-integration.test.ts.snap
+++ b/src/components/updated-terms-conditions/tests/__snapshots__/updated-terms-conditions-integration.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`Integration:: updated-terms-code should return error when csrf not present 1`] = `
 Object {
+  "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
 }
@@ -9,6 +10,7 @@ Object {
 
 exports[`Integration:: updated-terms-code should return update terms and conditions page 1`] = `
 Object {
+  "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
 }

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -44,7 +44,7 @@ describe("Integration:: updated-terms-code", () => {
     await request(
       app,
       (test) => test.get(PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS),
-      { expectTaxonomyMatchSnapshot: false }
+      { expectAnalyticsPropertiesMatchSnapshot: false }
     ).then((res) => {
       const $ = cheerio.load(res.text);
       token = $("[name=_csrf]").val();

--- a/src/middleware/get-analytics-properties-middleware.ts
+++ b/src/middleware/get-analytics-properties-middleware.ts
@@ -1,9 +1,11 @@
 import { getRequestTaxonomy } from "../utils/taxonomy";
 import { NextFunction, Request, Response } from "express";
+import { getContentId } from "../utils/contentId";
+import { CONTENT_IDS } from "../app.constants";
 
 type CallbackFunction = (err: Error, html: string) => void;
 
-export function getRequestTaxonomyMiddleware(
+export function getAnalyticsPropertiesMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
@@ -16,15 +18,18 @@ export function getRequestTaxonomyMiddleware(
     callback?: CallbackFunction
   ) {
     const taxonomy = getRequestTaxonomy(req);
+    const contentId = getContentId(req, CONTENT_IDS);
 
     let done = callback;
     let opts;
 
     if (isCallbackFunction(options)) {
       done = options;
-      opts = taxonomy;
+      opts = { contentId, ...taxonomy };
     } else {
-      opts = options ? { ...options, ...taxonomy } : taxonomy;
+      opts = options
+        ? { contentId, ...options, ...taxonomy }
+        : { contentId, ...taxonomy };
     }
 
     _render.call(this, view, opts, done);

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,3 +102,8 @@ export interface UserSessionClient {
   rpRedirectUri?: string;
   rpState?: string;
 }
+
+export interface ContentIdVariants {
+  default: string;
+  upliftRequired?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,5 +105,6 @@ export interface UserSessionClient {
 
 export interface ContentIdVariants {
   default: string;
+  reauth?: string;
   upliftRequired?: string;
 }

--- a/src/utils/contentId.test.ts
+++ b/src/utils/contentId.test.ts
@@ -16,6 +16,7 @@ const TEST_CONTENT_IDS: {
   },
   [TEST_PATH_NAMES.ALL_ASSOCIATED_IDS]: {
     default: "this-is-a-default-content-id",
+    reauth: "this-is-a-reauth-content-id",
     upliftRequired: "this-is-a-uplift-required-content-id",
   },
 };
@@ -26,6 +27,10 @@ type VariantExpectation = {
   expectedContentId: string;
 };
 
+const TestReauthUser: Partial<UserSession> = {
+  reauthenticate: "testvalue",
+};
+
 const TestUpliftRequiredUser: Partial<UserSession> = {
   isUpliftRequired: true,
 };
@@ -33,6 +38,11 @@ const TestUpliftRequiredUser: Partial<UserSession> = {
 const mappingsToTest: VariantExpectation[] = [
   { expectedContentId: "" },
   {
+    path: TEST_PATH_NAMES.JUST_DEFAULT,
+    expectedContentId: TEST_CONTENT_IDS[TEST_PATH_NAMES.JUST_DEFAULT].default,
+  },
+  {
+    user: TestReauthUser,
     path: TEST_PATH_NAMES.JUST_DEFAULT,
     expectedContentId: TEST_CONTENT_IDS[TEST_PATH_NAMES.JUST_DEFAULT].default,
   },
@@ -47,6 +57,12 @@ const mappingsToTest: VariantExpectation[] = [
       TEST_CONTENT_IDS[TEST_PATH_NAMES.ALL_ASSOCIATED_IDS].default,
   },
   {
+    user: TestReauthUser,
+    path: TEST_PATH_NAMES.ALL_ASSOCIATED_IDS,
+    expectedContentId:
+      TEST_CONTENT_IDS[TEST_PATH_NAMES.ALL_ASSOCIATED_IDS].reauth,
+  },
+  {
     user: TestUpliftRequiredUser,
     path: TEST_PATH_NAMES.ALL_ASSOCIATED_IDS,
     expectedContentId:
@@ -55,6 +71,10 @@ const mappingsToTest: VariantExpectation[] = [
 ];
 
 describe("getContentId", () => {
+  beforeEach(() => {
+    process.env.SUPPORT_REAUTHENTICATION = "1";
+  });
+
   it(`user on path with no associated contentIds returns empty string`, async () => {
     const contentId = getContentId(
       {

--- a/src/utils/contentId.test.ts
+++ b/src/utils/contentId.test.ts
@@ -1,0 +1,80 @@
+import { getContentId } from "./contentId";
+import { Request } from "express";
+import { ContentIdVariants, UserSession } from "../types";
+import { expect } from "../../test/utils/test-utils";
+
+const TEST_PATH_NAMES = {
+  JUST_DEFAULT: "/just-default",
+  ALL_ASSOCIATED_IDS: "/all-associated-ids",
+};
+
+const TEST_CONTENT_IDS: {
+  [path: string]: ContentIdVariants;
+} = {
+  [TEST_PATH_NAMES.JUST_DEFAULT]: {
+    default: "this-is-a-default-content-id",
+  },
+  [TEST_PATH_NAMES.ALL_ASSOCIATED_IDS]: {
+    default: "this-is-a-default-content-id",
+    upliftRequired: "this-is-a-uplift-required-content-id",
+  },
+};
+
+type VariantExpectation = {
+  user?: Partial<UserSession>;
+  path?: string;
+  expectedContentId: string;
+};
+
+const TestUpliftRequiredUser: Partial<UserSession> = {
+  isUpliftRequired: true,
+};
+
+const mappingsToTest: VariantExpectation[] = [
+  { expectedContentId: "" },
+  {
+    path: TEST_PATH_NAMES.JUST_DEFAULT,
+    expectedContentId: TEST_CONTENT_IDS[TEST_PATH_NAMES.JUST_DEFAULT].default,
+  },
+  {
+    user: TestUpliftRequiredUser,
+    path: TEST_PATH_NAMES.JUST_DEFAULT,
+    expectedContentId: TEST_CONTENT_IDS[TEST_PATH_NAMES.JUST_DEFAULT].default,
+  },
+  {
+    path: TEST_PATH_NAMES.ALL_ASSOCIATED_IDS,
+    expectedContentId:
+      TEST_CONTENT_IDS[TEST_PATH_NAMES.ALL_ASSOCIATED_IDS].default,
+  },
+  {
+    user: TestUpliftRequiredUser,
+    path: TEST_PATH_NAMES.ALL_ASSOCIATED_IDS,
+    expectedContentId:
+      TEST_CONTENT_IDS[TEST_PATH_NAMES.ALL_ASSOCIATED_IDS].upliftRequired,
+  },
+];
+
+describe("getContentId", () => {
+  it(`user on path with no associated contentIds returns empty string`, async () => {
+    const contentId = getContentId(
+      {
+        path: "/undefined-path-with-no-content-id",
+      } as Request,
+      TEST_CONTENT_IDS
+    );
+    expect(contentId).to.eq("");
+  });
+
+  mappingsToTest.forEach((mapping) => {
+    it(`user (${JSON.stringify(mapping.user)}) on path (${mapping.path}) should map to contentId ${JSON.stringify(mapping.expectedContentId)}`, async () => {
+      const contentId = getContentId(
+        {
+          session: { user: mapping.user },
+          path: mapping.path,
+        } as Request,
+        TEST_CONTENT_IDS
+      );
+      expect(contentId).to.eq(mapping.expectedContentId);
+    });
+  });
+});

--- a/src/utils/contentId.ts
+++ b/src/utils/contentId.ts
@@ -1,4 +1,5 @@
 import { Request } from "express";
+import { supportReauthentication } from "../config";
 import { ContentIdVariants } from "../types";
 
 export function getContentId(
@@ -7,6 +8,8 @@ export function getContentId(
     [path: string]: ContentIdVariants;
   }
 ): string {
+  const isReauth =
+    supportReauthentication() && Boolean(req?.session?.user?.reauthenticate);
   const isUpliftRequired = Boolean(req?.session?.user?.isUpliftRequired);
 
   const supportedPaths = Object.keys(contentIds);
@@ -14,7 +17,9 @@ export function getContentId(
   const contentId = matchedSupportedPath && contentIds[matchedSupportedPath];
 
   if (contentId) {
-    if (isUpliftRequired && contentId.upliftRequired) {
+    if (isReauth && contentId.reauth) {
+      return contentId.reauth;
+    } else if (isUpliftRequired && contentId.upliftRequired) {
       return contentId.upliftRequired;
     } else {
       return contentId.default;

--- a/src/utils/contentId.ts
+++ b/src/utils/contentId.ts
@@ -1,0 +1,25 @@
+import { Request } from "express";
+import { ContentIdVariants } from "../types";
+
+export function getContentId(
+  req: Request,
+  contentIds: {
+    [path: string]: ContentIdVariants;
+  }
+): string {
+  const isUpliftRequired = Boolean(req?.session?.user?.isUpliftRequired);
+
+  const supportedPaths = Object.keys(contentIds);
+  const matchedSupportedPath = supportedPaths.find((path) => req.path === path);
+  const contentId = matchedSupportedPath && contentIds[matchedSupportedPath];
+
+  if (contentId) {
+    if (isUpliftRequired && contentId.upliftRequired) {
+      return contentId.upliftRequired;
+    } else {
+      return contentId.default;
+    }
+  }
+
+  return "";
+}

--- a/src/utils/taxonomy.test.ts
+++ b/src/utils/taxonomy.test.ts
@@ -29,6 +29,7 @@ const signInVariants: Variant[] = [
   { path: PATH_NAMES.ENTER_PASSWORD },
   { path: PATH_NAMES.RESEND_MFA_CODE },
 ];
+const reauthVariants: Variant[] = [{ user: { reauthenticate: "samplevalue" } }];
 const createAccountVariants: Variant[] = [
   { user: { isAccountCreationJourney: true } },
   { path: PATH_NAMES.CHECK_YOUR_EMAIL },
@@ -88,6 +89,13 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.SIGN_IN,
+    },
+  })),
+  ...reauthVariants.map((t) => ({
+    ...t,
+    expectedTaxonomy: {
+      taxonomyLevel1: TaxonomyLevel1.ACCOUNTS,
+      taxonomyLevel2: TaxonomyLevel2.REAUTH,
     },
   })),
   ...createAccountVariants.map((t) => ({

--- a/src/utils/taxonomy.ts
+++ b/src/utils/taxonomy.ts
@@ -1,6 +1,6 @@
 import { Request } from "express";
 import { CONTACT_US_THEMES, PATH_NAMES } from "../app.constants";
-import { supportAccountRecovery } from "../config";
+import { supportAccountRecovery, supportReauthentication } from "../config";
 
 export enum TaxonomyLevel1 {
   BLANK = "",
@@ -16,6 +16,7 @@ export enum TaxonomyLevel2 {
   ACCOUNT_RECOVERY = "account recovery",
   FEEDBACK = "feedback",
   GUIDANCE = "guidance",
+  REAUTH = "re auth",
 }
 
 export type Taxonomy = {
@@ -42,6 +43,7 @@ function getTaxonomyLevel2(req: Request) {
   let taxonomyLevel2 = TaxonomyLevel2.BLANK;
 
   if (isSignInTaxonomy(req)) taxonomyLevel2 = TaxonomyLevel2.SIGN_IN;
+  if (isReauthTaxonomy(req)) taxonomyLevel2 = TaxonomyLevel2.REAUTH;
   if (isCreateAccountTaxonomy(req))
     taxonomyLevel2 = TaxonomyLevel2.CREATE_ACCOUNT;
   if (isFeedbackTaxonomy(req)) {
@@ -67,6 +69,9 @@ const isSignInTaxonomy = (req: Request): boolean =>
     PATH_NAMES.ENTER_PASSWORD,
     PATH_NAMES.RESEND_MFA_CODE,
   ].includes(req.path);
+
+const isReauthTaxonomy = (req: Request): boolean =>
+  supportReauthentication() && Boolean(req?.session?.user?.reauthenticate);
 
 const isCreateAccountTaxonomy = (req: Request): boolean =>
   req?.session?.user?.isAccountCreationJourney ||
@@ -136,4 +141,6 @@ const isAuthenticationTaxonomy = (taxonomyLevel2: TaxonomyLevel2): boolean =>
   ].includes(taxonomyLevel2);
 
 const isAccountTaxonomy = (taxonomyLevel2: TaxonomyLevel2): boolean =>
-  [TaxonomyLevel2.ACCOUNT_INTERVENTION].includes(taxonomyLevel2);
+  [TaxonomyLevel2.ACCOUNT_INTERVENTION, TaxonomyLevel2.REAUTH].includes(
+    taxonomyLevel2
+  );

--- a/test/helpers/expect-response-helpers.ts
+++ b/test/helpers/expect-response-helpers.ts
@@ -1,11 +1,14 @@
 import request from "supertest";
 import { expect } from "../utils/test-utils";
 
-export function expectTaxonomyMatchSnapshot(res: request.Response): void {
+export function expectAnalyticsPropertiesMatchSnapshot(
+  res: request.Response
+): void {
   if (res.statusCode < 300 || res.statusCode >= 400) {
     expect({
       taxonomyLevel1: res.text.match(/taxonomy_level1: '([\w\d\s]*)'/)?.[1],
       taxonomyLevel2: res.text.match(/taxonomy_level2: '([\w\d\s]*)'/)?.[1],
+      contentId: res.text.match(/content_id: '([\w\d-]*)'/)?.[1],
     }).toMatchSnapshot();
   }
 }

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -4,7 +4,7 @@ import sinonChai from "sinon-chai";
 import chaiAsPromised from "chai-as-promised";
 import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
 import supertest, { Test } from "supertest";
-import { expectTaxonomyMatchSnapshot } from "../helpers/expect-taxonomy-helpers";
+import { expectAnalyticsPropertiesMatchSnapshot } from "../helpers/expect-response-helpers";
 import TestAgent = require("supertest/lib/agent");
 
 chai.should();
@@ -18,12 +18,12 @@ const request = (
   app: any,
   callback: (test: TestAgent) => Test,
   options: {
-    expectTaxonomyMatchSnapshot?: boolean;
+    expectAnalyticsPropertiesMatchSnapshot?: boolean;
   } = {}
 ): supertest.Test => {
   let test = callback(supertest(app));
-  if (options.expectTaxonomyMatchSnapshot !== false) {
-    test = test.expect(expectTaxonomyMatchSnapshot);
+  if (options.expectAnalyticsPropertiesMatchSnapshot !== false) {
+    test = test.expect(expectAnalyticsPropertiesMatchSnapshot);
   }
   return test;
 };


### PR DESCRIPTION
## What

First apply `re auth` taxonomies when a user is reauthenticating. This is so data analytics can determine the context in why a user requested a page.

Then work on contentIds.

A snapshot of current contentIds is recorded via integration tests so changes can be regression tested.

Create a middleware to get contentId from request by looking at the path and user session, then apply it to templates when rendered. This is applied to just one path.

Reauth support is then added to the middleware and reauth contentIds are added to other paths.


## How to review

1. Code Review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [X] Performance analyst has been notified of the change.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2144