### PR TITLE
AUT-3545: enable ECS canary in prod (step 2)

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -91,6 +91,9 @@ Conditions:
               - !Ref Environment
               - "integration"
           - Fn::Equals:
+              - !Ref Environment
+              - "production"
+          - Fn::Equals:
               - !Ref SubEnvironment
               - "authdev1"
 


### PR DESCRIPTION
## What

Enable ECS canary in prod (step 2). This change shifts control of deployment from ECS Service to CodeDeploy.
Based on [ECS canary migration guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance)

Issue: [AUT-3545], [AUT-3494]

[AUT-3545]: https://govukverify.atlassian.net/browse/AUT-3545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-3494]: https://govukverify.atlassian.net/browse/AUT-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ