### PR TITLE
AUT-2894: Release no photo ID contact forms

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -16,7 +16,7 @@ support_account_interventions = "1"
 support_authorize_controller  = "1"
 support_reauthentication      = "1"
 language_toggle_enabled       = "1"
-no_photo_id_contact_forms     = "0"
+no_photo_id_contact_forms     = "1"
 support_new_ipv_spinner       = "0"
 
 code_request_blocked_minutes                        = "120"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -24,7 +24,7 @@ code_entered_wrong_blocked_minutes                  = "120"
 password_reset_code_entered_wrong_blocked_minutes   = "120"
 reduced_code_block_duration_minutes                 = "15"
 language_toggle_enabled                             = "1"
-no_photo_id_contact_forms                           = "0"
+no_photo_id_contact_forms                           = "1"
 support_new_ipv_spinner                             = "0"
 
 url_for_support_links = "https://home.account.gov.uk/contact-gov-uk-one-login"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1853,7 +1853,7 @@
         "section1": {
           "header": "Dywedwch wrthym beth ddigwyddodd",
           "radio1": "Cawsoch broblem ateb cwestiynau diogelwch",
-          "radio2": "Cawsoch broblem gyda’ch dogfen hunaniaeth",
+          "radio2": "Cawsoch broblem gyda’ch ID gyda llun",
           "radio3": "Mae angen i chi ddiweddaru eich gwybodaeth bersonol",
           "radio4": "Roedd problem dechnegol (er enghraifft fe welsoch neges gwall)",
           "radio5": "Rhywbeth arall",
@@ -2220,8 +2220,8 @@
         }
       },
       "provingIdentityProblemWithIdentityDocument": {
-        "title": "Problem gyda’ch dogfen hunaniaeth",
-        "header": "Problem gyda’ch dogfen hunaniaeth",
+        "title": "Problem gyda’ch ID gyda llun",
+        "header": "Problem gyda’ch ID gyda llun",
         "identityDocument": {
           "header": "Dewiswch pa ddogfen hunaniaeth oeddech chi’n ei defnyddio",
           "types": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1853,7 +1853,7 @@
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You had a problem answering security questions",
-          "radio2": "You had a problem with your identity document",
+          "radio2": "You had a problem with your photo ID",
           "radio3": "You need to update your personal information",
           "radio4": "There was a technical problem (for example, you saw an error message)",
           "radio5": "Something else",
@@ -2220,8 +2220,8 @@
         }
       },
       "provingIdentityProblemWithIdentityDocument": {
-        "title": "A problem with your identity document",
-        "header": "A problem with your identity document",
+        "title": "A problem with your photo ID",
+        "header": "A problem with your photo ID",
         "identityDocument": {
           "header": "Which identity document were you using?",
           "types": {


### PR DESCRIPTION
> [!CAUTION]  
> Do not merge before we have been given the go-ahead (initially anticipated early week commencing 11 November 2024 but has been delayed - See Jira)

## What

1. Introduces contact form heading and label changes from _"...your identity document"_ to _"...your photo ID"_
2. Enables the no photo ID contact forms changes made in this PR and those linked below in integration and production

### Screenshots

#### Label change

This is the label change from "You had a problem with your identity document" to "You had a problem with your photo ID"

<details>

<summary>English</summary>

<img width="360" alt="Screenshot 2024-11-07 at 13 51 36" src="https://github.com/user-attachments/assets/5be0b814-00ed-4150-95e8-d4d200e231e7">

</details>

<details>

<summary>Welsh</summary>

<img width="360" alt="Screenshot 2024-11-07 at 13 53 59" src="https://github.com/user-attachments/assets/c11161f2-30ac-4992-ab3f-3de604c78033">

</details>

#### Heading change

This changes the heading from "A problem with your identity document" to "A problem with your photo ID" 

<details>

<summary>English</summary>

<img width="327" alt="Screenshot 2024-11-07 at 13 56 54" src="https://github.com/user-attachments/assets/1605cff3-834f-44de-ae07-469b85514d6a">

</details>

<details>

<summary>Welsh</summary>

<img width="326" alt="Screenshot 2024-11-07 at 13 57 09" src="https://github.com/user-attachments/assets/449563e4-f3c9-41cf-8b6a-e39c0906ad04">



</details>

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change
- [x] A UCD review has been performed (See Jira ticket - UCD Hive provided confirmation)

## Related PRs

- The content changes were originally made in #1648 
- The new radio options were introduced in https://github.com/govuk-one-login/authentication-frontend/pull/1647
- The new "Bank or building society" form was introduced in https://github.com/govuk-one-login/authentication-frontend/pull/1649
- The new national insurance form was introduced in https://github.com/govuk-one-login/authentication-frontend/pull/1651
