### PR TITLE
AUT-3762: Add graceful shutdown

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
-import express from "express";
+import express, { Application } from "express";
 import cookieParser from "cookie-parser";
 import csurf from "csurf";
-import { loggerMiddleware } from "./utils/logger";
+import { logger, loggerMiddleware } from "./utils/logger";
 
 import { sanitizeRequestMiddleware } from "./middleware/sanitize-request-middleware";
 import i18nextMiddleware from "i18next-http-middleware";
@@ -89,6 +89,8 @@ import { setCurrentUrlMiddleware } from "./middleware/current-url-middleware";
 import { getRedisConfig } from "./utils/redis";
 import { csrfMissingHandler } from "./handlers/csrf-missing-handler";
 import { channelMiddleware } from "./middleware/channel-middleware";
+import { frontendVitalSignsInit } from "@govuk-one-login/frontend-vital-signs";
+import { Server } from "node:http";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -224,4 +226,30 @@ async function createApp(): Promise<express.Application> {
   return app;
 }
 
-export { createApp };
+async function startServer(app: Application): Promise<Server> {
+  const port: number | string = process.env.PORT || 3000;
+  let server: Server;
+
+  await new Promise<void>((resolve) => {
+    server = app
+      .listen(port, () => {
+        logger.info(`Server listening on port ${port}`);
+        app.emit("appStarted");
+        resolve();
+      })
+      .on("error", (error: Error) => {
+        logger.error(`Unable to start server because of ${error.message}`);
+      });
+
+    server.keepAliveTimeout = 61 * 1000;
+    server.headersTimeout = 91 * 1000;
+
+    frontendVitalSignsInit(server, {
+      staticPaths: [/^\/assets\/.*/, /^\/public\/.*/],
+    });
+  });
+
+  return server;
+}
+
+export { createApp, startServer };

--- a/src/app.ts
+++ b/src/app.ts
@@ -272,4 +272,17 @@ async function startServer(app: Application): Promise<{
   return { server, closeServer };
 }
 
-export { createApp, startServer };
+const shutdownProcess =
+  (closeServer: () => Promise<void>) => async (): Promise<void> => {
+    try {
+      logger.info("closing server");
+      await closeServer();
+      logger.info("server closed");
+      process.exit(0);
+    } catch (error) {
+      logger.error(`error closing server: ${error.message}`);
+      process.exit(1);
+    }
+  };
+
+export { createApp, startServer, shutdownProcess };

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -2,27 +2,45 @@ import { RedisClientOptions, createClient } from "redis";
 import RedisStore from "connect-redis";
 import { RedisConfig } from "src/utils/types";
 
+let redisClient: ReturnType<typeof createClient> | undefined;
+let usedRedisConfig: RedisConfig | undefined;
+
 export function getSessionStore(redisConfig: RedisConfig): RedisStore {
-  const config: RedisClientOptions = {
-    socket: {
-      host: redisConfig.host,
-      port: redisConfig.port,
-    },
-  };
+  if (redisClient && !isRedisConfigEqual(redisConfig, usedRedisConfig)) {
+    throw new Error("Redis client already established with different config");
+  } else if (!redisClient) {
+    usedRedisConfig = redisConfig;
 
-  if (redisConfig.tls) {
-    config.socket.tls = redisConfig.tls;
-  }
-  if (redisConfig.password) {
-    config.password = redisConfig.password;
-  }
+    const config: RedisClientOptions = {
+      socket: {
+        host: redisConfig.host,
+        port: redisConfig.port,
+      },
+    };
 
-  const client = createClient(config);
-  client.connect();
+    if (redisConfig.tls) {
+      config.socket.tls = redisConfig.tls;
+    }
+    if (redisConfig.password) {
+      config.password = redisConfig.password;
+    }
+
+    redisClient = createClient(config);
+    redisClient.connect();
+    usedRedisConfig = redisConfig;
+  }
 
   return new RedisStore({
-    client,
+    client: redisClient,
   });
+}
+
+export async function disconnectRedisClient(): Promise<void> {
+  if (redisClient) {
+    await redisClient.disconnect();
+    redisClient = undefined;
+    usedRedisConfig = undefined;
+  }
 }
 
 export function getSessionCookieOptions(
@@ -37,4 +55,13 @@ export function getSessionCookieOptions(
     signed: true,
     secure: isProdEnv,
   };
+}
+
+export function isRedisConfigEqual(a: RedisConfig, b: RedisConfig): boolean {
+  const keys = new Set<keyof typeof a & keyof typeof b>();
+  (Object.keys(a) as (keyof typeof a)[]).forEach((k) => keys.add(k));
+  (Object.keys(b) as (keyof typeof b)[]).forEach((k) => keys.add(k));
+  return (
+    Array.from(keys).reduce((acc, k) => acc + (a[k] === b[k] ? 0 : 1), 0) === 0
+  );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,24 +1,9 @@
-import { createApp } from "./app";
+import { createApp, startServer } from "./app";
 import { logger } from "./utils/logger";
-import { frontendVitalSignsInit } from "@govuk-one-login/frontend-vital-signs";
-
-const port: number | string = process.env.PORT || 3000;
 
 (async () => {
   const app = await createApp();
-  const server = app
-    .listen(port, () => {
-      logger.info(`Server listening on port ${port}`);
-      app.emit("appStarted");
-    })
-    .on("error", (error: Error) => {
-      logger.error(`Unable to start server because of ${error.message}`);
-    });
-  server.keepAliveTimeout = 61 * 1000;
-  server.headersTimeout = 91 * 1000;
-  frontendVitalSignsInit(server, {
-    staticPaths: [/^\/assets\/.*/, /^\/public\/.*/],
-  });
+  await startServer(app);
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,12 @@
-import { createApp, startServer } from "./app";
+import { createApp, shutdownProcess, startServer } from "./app";
 import { logger } from "./utils/logger";
 
 (async () => {
   const app = await createApp();
-  await startServer(app);
+  const { closeServer } = await startServer(app);
+  const shutdown = shutdownProcess(closeServer);
+  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", shutdown);
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);
 });

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe } from "mocha";
+import { expect, sinon } from "../utils/test-utils";
+import { startServer } from "../../src/app";
+import express from "express";
+import decache from "decache";
+
+describe("app", () => {
+  describe("startServer", () => {
+    beforeEach(() => {
+      process.env.PORT = "3060";
+    });
+
+    it("should start server on expected port", async () => {
+      const app = express();
+      const listenSpy = sinon.spy(app, "listen");
+      const server = await startServer(app);
+      expect(listenSpy).to.be.calledOnceWith(process.env.PORT);
+      server.close();
+    });
+
+    it("should start server with expected timeouts", async () => {
+      const app = express();
+      const server = await startServer(app);
+      expect(server.keepAliveTimeout).to.be.eq(61 * 1000);
+      expect(server.headersTimeout).to.be.eq(91 * 1000);
+      server.close();
+    });
+
+    it("should start server with vital-signs package", async () => {
+      decache("../../src/app");
+      decache("@govuk-one-login/frontend-vital-signs");
+      const frontendVitalSigns = require("@govuk-one-login/frontend-vital-signs");
+      sinon
+        .stub(frontendVitalSigns, "frontendVitalSignsInit")
+        .callsFake(() => {});
+      const { startServer } = require("../../src/app");
+      const app = express();
+      const server = await startServer(app);
+      expect(frontendVitalSigns.frontendVitalSignsInit).to.be.calledOnceWith(
+        server,
+        { staticPaths: [/^\/assets\/.*/, /^\/public\/.*/] }
+      );
+      server.close();
+    });
+  });
+});

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -1,0 +1,135 @@
+import { describe, beforeEach, it } from "mocha";
+import { RedisConfig } from "../../src/utils/types";
+import { isRedisConfigEqual } from "../../src/config/session";
+import { expect, sinon } from "../utils/test-utils";
+import decache from "decache";
+import { RedisModules } from "redis";
+
+describe("session", () => {
+  const redisConfig = {
+    host: "test",
+    port: 12345,
+    password: "string",
+    tls: true,
+  };
+
+  let redis: RedisModules;
+  let connect: () => void;
+  let disconnect: () => void;
+
+  beforeEach(() => {
+    decache("../../src/config/session");
+    decache("redis");
+    redis = require("redis");
+    connect = sinon.fake();
+    disconnect = sinon.fake();
+    sinon
+      .stub(redis, "createClient")
+      .callsFake(() => ({ connect, disconnect }));
+  });
+
+  describe("getSessionStore", () => {
+    it("should create a new client if none already exists and connect to redis", () => {
+      const { getSessionStore } = require("../../src/config/session");
+      getSessionStore(redisConfig);
+      expect(redis.createClient).to.be.callCount(1);
+      expect(connect).to.be.callCount(1);
+    });
+
+    it("should throw error when there is already a redis client and the config is different", () => {
+      const { getSessionStore } = require("../../src/config/session");
+      getSessionStore(redisConfig);
+      expect(() =>
+        getSessionStore({ ...redisConfig, host: "somethingdifferent" })
+      ).to.throw();
+    });
+
+    it("should not create a new client if one already exists with the same configuration", () => {
+      const { getSessionStore } = require("../../src/config/session");
+      getSessionStore(redisConfig);
+      getSessionStore(redisConfig);
+      getSessionStore(redisConfig);
+      getSessionStore(redisConfig);
+      expect(redis.createClient).to.be.callCount(1);
+      expect(connect).to.be.callCount(1);
+    });
+  });
+
+  describe("disconnectRedisClient", () => {
+    it("should not error if there is no client", () => {
+      const { disconnectRedisClient } = require("../../src/config/session");
+      expect(() => disconnectRedisClient()).to.not.throw();
+    });
+
+    it("should disconnect the client if a client exists, clear up and allow new client", async () => {
+      const {
+        getSessionStore,
+        disconnectRedisClient,
+      } = require("../../src/config/session");
+      getSessionStore(redisConfig);
+
+      await disconnectRedisClient();
+
+      expect(disconnect).to.be.callCount(1);
+
+      getSessionStore(redisConfig);
+      expect(redis.createClient).to.be.callCount(2);
+      expect(connect).to.be.callCount(2);
+    });
+  });
+
+  describe("isRedisConfigEqual", () => {
+    const expectations: { a: RedisConfig; b: RedisConfig; equal: boolean }[] = [
+      {
+        equal: true,
+        a: {
+          host: "test",
+          port: 12345,
+          password: "string",
+          tls: true,
+        },
+        b: {
+          host: "test",
+          port: 12345,
+          password: "string",
+          tls: true,
+        },
+      },
+      {
+        equal: false,
+        a: {
+          host: "test",
+          port: 12345,
+        },
+        b: {
+          host: "test",
+          port: 12345,
+          password: "string",
+          tls: true,
+        },
+      },
+      {
+        equal: false,
+        a: {
+          host: "test",
+          port: 12345,
+          password: "incorrect",
+          tls: true,
+        },
+        b: {
+          host: "test",
+          port: 12345,
+          password: "string",
+          tls: true,
+        },
+      },
+    ];
+    expectations.forEach((expectation) => {
+      it(`should return ${expectation.equal} when a is ${JSON.stringify(expectation.a)} and b is ${JSON.stringify(expectation.b)}`, () => {
+        expect(isRedisConfigEqual(expectation.a, expectation.b)).to.eq(
+          expectation.equal
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

### Extract server start logic to tested method
Before adding graceful shutdown, make the existing start server logic testable and add tests to assert the server starts on the expected port, with the expected timeouts and with the vital-signs package.


### Maintain one redis client with disconnect
The redis client can be disconnected, but in order to do so the client needs to be available outside of the method that creates it.

A new `disconnectRedisClient()` method is added that will disconnect the client if there is a client set.

New calls to `getSessionStore` will reuse an existing redis client so long as the redisConfig matches. Otherwise an error is thrown.


### Create method to gracefully close server
This new `closeServer()` method will disconnect the redis client and stop vital-signs logging before shutting down the HTTP server.


### Graceful shutdown on SIGTERM and SIGINT
Should the process receive a signal indicating it should shutdown, the `closeServer()` method is run that will systematically close down the server. The process is then exited with a success code (0).

If the shutdown fails for some reason, we exit the process with an error code (1).


## How to review

1. Code review, commit-by-commit.
2. `./startup.sh -lc`.
3. Wait for server to be running.
4. SIGINT by pressing `CTRL+C`.
5. See logs indicating graceful shutdown.
6. `./startup.sh -l`.
7. On macOS you can trigger a SIGTERM with
  - `ps | grep "node -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js"`
  - Find the PID of the none-grep process
  - `kill -15 [PID]`
9. See logs indicating graceful shutdown.