### PR TITLE
AUT-3545: basic auth sidecar image URI in prod env mapping

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -246,6 +246,7 @@ Mappings:
         -----END PUBLIC KEY-----
       redisNodeSize: cache.t2.small
     production:
+      basicAuthSidecarURI: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/basic-auth-sidecar-image-repository-containerrepository-s9nnygnutubd"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       frontendAutoScalingMinCount: 4
       frontendAutoScalingMaxCount: 240


### PR DESCRIPTION
## What

Added missing basic auth sidecar image URI in prod env mapping
Sidecar is temporarily deployed in prod to block public access

Issue: [AUT-3545]

[AUT-3545]: https://govukverify.atlassian.net/browse/AUT-3545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ