### PR TITLE
AUT-3840: Introduce app specific reauth content for email entry

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -334,3 +334,8 @@ export const WEB_TO_MOBILE_TEMPLATE_MAPPINGS: Record<string, string> = {
   "account-not-found/index-optional.njk": "account-not-found/index-mobile.njk",
   "account-not-found/index-mandatory.njk": "account-not-found/index-mobile.njk",
 };
+
+export const WEB_TO_MOBILE_ERROR_MESSAGE_MAPPINGS: Record<string, string> = {
+  "pages.reEnterEmailAccount.enterYourEmailAddressError":
+    "mobileAppPages.reEnterEmailAccount.enterYourEmailAddressError",
+};

--- a/src/components/enter-email/enter-email-validation.ts
+++ b/src/components/enter-email/enter-email-validation.ts
@@ -2,6 +2,8 @@ import { body } from "express-validator";
 import { validateBodyMiddlewareReauthTemplate } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { RE_ENTER_EMAIL_TEMPLATE } from "./enter-email-controller";
+import { getChannelSpecificErrorMessage } from "../../utils/get-channel-specific-error-message";
+import { WEB_TO_MOBILE_ERROR_MESSAGE_MAPPINGS } from "../../app.constants";
 
 export function validateEnterEmailRequest(
   template = "enter-email/index-existing-account.njk"
@@ -42,7 +44,13 @@ export function validateEnterEmailRequest(
       })
       .custom((value, { req }) => {
         if (req.session.user.reauthenticate) {
-          return req.t("pages.reEnterEmailAccount.enterYourEmailAddressError", {
+          const errorMessage = getChannelSpecificErrorMessage(
+            "pages.reEnterEmailAccount.enterYourEmailAddressError",
+            req.body.isStrategicAppReauth === "true",
+            WEB_TO_MOBILE_ERROR_MESSAGE_MAPPINGS
+          );
+
+          return req.t(errorMessage, {
             value,
           });
         }

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -14,12 +14,17 @@
 <form action="/enter-email" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="isStrategicAppReauth" value="{{isStrategicAppReauth}}"/>
 
     <h1 class="govuk-heading-l">
         {{ 'pages.reEnterEmailAccount.header' | translate }}
     </h1>
 
-    <p class="govuk-body">{{'pages.reEnterEmailAccount.paragraph1' | translate}}</p>
+    {% if isStrategicAppReauth %}
+        <p class="govuk-body">{{'mobileAppPages.reEnterEmailAccount.paragraph1' | translate}}</p>
+    {% else %}
+        <p class="govuk-body">{{'pages.reEnterEmailAccount.paragraph1' | translate}}</p>
+    {% endif %}
 
     {{ govukInput({
          label: {

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Integration::enter email should return a strategic app specific validation error when email not entered and channel is strategic app 1`] = `
+Object {
+  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+}
+`;
+
 exports[`Integration::enter email should return enter email page with reauth analytics properties 1`] = `
 Object {
   "contentId": "aff1628e-177d-4afc-825b-56e926b2fc1f",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -198,6 +198,10 @@
       "info": {
         "paragraph2": "Arhoswch am 2 awr, yna rhowch gynnig arall."
       }
+    },
+    "reEnterEmailAccount": {
+      "paragraph1": "Defnyddiwch yr un cyfeiriad e-bost a ddefnyddiwyd y tro diwethaf i chi fewngofnodi i’r ap hwn. Mae hyn er mwyn cadw’ch gwybodaeth yn ddiogel.",
+      "enterYourEmailAddressError": "Rhowch yr un cyfeiriad e-bost a ddefnyddiwyd gennych y tro diwethaf i chi fewngofnodi i’r ap hwn"
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -198,6 +198,10 @@
       "info": {
         "paragraph2": "Wait 2 hours, then try again."
       }
+    },
+    "reEnterEmailAccount": {
+      "paragraph1": "Use the same email address you used last time you signed in to this app. This is to keep your information secure.",
+      "enterYourEmailAddressError": "Enter the same email address you used last time you signed in to this app"
     }
   },
   "pages": {

--- a/src/utils/get-channel-specific-error-message.ts
+++ b/src/utils/get-channel-specific-error-message.ts
@@ -1,0 +1,21 @@
+import { logger } from "./logger";
+
+export function getChannelSpecificErrorMessage(
+  webMessage: string,
+  isStrategicAppChannel: boolean,
+  messageMappings: Record<string, string>
+): string {
+  if (!isStrategicAppChannel) {
+    return webMessage;
+  }
+
+  const appMessage: string = messageMappings[webMessage];
+
+  if (appMessage === undefined) {
+    logger.warn(
+      `No '${webMessage}' property found in messageMappings. Falling back to webMessage`
+    );
+    return webMessage;
+  }
+  return appMessage;
+}

--- a/test/unit/utils/get-channel-specific-error-message.test.ts
+++ b/test/unit/utils/get-channel-specific-error-message.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { getChannelSpecificErrorMessage } from "../../../src/utils/get-channel-specific-error-message";
+
+const mappings = {
+  "pages.error.specificError": "mobileAppPages.error.specificError",
+};
+
+describe("getChannelSpecificErrorMessage", () => {
+  describe("where the channel is not mobile", () => {
+    describe("and the webMessage is not mapped", () => {
+      it("should return the original webMessage", () => {
+        expect(
+          getChannelSpecificErrorMessage(
+            "pages.error.unmappedError",
+            false,
+            mappings
+          )
+        ).to.equal("pages.error.unmappedError");
+      });
+    });
+    describe("and the webMessage is mapped", () => {
+      it("should return the original webMessage", () => {
+        expect(
+          getChannelSpecificErrorMessage(
+            "pages.error.specificError",
+            false,
+            mappings
+          )
+        ).to.equal("pages.error.specificError");
+      });
+    });
+  });
+
+  describe("where the channel is mobile", () => {
+    describe("and the webMessage is not mapped", () => {
+      it("should return the original webMessage", () => {
+        expect(
+          getChannelSpecificErrorMessage(
+            "pages.error.unmappedError",
+            true,
+            mappings
+          )
+        ).to.equal("pages.error.unmappedError");
+      });
+    });
+    describe("and the webMessage is mapped", () => {
+      it("should return the original webMessage", () => {
+        expect(
+          getChannelSpecificErrorMessage(
+            "pages.error.specificError",
+            true,
+            mappings
+          )
+        ).to.equal("mobileAppPages.error.specificError");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

This PR does two things:

1. Updates the reauth email entry template to include content that is specific to the strategic app. This follows [approach 2](https://github.com/govuk-one-login/architecture/blob/main/adr/0193-embedding-web-frontends-in-mobile-apps.md#approach-2--shared-pages) described in the ADR which uses logic in the template. 
2. Introduces a channel specific error message for the strategic app. Because this is also the first PR to introduce different error messages for channels, I've separated the commit which introduces the relevant utility so the approach can be more easily be understood by future developers.

### Note to PR reviewer

I found it quite challenging to reproduce the error state for this ticket in the frontend because it relies on the user being in a very specific combination of states. I've described how I achieved this below, but suspect I've done this in a suboptimal way (largely because I don't know how to get the backend to replicate this state when working locally). If you know of a better way (for example by tweaking something in an API response somewhere), I'd love to know how 😃 

<details>

<summary>How I reproduced the error state for local development</summary>

I did this by doing the following

1. tweaking `channelMiddleware` so that `res.locals.strategicAppChannel` always  `= true`
2. updating `enter-email-controller.ts` so that:
    i. `enterEmailGet` always sets `const isReAuthenticationRequired` to `= true;`
    ii. `enterEmailPost` always sets `const reauthenticateJourney` to `= "123456"`
    iii. `enterEmailPost` will always `return handleBadRequest(req, res, CHANNEL_SPECIFIC_EMAIL_ERROR_KEY)`

</details>

### Screenshots 

<details>

<summary>English</summary>

<img width="322" alt="English" src="https://github.com/user-attachments/assets/1474e718-b722-44dd-8dd4-814bee250f73">

</details>


<details>

<summary>English - Error state</summary>

<img width="323" alt="English - Error" src="https://github.com/user-attachments/assets/c70791b8-4a0f-4693-86a0-489581f2196c">

</details>


<details>

<summary>Welsh</summary>

<img width="323" alt="Welsh" src="https://github.com/user-attachments/assets/f87cb9c6-7a71-49b1-88d7-97e364455c54">

</details>


<details>

<summary>Welsh - Error state</summary>

<img width="323" alt="Welsh" src="https://github.com/user-attachments/assets/9d157717-7a46-4d93-8dc3-c9ef1aab4e43">


</details>

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.