### PR TITLE
BAU: Upgrade GOV.UK Frontend Analytics package to v3

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -52,5 +52,5 @@ orch_stub_to_auth_audience           = "https://signin.authdev1.sandpit.account.
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-ua_disabled             = "false"
+ua_enabled              = "true"
 analytics_cookie_domain = ".sandpit.account.gov.uk"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -57,5 +57,5 @@ orch_stub_to_auth_audience           = "https://signin.authdev2.sandpit.account.
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-ua_disabled             = "false"
+ua_enabled              = "true"
 analytics_cookie_domain = ".sandpit.account.gov.uk"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -44,5 +44,5 @@ cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 cloudfront_WafAcl_Logdestination = "csls_cw_logs_destination_prodpython"
 
-ua_disabled             = "false"
+ua_enabled              = "true"
 analytics_cookie_domain = ".build.account.gov.uk"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -177,12 +177,12 @@ locals {
         value = var.prove_identity_welcome_enabled
       },
       {
-        name  = "GA4_DISABLED"
-        value = var.ga4_disabled
+        name  = "GA4_ENABLED"
+        value = var.ga4_enabled
       },
       {
-        name  = "UA_DISABLED"
-        value = var.ua_disabled
+        name  = "UA_ENABLED"
+        value = var.ua_enabled
       },
       {
         name  = "UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -40,5 +40,5 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.integration.account.gov.uk/"
 
-ua_disabled             = "false"
+ua_enabled              = "true"
 analytics_cookie_domain = ".integration.account.gov.uk"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -42,8 +42,8 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.account.gov.uk/"
 
-ua_disabled                          = "false"
+ua_enabled                           = "true"
 universal_analytics_gtm_container_id = "GTM-TT5HDKV"
-ga4_disabled                         = "false"
+ga4_enabled                          = "true"
 google_analytics_4_gtm_container_id  = "GTM-K4PBJH3"
 analytics_cookie_domain              = ".account.gov.uk"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -50,5 +50,5 @@ logging_endpoint_arns = [
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-ua_disabled             = "false"
+ua_enabled              = "true"
 analytics_cookie_domain = ".sandpit.account.gov.uk"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -42,8 +42,8 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.staging.account.gov.uk/"
 
-ua_disabled                          = "false"
+ua_enabled                           = "true"
 universal_analytics_gtm_container_id = "GTM-TK92W68"
-ga4_disabled                         = "false"
+ga4_enabled                          = "true"
 google_analytics_4_gtm_container_id  = "GTM-KD86CMZ"
 analytics_cookie_domain              = ".staging.account.gov.uk"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -385,15 +385,15 @@ variable "language_toggle_enabled" {
   description = "Enables English / Welsh language toggle in the user interface"
 }
 
-variable "ga4_disabled" {
+variable "ga4_enabled" {
   type        = string
-  default     = "true"
+  default     = "false"
   description = "Enables Google Analytics 4"
 }
 
-variable "ua_disabled" {
+variable "ua_enabled" {
   type        = string
-  default     = "true"
+  default     = "false"
   description = "Enables Universal Analytics"
 }
 

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -710,10 +710,10 @@ Resources:
               Value: 1
             - Name: PROVE_IDENTITY_WELCOME_ENABLED
               Value: 0
-            - Name: GA4_DISABLED
-              Value: true
-            - Name: UA_DISABLED
+            - Name: GA4_ENABLED
               Value: false
+            - Name: UA_ENABLED
+              Value: true
             - Name: UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID
               Value: GTM-TK92W68
             - Name: GOOGLE_ANALYTICS_4_GTM_CONTAINER_ID

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@aws-sdk/client-ssm": "^3.366.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.14.0",
-    "@govuk-one-login/frontend-analytics": "2.0.1",
+    "@govuk-one-login/frontend-analytics": "3.0.1",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "^1.1.1",
     "@govuk-one-login/frontend-vital-signs": "0.0.4",

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -127,12 +127,12 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
     {
         "header": "Analytics",
         "variables": {
-            "GA4_DISABLED": {
-                "value": "false",
+            "GA4_ENABLED": {
+                "value": "true",
                 "comment": "GA4 Enablement",
             },
-            "UA_DISABLED": {
-                "value": "false",
+            "UA_ENABLED": {
+                "value": "true",
                 "comment": "Univeral Analytics",
             },
             "UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID": {

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -177,8 +177,8 @@
                         uaContainerId: "{{uaContainerId}}"
                     }, {
                         isDataSensitive: false,
-                        disableGa4Tracking: {{isGa4Disabled}},
-                        disableUaTracking: {{isUaDisabled}},
+                        enableGa4Tracking: {{isGa4Enabled}},
+                        enableUaTracking: {{isUaEnabled}},
                         cookieDomain: "{{analyticsCookieDomain}}"
                     });
             }

--- a/src/config.ts
+++ b/src/config.ts
@@ -173,12 +173,12 @@ export function getGTMContainerID(): string {
   return process.env.UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID || "";
 }
 
-export function googleAnalytics4Disabled(): string {
-  return process.env.GA4_DISABLED || "true";
+export function googleAnalytics4Enabled(): string {
+  return process.env.GA4_ENABLED || "false";
 }
 
-export function universalAnalyticsDisabled(): string {
-  return process.env.UA_DISABLED || "false";
+export function universalAnalyticsEnabled(): string {
+  return process.env.UA_ENABLED || "false";
 }
 export function proveIdentityWelcomeEnabled(): boolean {
   return process.env.PROVE_IDENTITY_WELCOME_ENABLED === "1";

--- a/src/middleware/analytics-middleware.ts
+++ b/src/middleware/analytics-middleware.ts
@@ -3,14 +3,14 @@ import {
   getAnalyticsCookieDomain,
   getGA4ContainerId,
   getGTMContainerID,
-  googleAnalytics4Disabled,
-  universalAnalyticsDisabled,
+  googleAnalytics4Enabled,
+  universalAnalyticsEnabled,
 } from "../config";
 export function setGTM(req: Request, res: Response, next: NextFunction): void {
   res.locals.ga4ContainerId = getGA4ContainerId();
   res.locals.uaContainerId = getGTMContainerID();
   res.locals.analyticsCookieDomain = getAnalyticsCookieDomain();
-  res.locals.isGa4Disabled = googleAnalytics4Disabled();
-  res.locals.isUaDisabled = universalAnalyticsDisabled();
+  res.locals.isGa4Enabled = googleAnalytics4Enabled();
+  res.locals.isUaEnabled = universalAnalyticsEnabled();
   next();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,12 +876,13 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@govuk-one-login/frontend-analytics@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-2.0.1.tgz#ff843241de1d1475407f719fb3f0f7180fc62dc1"
-  integrity sha512-8xAsQrRomVYxedFOQ8JDVdYx1JReJevSjU5EDZlcS/x3PhpCxm9DHjEqyOIvTo34zkFFoI4f2um6YkdD9IRQAg==
+"@govuk-one-login/frontend-analytics@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.0.1.tgz#3dcf4a117abca0823a11e7190f37c335c464d41d"
+  integrity sha512-Si1ZHG+RV4JBdDBH2bAAJFHRxnukExeix/JOL12prMThUkLsnZbamgPUAcVoByZRydYYXzilJgRw7PNiO1g1Kg==
   dependencies:
     copy-webpack-plugin "^12.0.2"
+    loglevel "^1.9.1"
 
 "@govuk-one-login/frontend-language-toggle@^1.1.0":
   version "1.1.0"
@@ -1086,7 +1087,7 @@
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
-  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
   integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
   dependencies:
     "@nodelib/fs.stat" "2.0.5"
@@ -1094,12 +1095,12 @@
 
 "@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
-  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
 "@nodelib/fs.walk@^1.2.3":
   version "1.2.8"
-  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
@@ -2259,14 +2260,14 @@ ajv@^6.12.4:
     uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.9.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.16.0.tgz#22e2a92b94f005f7e0f9c9d39652ef0b8f6f0cb4"
-  integrity sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
   dependencies:
     fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
-    uri-js "^4.4.1"
 
 ansi-colors@^4.1.3:
   version "4.1.3"
@@ -3717,6 +3718,11 @@ fast-safe-stringify@^2.1.1:
   resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-uri@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.3.tgz#892a1c91802d5d7860de728f18608a0573142241"
+  integrity sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==
+
 fast-xml-parser@4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz#86dbf3f18edf8739326447bcaac31b4ae7f6514f"
@@ -3725,9 +3731,9 @@ fast-xml-parser@4.4.1:
     strnum "^1.0.5"
 
 fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
+  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
 
@@ -3966,7 +3972,7 @@ get-port@^5.1.1:
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
-  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
@@ -4266,10 +4272,15 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.1:
+ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.1"
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
+
+ignore@^5.2.4:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 immutable@^4.0.0:
   version "4.3.0"
@@ -4339,7 +4350,7 @@ is-callable@^1.1.3:
 
 is-extglob@^2.1.1:
   version "2.1.1"
-  resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-fullwidth-code-point@^3.0.0:
@@ -4356,7 +4367,7 @@ is-generator-function@^1.0.7:
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
-  resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
@@ -4371,7 +4382,7 @@ is-ip@^5.0.1:
 
 is-number@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-plain-obj@^2.1.0:
@@ -4795,6 +4806,11 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+loglevel@^1.9.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 loopbench@^1.2.0:
   version "1.2.0"
@@ -5551,12 +5567,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
 
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-punycode@^2.3.1:
+punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -5584,7 +5595,7 @@ querystring@0.2.0:
 
 queue-microtask@^1.2.2:
   version "1.2.3"
-  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 queue-tick@^1.0.1:
@@ -5604,7 +5615,7 @@ random-bytes@~1.0.0:
 
 randombytes@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
@@ -5752,7 +5763,7 @@ retry@^0.12.0:
 
 reusify@^1.0.4:
   version "1.0.4"
-  resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
 rimraf@^3.0.0:
@@ -5774,7 +5785,7 @@ rrweb-cssom@^0.7.1:
 
 run-parallel@^1.1.9:
   version "1.2.0"
-  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
@@ -6386,7 +6397,7 @@ to-fast-properties@^2.0.0:
 
 to-regex-range@^5.0.1:
   version "5.0.1"
-  resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
@@ -6570,7 +6581,7 @@ update-browserslist-db@^1.1.0:
     escalade "^3.1.2"
     picocolors "^1.0.1"
 
-uri-js@^4.2.2, uri-js@^4.4.1:
+uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==


### PR DESCRIPTION
## What

Updates `@govuk-one-login/frontend-analytics` from `2.0.1` to `3.0.1`

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.

## Related PRs

This PR makes the upgrade proposed by Dependabot in https://github.com/govuk-one-login/authentication-frontend/pull/2093
