### PR TITLE
BAU: Group some npm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,19 @@ updates:
       - dependency-name: "node"
         versions: ["17.x", "19.x", "20.x"]
     groups:
+      npm-aws-dependencies:
+        patterns:
+          - "@aws-sdk/*"
+      npm-express-dependencies:
+        patterns:
+          - "express"
+          - "express-session"
+          - "express-validator"
+          - "@types/express"
+          - "@types/express-session"
+      npm-otplib-dependencies:
+        patterns:
+          - "@otplib/*"
       npm-patch-dependencies:
         update-types:
           - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     ignore:
       - dependency-name: "node"
         versions: ["17.x", "19.x", "20.x"]
+    groups:
+      npm-patch-dependencies:
+        update-types:
+          - patch
     open-pull-requests-limit: 100
     commit-message:
       prefix: BAU


### PR DESCRIPTION
## What

### Group all dependabot update npm patch dependencies
As patch bumps are the least likely to impact our use of a dependency, they should be a relatively safe initial grouping to attempt to lower the number of dependabot PRs we need to rebase/review/merge.

The current problem is we get daily PRs for patch bumps, and they end up being out of date with the `main` as a previous dependabot PR merges. This means it's currently a lengthy process of:

- Dep A: approve
- Dep B: approve
- Dep C: approve
- Dep A: merged
- Dep B: out of date
- Dep C: out of date
- Dep B: rebase
- Dep C: rebase
- Dep B: approve
- Dep B: merged
- Dep C: out of date
- Dep C: rebase
- Dep C: approve
- Dep C: merged


### Group dependabot updates of aws, express and otplib dependencies
As these dependency groupings are closely related and interdependent this groups their dependabot update PRs for all semver bumps.


## How to review

1. Code Review
