### PR TITLE
BAU: Dependabot to ignore language toggle v 2.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
         versions: ["> 20"]
       - dependency-name: "@types/node"
         versions: ["> 20"]
+      - dependency-name: "@govuk-one-login/frontend-language-toggle"
+        versions: ["2.0.1"]
     groups:
       npm-pino-dependencies:
         patterns:


### PR DESCRIPTION
## What

Work on #2235 revealed this version of the package does not include the CSS that's required. FEC are working on fixing this for a future release. This just ensures Dependabot doesn't try to get us to upgrade to this version

## How to review

1. Code Review

## Related PRs

#2235 
