### PR TITLE
AUT-3544 - Enable ECS canary in integration env frontend

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -88,6 +88,9 @@ Conditions:
           - !Ref Environment
           - "staging"
         - Fn::Equals:
+          - !Ref Environment
+          - "integration"
+        - Fn::Equals:
           - !Ref SubEnvironment
           - "authdev1"
 


### PR DESCRIPTION
## What

Enable ECS canary in integration env frontend.
This is the phase2 change as per the [migration guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance) that removes LoadBalancers, NetworkConfiguration, TaskDefinition from ECS Service

Issue: [AUT-3544]


[AUT-3544]: https://govukverify.atlassian.net/browse/AUT-3544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ