### PR TITLE
AUT-3753: Implement `vital-signs` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "^0.0.3",
+    "@govuk-one-login/frontend-vital-signs": "0.0.4",
     "@govuk-one-login/spinner": "^1.0.1",
     "@otplib/core": "^12.0.1",
     "@otplib/plugin-base32-enc-dec": "^12.0.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { createApp } from "./app";
 import { logger } from "./utils/logger";
+import { frontendVitalSignsInit } from "@govuk-one-login/frontend-vital-signs";
 
 const port: number | string = process.env.PORT || 3000;
 
@@ -15,6 +16,9 @@ const port: number | string = process.env.PORT || 3000;
     });
   server.keepAliveTimeout = 61 * 1000;
   server.headersTimeout = 91 * 1000;
+  frontendVitalSignsInit(server, {
+    staticPaths: [/^\/assets\/.*/, /^\/public\/.*/],
+  });
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -861,6 +861,13 @@
     forwarded-parse "^2.1.2"
     pino "^8.20.0"
 
+"@govuk-one-login/frontend-vital-signs@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-vital-signs/-/frontend-vital-signs-0.0.4.tgz#0c0b019c485e953811d37f4c03042f779e0b2112"
+  integrity sha512-IXPZowxi2uxdbMquk2jnTNMr3sYh1Nc3R1UGOTXhad3ta7vYQy1acm/Z9Dux3L2g5xYp9He+cFJFUoOqtMi8FA==
+  dependencies:
+    pino "^8.20.0"
+
 "@govuk-one-login/spinner@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@govuk-one-login/spinner/-/spinner-1.0.1.tgz#62a18e68440154244dee7b4319e4eff8988e6b3a"


### PR DESCRIPTION
## What

Add `vital-signs` package to get observability stats logged. For the most part we use default settings, except for static paths which are explicitally set for our `/assets/**/*` and `/public/**/*` paths.

This will enable us to see stats like event loop delay & utilization, average response time, max concurrent connections and requests per second in our logs.

The defaults at the time of commiting have it log every 10 seconds and log level at "info" with all available metrics.

## How to review

Code review.

Note that this has been deployed to our dev environment and manually smoke tested to ensure it's not fundamentally broken our application.

Logs were also seen in CloudWatch, e.g. 

```
{
  "level": 30,
  "time": 1729076995468,
  "pid": 28,
  "hostname": "[REDACTED].compute.internal",
  "name": "@govuk-one-login/frontend-vital-signs",
  "version": "0.0.3",
  "eventLoopDelay": 10.096631716885744,
  "eventLoopUtilization": {
    "idle": 9951.420236999998,
    "active": 48.31626699997287,
    "utilization": 0.004831754014782888
  },
  "requestsPerSecond": {
    "dynamic": 0.3,
    "static": 0
  },
  "avgResponseTime": {
    "dynamic": 627.25,
    "static": null
  },
  "maxConcurrentConnections": 2
}
```
