### PR TITLE
BAU: Grouping pino dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
       - dependency-name: "node"
         versions: ["17.x", "19.x", "20.x"]
     groups:
+      npm-pino-dependencies:
+        patterns:
+          - "pino"
+          - "pino-http"
+          - "pino-pretty"
+          - "@types/pino-pretty"
       npm-aws-dependencies:
         patterns:
           - "@aws-sdk/*"


### PR DESCRIPTION
## What

As they are closely related and previous attempts to upgrade required both `pino` and `pino-http` to be upgraded at the same time.

This should help organise these PRs a bit more.

## How to review

1. Code Review
