### PR TITLE
AUT-3756: Use tini as PID 1

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+yarn start


### PR DESCRIPTION
## What

Rather than running Node.js directly as PID 1, we use tini to ensure
that signals are properly forwarded to the app process.

Additionally, move the `yarn start` command to a separate script for
visibility. This part is not strictly necessary, but it makes me happier
to not have raw shell commands within the Dockerfile.

## How to review

1. Ensure the container still builds locally:

   ```sh
   docker build . --build-context oneagent_codemodules="$(mktemp -d)" -t  auth-frontend:aut-3756
   ```

1. Deploy to the `dev` environment, check it still runs and exits correctly.
