### PR TITLE
AUT-3823: Implement call to MFA reset authorize API to redirect to IPV Core

### DIFF
--- a/ci/terraform/dev.tfvars
+++ b/ci/terraform/dev.tfvars
@@ -28,6 +28,7 @@ reduced_code_block_duration_minutes                 = "0.5"
 url_for_support_links                               = "https://home.dev.account.gov.uk/contact-gov-uk-one-login"
 language_toggle_enabled                             = "1"
 no_photo_id_contact_forms                           = "1"
+support_mfa_reset_with_ipv                          = "1"
 
 logging_endpoint_arns = []
 

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -203,6 +203,10 @@ locals {
       {
         name  = "SUPPORT_HTTP_KEEP_ALIVE"
         value = var.support_http_keep_alive
+      },
+      {
+        name  = "SUPPORT_MFA_RESET_WITH_IPV"
+        value = var.support_mfa_reset_with_ipv
       }
     ]
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -426,3 +426,9 @@ variable "support_http_keep_alive" {
   default     = "0"
   description = "Switch on http keep alive for axios"
 }
+
+variable "support_mfa_reset_with_ipv" {
+  type        = string
+  default     = "0"
+  description = "Switch to support the IPV prove identity journey when resetting the mfa"
+}

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -97,6 +97,11 @@ Conditions:
               - !Ref SubEnvironment
               - "authdev1"
 
+  UseMfaResetWithIpv:
+    Fn::Equals:
+        - !Ref Environment
+        - "dev"
+
   UseSubEnvironment:
     Fn::And:
       - Fn::Equals:
@@ -728,7 +733,7 @@ Resources:
             - Name: SUPPORT_NEW_IPV_SPINNER
               Value: !If [IsNotProduction, "1", "0"]
             - Name: SUPPORT_MFA_RESET_WITH_IPV
-              Value: 0
+              Value: !If [UseMfaResetWithIpv, "1", "0"]
           Secrets:
             - Name: API_KEY
               ValueFrom: !If

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -727,6 +727,8 @@ Resources:
                 ]
             - Name: SUPPORT_NEW_IPV_SPINNER
               Value: !If [IsNotProduction, "1", "0"]
+            - Name: SUPPORT_MFA_RESET_WITH_IPV
+              Value: 0
           Secrets:
             - Name: API_KEY
               ValueFrom: !If

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -145,6 +145,7 @@ export const API_ENDPOINTS = {
   ACCOUNT_RECOVERY: "/account-recovery",
   CHECK_REAUTH_USER: "/check-reauth-user",
   CHECK_EMAIL_FRAUD_BLOCK: "/check-email-fraud-block",
+  MFA_RESET_AUTHORIZE: "/mfa-reset-authorize",
 };
 
 export const ERROR_MESSAGES = {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -73,6 +73,7 @@ export const PATH_NAMES = {
   UNAVAILABLE_PERMANENT: "/unavailable-permanent",
   UNAVAILABLE_TEMPORARY: "/unavailable-temporary",
   RESET_PASSWORD_2FA_AUTH_APP: "/reset-password-2fa-auth-app",
+  MFA_RESET_WITH_IPV: "/mfa-reset-with-ipv",
 };
 
 export const CONTENT_IDS: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import {
   supportAccountInterventions,
   supportAccountRecovery,
   supportAuthorizeController,
+  supportMfaResetWithIpv,
 } from "./config";
 import { logErrorMiddleware } from "./middleware/log-error-middleware";
 import { getCookieLanguageMiddleware } from "./middleware/cookie-lang-middleware";
@@ -98,6 +99,7 @@ import { applyOverloadProtection } from "./middleware/overload-protection-middle
 import { frontendVitalSignsInit } from "@govuk-one-login/frontend-vital-signs";
 import { Server } from "node:http";
 import { getAnalyticsPropertiesMiddleware } from "./middleware/get-analytics-properties-middleware";
+import { mfaResetWithIpvRouter } from "./components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -152,6 +154,9 @@ function registerRoutes(app: express.Application) {
     app.use(accountInterventionRouter);
     app.use(permanentlyBlockedRouter);
     app.use(temporarilyBlockedRouter);
+  }
+  if (supportMfaResetWithIpv()) {
+    app.use(mfaResetWithIpvRouter);
   }
 }
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -415,6 +415,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_INVALID,
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES,
+            PATH_NAMES.MFA_RESET_WITH_IPV,
           ],
         },
       },

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -438,6 +438,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_INVALID,
             PATH_NAMES.CHECK_YOUR_EMAIL,
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES,
+            PATH_NAMES.MFA_RESET_WITH_IPV,
           ],
         },
       },

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -195,7 +195,7 @@ function handleAuthAppCodePostError(
       return handleReauthFailure(req, res);
     } else {
       throw new ReauthJourneyError(
-        "Reauth erorr response returned on a non reauth journey"
+        "Reauth error response returned on a non reauth journey"
       );
     }
   }

--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -27,7 +27,7 @@
 
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
         <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
-        <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
+        <input type="hidden" name="mfaResetPath" value="{{mfaResetPath}}"/>
 
         {{ govukInput({
             label: {
@@ -58,7 +58,7 @@
         {% set detailsHTML %}
             <p class="govuk-body">
                 {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
-                <a href="{{checkEmailLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+                <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
             </p>
         {% endset %}
 

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -13,7 +13,7 @@
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
-    <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
+    <input type="hidden" name="mfaResetPath" value="{{mfaResetPath}}"/>
 
     {{ govukInput({
       label: {
@@ -44,7 +44,7 @@
     {% set detailsHTML %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
-        <a href="{{checkEmailLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+        <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
       </p>
     {% endset %}
 

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -17,6 +17,17 @@ import { VerifyMfaCodeInterface } from "../types";
 import * as journey from "../../common/journey/journey";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
 
+const fakeAccountRecoveryService = (accountRecoveryPermitted: boolean) => {
+  return {
+    accountRecovery: sinon.fake.returns({
+      success: true,
+      data: {
+        accountRecoveryPermitted: accountRecoveryPermitted,
+      },
+    }),
+  } as unknown as AccountRecoveryInterface;
+};
+
 describe("enter authenticator app code controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
@@ -36,16 +47,7 @@ describe("enter authenticator app code controller", () => {
     it("should render enter mfa code view with isAccountRecoveryPermitted true when user is permitted to perform account recovery, account recovery is enabled for environment and mfa reset with ipv is not enabled", async () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = "0";
 
-      const fakeService: AccountRecoveryInterface = {
-        accountRecovery: sinon.fake.returns({
-          success: true,
-          data: {
-            accountRecoveryPermitted: true,
-          },
-        }),
-      } as unknown as AccountRecoveryInterface;
-
-      await enterAuthenticatorAppCodeGet(fakeService)(
+      await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(true))(
         req as Request,
         res as Response
       );
@@ -62,16 +64,7 @@ describe("enter authenticator app code controller", () => {
     });
 
     it("should render enter mfa code view with isAccountRecoveryPermitted false when user is not permitted to perform account recovery", async () => {
-      const fakeService: AccountRecoveryInterface = {
-        accountRecovery: sinon.fake.returns({
-          success: true,
-          data: {
-            accountRecoveryPermitted: false,
-          },
-        }),
-      } as unknown as AccountRecoveryInterface;
-
-      await enterAuthenticatorAppCodeGet(fakeService)(
+      await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(false))(
         req as Request,
         res as Response
       );
@@ -89,16 +82,8 @@ describe("enter authenticator app code controller", () => {
 
     it("should render enter mfa code view with isAccountRecoveryPermitted false when account recovery is disable for the environment", async () => {
       process.env.SUPPORT_ACCOUNT_RECOVERY = "0";
-      const fakeService: AccountRecoveryInterface = {
-        accountRecovery: sinon.fake.returns({
-          success: true,
-          data: {
-            accountRecoveryPermitted: true,
-          },
-        }),
-      } as unknown as AccountRecoveryInterface;
 
-      await enterAuthenticatorAppCodeGet(fakeService)(
+      await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(true))(
         req as Request,
         res as Response
       );
@@ -114,16 +99,7 @@ describe("enter authenticator app code controller", () => {
     it("should render 2fa service uplift view when uplift is required ", async () => {
       req.session.user.isUpliftRequired = true;
 
-      const fakeService: AccountRecoveryInterface = {
-        accountRecovery: sinon.fake.returns({
-          success: true,
-          data: {
-            accountRecoveryPermitted: true,
-          },
-        }),
-      } as unknown as AccountRecoveryInterface;
-
-      await enterAuthenticatorAppCodeGet(fakeService)(
+      await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(true))(
         req as Request,
         res as Response
       );
@@ -142,16 +118,7 @@ describe("enter authenticator app code controller", () => {
     it("should render default template when uplift is not required", async () => {
       req.session.user.isUpliftRequired = false;
 
-      const fakeService: AccountRecoveryInterface = {
-        accountRecovery: sinon.fake.returns({
-          success: true,
-          data: {
-            accountRecoveryPermitted: true,
-          },
-        }),
-      } as unknown as AccountRecoveryInterface;
-
-      await enterAuthenticatorAppCodeGet(fakeService)(
+      await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(true))(
         req as Request,
         res as Response
       );
@@ -170,16 +137,7 @@ describe("enter authenticator app code controller", () => {
     it("should render enter authenticator app code view with mfaResetPath being IPV_DUMMY_URL when mfa reset with ipv is supported", async () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
 
-      const fakeService: AccountRecoveryInterface = {
-        accountRecovery: sinon.fake.returns({
-          success: true,
-          data: {
-            accountRecoveryPermitted: true,
-          },
-        }),
-      } as unknown as AccountRecoveryInterface;
-
-      await enterAuthenticatorAppCodeGet(fakeService)(
+      await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(true))(
         req as Request,
         res as Response
       );

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -28,6 +28,21 @@ const fakeAccountRecoveryService = (accountRecoveryPermitted: boolean) => {
   } as unknown as AccountRecoveryInterface;
 };
 
+const fakeVerifyMfaCodeService = (errorCode?: number) => {
+  return {
+    verifyMfaCode: sinon.fake.returns({
+      success: errorCode === undefined,
+      data:
+        errorCode !== undefined
+          ? {
+              code: errorCode,
+              message: "",
+            }
+          : null,
+    }),
+  } as unknown as VerifyMfaCodeInterface;
+};
+
 describe("enter authenticator app code controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
@@ -154,11 +169,7 @@ describe("enter authenticator app code controller", () => {
 
   describe("enterAuthenticatorAppCodePost", () => {
     it("can send the journeyType when verifying the code", async () => {
-      const fakeService: VerifyMfaCodeInterface = {
-        verifyMfaCode: sinon.fake.returns({
-          success: true,
-        }),
-      } as unknown as VerifyMfaCodeInterface;
+      const fakeService = fakeVerifyMfaCodeService();
 
       const getJourneyTypeFromUserSessionSpy = sinon.spy(
         journey,
@@ -195,11 +206,7 @@ describe("enter authenticator app code controller", () => {
     });
 
     it("should redirect to /auth-code when valid code entered", async () => {
-      const fakeService: VerifyMfaCodeInterface = {
-        verifyMfaCode: sinon.fake.returns({
-          success: true,
-        }),
-      } as unknown as VerifyMfaCodeInterface;
+      const fakeService = fakeVerifyMfaCodeService();
 
       req.body.code = "123456";
       res.locals.sessionId = "123456-djjad";
@@ -214,15 +221,9 @@ describe("enter authenticator app code controller", () => {
     });
 
     it("should return error when invalid code entered", async () => {
-      const fakeService: VerifyMfaCodeInterface = {
-        verifyMfaCode: sinon.fake.returns({
-          success: false,
-          data: {
-            code: ERROR_CODES.AUTH_APP_INVALID_CODE,
-            message: "",
-          },
-        }),
-      } as unknown as VerifyMfaCodeInterface;
+      const fakeService = fakeVerifyMfaCodeService(
+        ERROR_CODES.AUTH_APP_INVALID_CODE
+      );
 
       req.t = sinon.fake.returns("translated string");
       req.body.code = "678988";
@@ -240,15 +241,9 @@ describe("enter authenticator app code controller", () => {
     });
 
     it("should redirect to security code expired when invalid authenticator app code entered more than max retries", async () => {
-      const fakeService: VerifyMfaCodeInterface = {
-        verifyMfaCode: sinon.fake.returns({
-          data: {
-            code: ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED,
-            message: "",
-          },
-          success: false,
-        }),
-      } as unknown as VerifyMfaCodeInterface;
+      const fakeService = fakeVerifyMfaCodeService(
+        ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED
+      );
 
       req.t = sinon.fake.returns("translated string");
       req.body.code = "678988";
@@ -267,15 +262,9 @@ describe("enter authenticator app code controller", () => {
 
     it("should redirect to orchestration with error require login reauth journey than max retries", async () => {
       process.env.SUPPORT_REAUTHENTICATION = "1";
-      const fakeService: VerifyMfaCodeInterface = {
-        verifyMfaCode: sinon.fake.returns({
-          data: {
-            code: ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED,
-            message: "",
-          },
-          success: false,
-        }),
-      } as unknown as VerifyMfaCodeInterface;
+      const fakeService = fakeVerifyMfaCodeService(
+        ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED
+      );
 
       req.t = sinon.fake.returns("translated string");
       req.body.code = "678988";
@@ -296,15 +285,9 @@ describe("enter authenticator app code controller", () => {
 
     it("should redirect to orchestration with error required login reauth journey on reauth sign in details exceeded", async () => {
       process.env.SUPPORT_REAUTHENTICATION = "1";
-      const fakeService: VerifyMfaCodeInterface = {
-        verifyMfaCode: sinon.fake.returns({
-          data: {
-            code: ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED,
-            message: "",
-          },
-          success: false,
-        }),
-      } as unknown as VerifyMfaCodeInterface;
+      const fakeService = fakeVerifyMfaCodeService(
+        ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED
+      );
 
       req.t = sinon.fake.returns("translated string");
       req.body.code = "678988";

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -29,10 +29,13 @@ describe("enter authenticator app code controller", () => {
 
   afterEach(() => {
     sinon.restore();
+    delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
   });
 
   describe("enterAuthenticatorAppCodeGet", () => {
-    it("should render enter mfa code view with isAccountRecoveryPermitted true when user is permitted to perform account recovery and account recovery is enabled for environment", async () => {
+    it("should render enter mfa code view with isAccountRecoveryPermitted true when user is permitted to perform account recovery, account recovery is enabled for environment and mfa reset with ipv is not enabled", async () => {
+      process.env.SUPPORT_MFA_RESET_WITH_IPV = "0";
+
       const fakeService: AccountRecoveryInterface = {
         accountRecovery: sinon.fake.returns({
           success: true,
@@ -51,7 +54,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: true,
-          checkEmailLink:
+          mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
         }
@@ -77,7 +80,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: false,
-          checkEmailLink:
+          mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
         }
@@ -129,7 +132,7 @@ describe("enter authenticator app code controller", () => {
         UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME,
         {
           isAccountRecoveryPermitted: true,
-          checkEmailLink:
+          mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
         }
@@ -157,9 +160,35 @@ describe("enter authenticator app code controller", () => {
         ENTER_AUTH_APP_CODE_DEFAULT_TEMPLATE_NAME,
         {
           isAccountRecoveryPermitted: true,
-          checkEmailLink:
+          mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
+        }
+      );
+    });
+
+    it("should render enter authenticator app code view with mfaResetPath being IPV_DUMMY_URL when mfa reset with ipv is supported", async () => {
+      process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+
+      const fakeService: AccountRecoveryInterface = {
+        accountRecovery: sinon.fake.returns({
+          success: true,
+          data: {
+            accountRecoveryPermitted: true,
+          },
+        }),
+      } as unknown as AccountRecoveryInterface;
+
+      await enterAuthenticatorAppCodeGet(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.calledWith(
+        "enter-authenticator-app-code/index.njk",
+        {
+          isAccountRecoveryPermitted: true,
+          mfaResetPath: PATH_NAMES.MFA_RESET_WITH_IPV,
         }
       );
     });

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -26,7 +26,7 @@
     <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="supportAccountRecovery" value="{{supportAccountRecovery}}"/>
-    <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
+    <input type="hidden" name="mfaResetPath" value="{{mfaResetPath}}"/>
 
     {{ govukInput({
   label: {
@@ -53,7 +53,7 @@
     {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
         <p class="govuk-body">
             {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
-            <a href={{ checkEmailLink }} class="govuk-link"
+            <a href={{ mfaResetPath }} class="govuk-link"
                rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
         </p>
     {% endif %}

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -42,7 +42,6 @@ describe("enter mfa controller", () => {
     req.session.user = { redactedPhoneNumber: TEST_PHONE_NUMBER };
     res = mockResponse();
     process.env.SUPPORT_ACCOUNT_RECOVERY = "1";
-    process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "0";
   });
 
   afterEach(() => {

--- a/src/components/mfa-reset-with-ipv/mfa-reset-authorize-service.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-authorize-service.ts
@@ -1,0 +1,43 @@
+import { MfaResetAuthorizeInterface, MfaResetAuthorizeResponse } from "./types";
+import {
+  createApiResponse,
+  getInternalRequestConfigWithSecurityHeaders,
+  http,
+  Http,
+} from "../../utils/http";
+import { ApiResponseResult } from "../../types";
+import { API_ENDPOINTS } from "../../app.constants";
+import { Request } from "express";
+
+export function mfaResetAuthorizeService(
+  axios: Http = http
+): MfaResetAuthorizeInterface {
+  const ipvRedirectUrl = async function (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request,
+    email: string
+  ): Promise<ApiResponseResult<MfaResetAuthorizeResponse>> {
+    const config = getInternalRequestConfigWithSecurityHeaders(
+      {
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        persistentSessionId: persistentSessionId,
+      },
+      req,
+      API_ENDPOINTS.MFA_RESET_AUTHORIZE
+    );
+
+    const response = await axios.client.post<MfaResetAuthorizeResponse>(
+      API_ENDPOINTS.MFA_RESET_AUTHORIZE,
+      { email },
+      config
+    );
+    return createApiResponse<MfaResetAuthorizeResponse>(response);
+  };
+
+  return {
+    ipvRedirectUrl: ipvRedirectUrl,
+  };
+}

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -1,0 +1,30 @@
+import { MfaResetAuthorizeInterface } from "./types";
+import { mfaResetAuthorizeService } from "./mfa-reset-authorize-service";
+import { ExpressRouteFunc } from "../../types";
+import { Request, Response } from "express";
+import { BadRequestError } from "../../utils/error";
+
+export function mfaResetWithIpvGet(
+  service: MfaResetAuthorizeInterface = mfaResetAuthorizeService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { email } = req.session.user;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const result = await service.ipvRedirectUrl(
+      sessionId,
+      clientSessionId,
+      persistentSessionId,
+      req,
+      email
+    );
+
+    if (!result.success) {
+      throw new BadRequestError(result.data.message, result.data.code);
+    }
+
+    const ipvCoreURL = result.data.authorize_url;
+
+    res.redirect(ipvCoreURL);
+  };
+}

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes.ts
@@ -1,0 +1,17 @@
+import express from "express";
+import { PATH_NAMES } from "../../app.constants";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { asyncHandler } from "../../utils/async";
+import { mfaResetWithIpvGet } from "./mfa-reset-with-ipv-controller";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.MFA_RESET_WITH_IPV,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(mfaResetWithIpvGet())
+);
+
+export { router as mfaResetWithIpvRouter };

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-authorize-service.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-authorize-service.test.ts
@@ -1,0 +1,65 @@
+import { describe } from "mocha";
+import sinon, { SinonStub } from "sinon";
+import { MfaResetAuthorizeInterface } from "../types";
+import {
+  checkApiCallMadeWithExpectedBodyAndHeaders,
+  expectedHeadersFromCommonVarsWithSecurityHeaders,
+  requestHeadersWithIpAndAuditEncoded,
+  resetApiKeyAndBaseUrlEnvVars,
+  setupApiKeyAndBaseUrlEnvVars,
+} from "../../../../test/helpers/service-test-helper";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
+import { Http } from "../../../utils/http";
+import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { commonVariables } from "../../../../test/helpers/common-test-variables";
+import { mfaResetAuthorizeService } from "../mfa-reset-authorize-service";
+
+describe("mfa reset authorize service", () => {
+  const http = new Http();
+  const service: MfaResetAuthorizeInterface = mfaResetAuthorizeService(http);
+  let postStub: SinonStub;
+  const { sessionId, clientSessionId, email, diPersistentSessionId } =
+    commonVariables;
+  const req = createMockRequest(PATH_NAMES.ENTER_MFA, {
+    headers: requestHeadersWithIpAndAuditEncoded,
+  });
+  const axiosResponse = Promise.resolve({
+    data: {},
+    status: 200,
+    statusText: "OK",
+  });
+
+  beforeEach(() => {
+    setupApiKeyAndBaseUrlEnvVars();
+    postStub = sinon.stub(http.client, "post");
+    postStub.resolves(axiosResponse);
+  });
+
+  afterEach(() => {
+    postStub.reset();
+    resetApiKeyAndBaseUrlEnvVars();
+  });
+
+  it("successfully calls the mfa reset authorize API", async () => {
+    const result = await service.ipvRedirectUrl(
+      sessionId,
+      clientSessionId,
+      diPersistentSessionId,
+      req,
+      email
+    );
+
+    const expectedApiCallDetails = {
+      expectedPath: API_ENDPOINTS.MFA_RESET_AUTHORIZE,
+      expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+      expectedBody: { email },
+    };
+
+    checkApiCallMadeWithExpectedBodyAndHeaders(
+      result,
+      postStub,
+      true,
+      expectedApiCallDetails
+    );
+  });
+});

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
@@ -1,0 +1,60 @@
+import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
+import sinon from "sinon";
+import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { HTTP_STATUS_CODES, PATH_NAMES } from "../../../app.constants";
+import { mfaResetWithIpvGet } from "../mfa-reset-with-ipv-controller";
+import { expect } from "chai";
+import { MfaResetAuthorizeInterface } from "../types";
+import { Request, Response } from "express";
+import { BadRequestError } from "../../../utils/error";
+
+const IPV_DUMMY_URL =
+  "https://test-idp-url.com/callback?code=123-4ddkk0sdkkd-ad";
+
+const fakeMfaResetAuthorizeService = (successfulAuthorizeResponse: boolean) => {
+  return {
+    ipvRedirectUrl: sinon.fake.returns({
+      success: successfulAuthorizeResponse,
+      data: {
+        authorize_url: successfulAuthorizeResponse ? IPV_DUMMY_URL : null,
+        code: successfulAuthorizeResponse
+          ? HTTP_STATUS_CODES.OK
+          : HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
+        message: successfulAuthorizeResponse ? null : "Test error message",
+      },
+    }),
+  } as unknown as MfaResetAuthorizeInterface;
+};
+
+describe("mfa reset with ipv controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = createMockRequest(PATH_NAMES.MFA_RESET_WITH_IPV);
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("mfaResetWithIpvGet", async () => {
+    it("should redirect to ipv when request is made to the MFA Reset Authorize endpoint successfully", async () => {
+      await mfaResetWithIpvGet(fakeMfaResetAuthorizeService(true))(
+        req as Request,
+        res as Response
+      );
+      expect(res.redirect).to.have.been.calledWith(IPV_DUMMY_URL);
+    });
+
+    it("should throw a BadRequestError when the request made to the MFA Reset Authorize endpoint is not successful", async () => {
+      await expect(
+        mfaResetWithIpvGet(fakeMfaResetAuthorizeService(false))(
+          req as Request,
+          res as Response
+        )
+      ).to.be.rejectedWith(BadRequestError, "500:Test error message");
+    });
+  });
+});

--- a/src/components/mfa-reset-with-ipv/types.ts
+++ b/src/components/mfa-reset-with-ipv/types.ts
@@ -1,0 +1,16 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { Request } from "express";
+
+export interface MfaResetAuthorizeResponse extends DefaultApiResponse {
+  authorize_url: string;
+}
+
+export interface MfaResetAuthorizeInterface {
+  ipvRedirectUrl: (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request,
+    email: string
+  ) => Promise<ApiResponseResult<MfaResetAuthorizeResponse>>;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,3 +194,7 @@ export function supportHttpKeepAlive(): boolean {
 export function isValidChannel(channel: string): boolean {
   return channel === CHANNEL.WEB || channel === CHANNEL.STRATEGIC_APP;
 }
+
+export function supportMfaResetWithIpv(): boolean {
+  return process.env.SUPPORT_MFA_RESET_WITH_IPV === "1";
+}


### PR DESCRIPTION
## What

Created a service to call the MfaResetAuthorizeHandler API in the backend. If the request is successful, the API returns a URL to redirect the user to IPV Core's prove identity journey. This service is called when the user clicks the "change how you get security codes" link on the enter mfa pages.

## How to review

1. Code review
2. Deploy this PR and relate auth API PR to dev environment
3. See that the JWT does a thing

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/5535