### PR TITLE
AUT-3545 - New prod environment transitional '-sp' domains and basic auth sidecar

### DIFF
--- a/cloudformation/cloudfront-waf/template.yaml
+++ b/cloudformation/cloudfront-waf/template.yaml
@@ -118,21 +118,23 @@ Conditions:
         - !Ref Environment
         - production
 
-  IsProdLikeEnvironment:
-    !Equals [!Ref Environment, production]
+  IsCSLSLogForwardingEnabled:
+    Fn::Equals:
+      - !Ref Environment
+      - "placeholder"
 
 Mappings:
   PlatformConfiguration:
     dev:
-      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython-2
     build:
-      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython-2
     staging:
-      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython-2
     integration:
-      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython-2
     production:
-      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:us-east-1:885513274347:destination:csls_cw_logs_destination_prodpython-2
 
 Resources:
   WAFv2GDSIPSet:
@@ -575,7 +577,7 @@ Resources:
 
   CSLSCloudWatchLogsSubscription:
     Type: AWS::Logs::SubscriptionFilter
-    Condition: IsProdLikeEnvironment
+    Condition: IsCSLSLogForwardingEnabled
     Properties:
       DestinationArn: !FindInMap [ PlatformConfiguration, !Ref Environment, CSLSEGRESS ]
       FilterPattern: ""

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -105,7 +105,6 @@ Conditions:
               - none
 
   UseNginxSidecar:
-    # TODO review this condition
     Fn::Or:
       - Fn::Equals:
           - !Ref Environment
@@ -113,6 +112,11 @@ Conditions:
       - Fn::Equals:
           - !Ref Environment
           - "integration"
+      # TODO Nginx sidecar is deployed in prod to block public access, while still using the transitional '-sp' domain
+      # The following lines must be removed BEFORE we switch DNS
+      - Fn::Equals:
+          - !Ref Environment
+          - "production"
 
   IsNotProduction:
     Fn::Not:

--- a/cloudformation/domains/template.yaml
+++ b/cloudformation/domains/template.yaml
@@ -14,6 +14,7 @@ Parameters:
       - build
       - staging
       - integration
+      - production
 
   EndpointSuffix:
     Description: >
@@ -42,6 +43,11 @@ Conditions:
         - !Ref Environment
         - "integration"
 
+  CreateProductionEnvironmentResources:
+    Fn::Equals:
+      - !Ref Environment
+      - "production"
+
 Mappings:
   EndpointConfigs:
     Auth:
@@ -54,9 +60,11 @@ Mappings:
       lowercaseName: signin
 
 Resources:
-  #
-  # dev hosted zones
-  #
+
+  # ==============================
+  # dev hosted zones and resources
+  # ==============================
+
   'Fn::ForEach::DevEnvironments':
     - EnvName
     - - authdev1
@@ -136,9 +144,9 @@ Resources:
                 Application: "auth-frontend"
                 Source: govuk-one-login/authentication-frontend/cloudformation/domains/template.yaml
 
-  #
-  # Non-prod and production hosted zones
-  #
+  # ===================================
+  # Non-prod hosted zones and resources
+  # ===================================
 
   #
   # auth
@@ -197,6 +205,7 @@ Resources:
     # TODO uncomment this when we retire and replace the -sp domains with the standard ones
     # - Accounts${Endpoint}HostedZone:
     #     Type: AWS::Route53::HostedZone
+    #     Condition: CreateNonProdEnvironmentResources
     #     DeletionPolicy: Retain
     #     UpdateReplacePolicy: Retain
     #     Properties:
@@ -247,6 +256,75 @@ Resources:
           Type: String
           Value: !Ref
             Fn::Sub: Accounts${Endpoint}Certificate
+          Tags:
+            Environment: !Ref Environment
+            Application: "auth-frontend"
+            Source: govuk-one-login/authentication-frontend/cloudformation/domains/template.yaml
+
+  # =====================================
+  # Production hosted zones and resources
+  # =====================================
+
+  'Fn::ForEach::ProdEndpoints':
+    - Endpoint
+    - - Signin
+      # For services not yet migrated to secure pipelines, the corresponding domain and resources are commented out in prod
+      # - Auth
+      # - Manage
+      # - Oidc
+    - Accounts${Endpoint}ProdHostedZone:
+        Type: AWS::Route53::HostedZone
+        Condition: CreateProductionEnvironmentResources
+        DeletionPolicy: Retain
+        UpdateReplacePolicy: Retain
+        Properties:
+          Name: !Sub ${Endpoint}${EndpointSuffix}.account.gov.uk
+
+      Accounts${Endpoint}ProdHostedZoneSSM:
+        Type: AWS::SSM::Parameter
+        Condition: CreateProductionEnvironmentResources
+        Properties:
+          Description: !Sub "The ${Endpoint} subdomain Public Hosted Zone Id"
+          Name: !Sub
+            - "/deploy/${Environment}/${lowercaseEndpoint}_route53_hostedzone_id"
+            - lowercaseEndpoint: !FindInMap
+              - EndpointConfigs
+              - !Ref Endpoint
+              - lowercaseName
+          Type: String
+          Value: !Ref
+            Fn::Sub: Accounts${Endpoint}ProdHostedZone
+          Tags:
+            Environment: !Ref Environment
+            Application: "auth-frontend"
+            Source: govuk-one-login/authentication-frontend/cloudformation/domains/template.yaml
+
+      Accounts${Endpoint}ProdCertificate:
+        Type: AWS::CertificateManager::Certificate
+        Condition: CreateProductionEnvironmentResources
+        Properties:
+          DomainName: !Sub ${Endpoint}${EndpointSuffix}.account.gov.uk
+          DomainValidationOptions:
+            - DomainName: !Sub ${Endpoint}${EndpointSuffix}.account.gov.uk
+              HostedZoneId: !GetAtt
+                - !Sub Accounts${Endpoint}ProdHostedZone
+                - Id
+          ValidationMethod: DNS
+
+      Accounts${Endpoint}ProdCertificateArnSSM:
+        Type: AWS::SSM::Parameter
+        Condition: CreateProductionEnvironmentResources
+        Properties:
+          Description: !Sub "The ${Endpoint} subdomain Certificate ARN"
+          Name: !Sub
+            - "/deploy/${Environment}/${lowercaseEndpoint}_certificate_arn"
+            - lowercaseEndpoint: !FindInMap
+              - EndpointConfigs
+              - !Ref Endpoint
+              - lowercaseName
+          Type: String
+          Value: !Ref
+            Fn::Sub: Accounts${Endpoint}ProdCertificate
           Tags:
             Environment: !Ref Environment
             Application: "auth-frontend"


### PR DESCRIPTION
## What

1. New prod env transitional domains, certs and SSM params
2. Nginx sidecar temporarily deployed in prod to block public access
3. Disable CSLS log forwarding from WAF deployed to us-east-1

Issue: [AUT-3545]

[AUT-3545]: https://govukverify.atlassian.net/browse/AUT-3545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ