### PR TITLE
Phase 2 Canary - Deployment control shifts from ECS Service to CodeDeploy

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -84,9 +84,9 @@ Conditions:
         - Fn::Equals:
           - !Ref Environment
           - "build"
-        # - Fn::Equals:
-        #   - !Ref Environment
-        #   - "staging"
+        - Fn::Equals:
+          - !Ref Environment
+          - "staging"
         - Fn::Equals:
           - !Ref SubEnvironment
           - "authdev1"


### PR DESCRIPTION
## What

Phase 2 - Control of deployment shifts from ECS Service to CodeDeploy
Issue: [AUT-3546]

Based on [ECS canary migration guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance)


[AUT-3546]: https://govukverify.atlassian.net/browse/AUT-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ