### PR TITLE
AUT-3757: Increasing target group deregistration delay

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -146,7 +146,7 @@ variable "health_check_grace_period_seconds" {
 }
 
 variable "deregistration_delay" {
-  default = 30
+  default = 90
 }
 
 variable "sidecar_image_uri" {

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -933,6 +933,9 @@ Resources:
       VpcId:
         Fn::ImportValue:
           !Sub "${VpcStackName}-VpcId"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "90"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ApplicationLoadBalancerTargetGroupA"
@@ -965,6 +968,9 @@ Resources:
       VpcId:
         Fn::ImportValue:
           !Sub "${VpcStackName}-VpcId"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "90"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ApplicationLoadBalancerTargetGroupB"


### PR DESCRIPTION

## What

Increasing the deregistration delay timeout of Target group from 30sec to 90sec so this is Greater than the Idle timeout on ALB (which is 60 sec)

## Why 

## How to review

1. Code Review
2. Deploy to sandpit with `./deploy-sandpit.sh -a`
3. Check the Frontend Target group delay registration is changing from 30sec to 90sec 

