### PR TITLE
[DAC-3581] - Navigation Tracker Not Firing on /sign-in-create and /account-created pages

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -24,7 +24,11 @@
     {{ govukButton({
         "text": "pages.accountCreated.continue" | translate,
         "type": "Submit",
-        "preventDoubleClick": true
+        "preventDoubleClick": true,
+        "data-nav":"true",
+        "data-link":"undefined"
+
+
     }) }}
 {% endif %}
 </form>

--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -25,10 +25,10 @@
         "text": "pages.accountCreated.continue" | translate,
         "type": "Submit",
         "preventDoubleClick": true,
-        "data-nav":"true",
-        "data-link":"undefined"
-
-
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 {% endif %}
 </form>

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -51,7 +51,7 @@
             attributes: {
                 "id": "create-account-link",
                 "data-nav":"true",
-                "data-link": '/enter-email-create'
+                "data-link": "/enter-email-create"
             }
         }) }}
         <div>
@@ -60,8 +60,8 @@
                 classes: "govuk-button--secondary",
                 attributes: {
                     "id": "sign-in-button",
-                    "data-nav":"true",
-                    "data-link": '/enter-email'
+                    "data-nav": "true",
+                    "data-link": "/enter-email"
                 }
             }) }}
         </div>

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -49,7 +49,9 @@
             name: "optionSelected",
             classes: "govuk-!-margin-right-3",
             attributes: {
-                "id": "create-account-link"
+                "id": "create-account-link",
+                "data-nav":"true",
+                "data-link": '/enter-email-create'
             }
         }) }}
         <div>
@@ -57,7 +59,9 @@
                 text: 'pages.signInOrCreate.signInText' | translate,
                 classes: "govuk-button--secondary",
                 attributes: {
-                    "id": "sign-in-button"
+                    "id": "sign-in-button",
+                    "data-nav":"true",
+                    "data-link": '/enter-email'
                 }
             }) }}
         </div>


### PR DESCRIPTION
## What

- Add data nav and data link attribute to submit buttons to configure navigation tracking
- For the `/account-created` page, it has been confirmed by both Auth (Gwyn Jones) and Orch ( Ethan Mills) that finding out the url of the page which the user is navigated to it is not possible and so in this instance we will be returning `undefined` .

For reasonings from Auth as to why, click [here](https://govukverify.atlassian.net/browse/DAC-3581?focusedCommentId=180370)
<!-- Describe what you have changed and why -->

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Run Locally
1. Connect to Google Tag Manager
1. Click on buttons to trigger navigationTracker
1. Confirm events are fired and correct data is being pushed to the data layer
1. You will need to remove your email from the tables in AWS in order to test the /account-created page if you have already done so before
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->


<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->


<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
