### PR TITLE
BAU: exclude all `tests` directories from `tsc`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "typeRoots": ["@types", "/node_modules/@types"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["test", "coverage", "src/components/**/tests"]
+  "exclude": ["test", "coverage", "src/**/tests", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## What

- Exclude all directories called `tests` under `./src/` from tsc compilation
- Exclude all files under `./src/` called `*.test.ts` from tsc compilation

## How to review

- Run `docker build . --build-context oneagent_codemodules=docker-image://dynatrace/dynatrace-codemodules:1.301.54.20241017-161011`, observe that no errors occur and the image is built correctly
- Check the new glob patterns make sense
