### PR TITLE
BAU: Dependabot ignore node versions more than v20.x.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     target-branch: main
     ignore:
       - dependency-name: "node"
-        versions: ["17.x", "19.x", "20.x"]
+        versions: ["> 20"]
     groups:
       npm-pino-dependencies:
         patterns:
@@ -44,6 +44,9 @@ updates:
       interval: daily
       time: "03:00"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "node"
+        versions: ["> 20"]
     groups:
       docker-all-dependencies:
         patterns:


### PR DESCRIPTION
## What

This pattern should still allow node version updates of v20 minor and patch versions, but v21 would be ignored etc.

This covers both Node and Docker ecosystems.

Doing this because our current configuration allows PRs for non-LTS Docker Node versions to be raised: https://github.com/govuk-one-login/authentication-frontend/pull/2248

## How to review

1. Code Review