### PR TITLE
AUT-3755: Move health check router

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -132,7 +132,6 @@ function registerRoutes(app: express.Application) {
   app.use(resetPassword2FAAuthAppRouter);
   app.use(upliftJourneyRouter);
   app.use(contactUsRouter);
-  app.use(healthcheckRouter);
   app.use(proveIdentityRouter);
   app.use(proveIdentityWelcomeRouter);
   app.use(proveIdentityCallbackRouter);
@@ -153,6 +152,7 @@ async function createApp(): Promise<express.Application> {
 
   app.enable("trust proxy");
 
+  app.use(healthcheckRouter);
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(noCacheMiddleware);

--- a/src/app.ts
+++ b/src/app.ts
@@ -152,11 +152,11 @@ async function createApp(): Promise<express.Application> {
 
   app.enable("trust proxy");
 
+  app.use(loggerMiddleware);
   app.use(healthcheckRouter);
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use(noCacheMiddleware);
-  app.use(loggerMiddleware);
 
   app.use(
     "/assets",

--- a/src/components/healthcheck/healthcheck-controller.ts
+++ b/src/components/healthcheck/healthcheck-controller.ts
@@ -1,6 +1,8 @@
 import { Request, Response } from "express";
 import { HTTP_STATUS_CODES } from "../../app.constants";
+import { logger } from "../../utils/logger";
 
 export function healthcheckGet(req: Request, res: Response): void {
+  logger.info(`Healthcheck returning 200 OK.`);
   res.status(HTTP_STATUS_CODES.OK).send("OK");
 }


### PR DESCRIPTION
## What

Prior to this PR, the healthCheckRouter was being processed by express after other more resource-intensive middlewares. This meant that if the health check were to fail, resources had already been wasted on invoking resource-intensive middlewares like the session middleware. This commit resolves this by moving healthCheckRouter invocations before other middlewares.

This PR also adds logging when handling the health check, in line with guidance given [here](https://github.com/govuk-one-login/architecture/blob/913c04af8b57e2cdce07c4b242a409690852d527/rfc/0083-express-on-ecs.md#too-many-connections) under the heading 'HealthChecks'

## How to review

1. Code Review
