### PR TITLE
Phase 2 PR Control of deployment shifts from ECS Service to CodeDeploy

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -80,9 +80,16 @@ Conditions:
   ECSServiceCanaryPhasedDeploy:
     Fn::And:
       - !Condition UseECSCanaryDeploymentStack
-      - Fn::Equals:
-        - !Ref Environment
-        - "build"
+      - Fn::Or:
+        - Fn::Equals:
+          - !Ref Environment
+          - "build"
+        - Fn::Equals:
+          - !Ref Environment
+          - "staging"
+        - Fn::Equals:
+          - !Ref SubEnvironment
+          - "authdev1"
 
   UseSubEnvironment:
     Fn::And:


### PR DESCRIPTION
## What

Phase 2 - Control of deployment shifts from ECS Service to CodeDeploy
Issue: [AUT-3494], [AUT-3546]

Based on [ECS canary migration guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance)

[AUT-3494]: https://govukverify.atlassian.net/browse/AUT-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-3546]: https://govukverify.atlassian.net/browse/AUT-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ