### PR TITLE
BAU: Add integration test for cookies post

### DIFF
--- a/src/components/common/cookies/tests/cookies-controller-integration.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller-integration.test.ts
@@ -10,54 +10,88 @@ describe("Integration:: cookies controller", () => {
   const dynamicGACookieName = "_gat_UA-[number]";
   const analyticsCookieNamesListedInCookieNotice: string[] = [];
 
-  before(async () => {
-    decache("../../../../app");
+  describe("get cookies", () => {
+    before(async () => {
+      decache("../../../../app");
 
-    app = await require("../../../../app").createApp();
+      app = await require("../../../../app").createApp();
 
-    await request(app, (test) => test.get(PATH_NAMES.COOKIES_POLICY)).then(
-      (res) => {
-        $ = cheerio.load(res.text);
-        $("table#analytics-cookies tbody td:first-child").each(
-          (i: any, elem: any) => {
-            const cookieName = $(elem).text();
-            analyticsCookieNamesListedInCookieNotice.push(cookieName);
-          }
-        );
-      }
-    );
-  });
+      await request(app, (test) => test.get(PATH_NAMES.COOKIES_POLICY)).then(
+        (res) => {
+          $ = cheerio.load(res.text);
+          $("table#analytics-cookies tbody td:first-child").each(
+            (i: any, elem: any) => {
+              const cookieName = $(elem).text();
+              analyticsCookieNamesListedInCookieNotice.push(cookieName);
+            }
+          );
+        }
+      );
+    });
 
-  after(() => {
-    sinon.restore();
-    app = undefined;
-  });
+    after(() => {
+      sinon.restore();
+      app = undefined;
+    });
 
-  describe("The cookies policy page", () => {
-    describe("table with an id of `analytics-cookies`", () => {
-      it("should exist, once", () => {
-        expect($("table#analytics-cookies").length).to.eq(1);
+    describe("The cookies policy page", () => {
+      describe("table with an id of `analytics-cookies`", () => {
+        it("should exist, once", () => {
+          expect($("table#analytics-cookies").length).to.eq(1);
+        });
+        it(`should include the dynamic Google Analytics cookie name, ${dynamicGACookieName}`, () => {
+          expect(analyticsCookieNamesListedInCookieNotice).to.include(
+            dynamicGACookieName
+          );
+        });
+        it("should list all items in the ANALYTICS_COOKIES array", () => {
+          ANALYTICS_COOKIES.forEach((i) => {
+            expect(analyticsCookieNamesListedInCookieNotice).to.include(i);
+          });
+        });
       });
-      it(`should include the dynamic Google Analytics cookie name, ${dynamicGACookieName}`, () => {
-        expect(analyticsCookieNamesListedInCookieNotice).to.include(
-          dynamicGACookieName
-        );
-      });
-      it("should list all items in the ANALYTICS_COOKIES array", () => {
-        ANALYTICS_COOKIES.forEach((i) => {
-          expect(analyticsCookieNamesListedInCookieNotice).to.include(i);
+    });
+    describe("the ANALYTICS_COOKIES array", () => {
+      describe("when the dynamic Google Analytics cookie name is added", () => {
+        it("should include all measurement cookies listed the cookie policy page", () => {
+          expect(analyticsCookieNamesListedInCookieNotice).to.have.same.members(
+            [...ANALYTICS_COOKIES, dynamicGACookieName]
+          );
         });
       });
     });
   });
-  describe("the ANALYTICS_COOKIES array", () => {
-    describe("when the dynamic Google Analytics cookie name is added", () => {
-      it("should include all measurement cookies listed the cookie policy page", () => {
-        expect(analyticsCookieNamesListedInCookieNotice).to.have.same.members([
-          ...ANALYTICS_COOKIES,
-          dynamicGACookieName,
-        ]);
+
+  describe("post cookies", () => {
+    let token: string | string[];
+    let cookies: string;
+    let app: any;
+
+    before(async () => {
+      decache("../../../../app");
+
+      app = await require("../../../../app").createApp();
+
+      await request(app, (test) => test.get(PATH_NAMES.COOKIES_POLICY), {
+        expectTaxonomyMatchSnapshot: false,
+      }).then((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
       });
+    });
+
+    it("successfully makes a call to update the cookie policy", async () => {
+      await request(app, (test) => test.post(PATH_NAMES.COOKIES_POLICY), {
+        expectTaxonomyMatchSnapshot: false,
+      })
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          cookiePreferences: true,
+        })
+        .expect(200);
     });
   });
 });


### PR DESCRIPTION
The test itself is very basic, just testing that we can successfully make a request to the post endpoint (without testing any of the expected functionality, which is already tested and much easier to test in the unit tests). This, among other breaking changes, prevents breaking updates to the cookies library. This has recently been seen in express dependency bumps, which bumps the cookie library to 0.7.x, which contains extra regex validation of the cookie values, which we don't currently meet as we use double quotes in the value.

This should prevent re-occurences of the incident that was caused by this cookie library bump.

## What

<!-- Describe what you have changed and why -->

## How to review


For example:

1. Code Review
1. While on this branch, bump a dependency locally such that cookies is updated to 0.7.x (for example, by bumping express to 0.4.21 as done in [this reverted PR.
](https://github.com/govuk-one-login/authentication-frontend/pull/2265) Verify that the new test fails, preventing us from accidentally bumping this dependency without being alerted that we need to implement a fix
