### PR TITLE
AUT-3545: Prod X-account redis sg group and auth kms share

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -37,6 +37,9 @@ logging_endpoint_arns = [
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
 
+new_auth_account_id               = "211125303002"
+new_auth_protectedsub_cidr_blocks = ["10.6.4.0/23", "10.6.6.0/23", "10.6.8.0/23"]
+
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5\n+3VZPbjHv+v0AjQ5Ps+avkXWKwOeScG9sS0cDf0utEXi3fN3cEraa9WuKQ==\n-----END PUBLIC KEY-----"
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.account.gov.uk/"


### PR DESCRIPTION
## What

Production env cross-account redis sg group rules and auth kms share
Issue: [AUT-3545]

<!-- Describe what you have changed and why -->

## How to review

Env specific change for production. Similar changes were made in integration recently [AUT-3544]

[AUT-3545]: https://govukverify.atlassian.net/browse/AUT-3545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-3544]: https://govukverify.atlassian.net/browse/AUT-3544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ