### PR TITLE
BAU: Stop dependabot from PRing @types/node over v20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     ignore:
       - dependency-name: "node"
         versions: ["> 20"]
+      - dependency-name: "@types/node"
+        versions: ["> 20"]
     groups:
       npm-pino-dependencies:
         patterns:


### PR DESCRIPTION
## What

Stop dependabot from PRing @types/node over v20.

We use LTS 20, so should not be suggesting types over that, like this PR: https://github.com/govuk-one-login/authentication-frontend/pull/2278