### PR TITLE
AUT-3841: Introduce app specific content for account created screen

### DIFF
--- a/src/components/account-created/account-created-controller.ts
+++ b/src/components/account-created/account-created-controller.ts
@@ -8,6 +8,7 @@ export function accountCreatedGet(req: Request, res: Response): void {
   res.render("account-created/index.njk", {
     serviceType,
     name,
+    strategicAppChannel: res.locals.strategicAppChannel,
   });
 }
 

--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -19,7 +19,12 @@
         "preventDoubleClick": true
     }) }}
 {% else %}
-    <p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
+
+    {% if strategicAppChannel === true %}
+        <p class="govuk-body">{{'mobileAppPages.accountCreated.text' | translate}}</p>
+    {% else %}
+        <p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
+    {% endif %}
 
     {{ govukButton({
         "text": "pages.accountCreated.continue" | translate,

--- a/src/components/account-created/tests/account-created-controller.test.ts
+++ b/src/components/account-created/tests/account-created-controller.test.ts
@@ -34,6 +34,20 @@ describe("account created controller", () => {
 
       expect(res.render).to.have.been.calledWith("account-created/index.njk");
     });
+
+    it("should pass through the strategicAppChannel", () => {
+      req.session.client.serviceType = "MANDATORY";
+      req.session.client.name = "test client name";
+      res.locals.strategicAppChannel = true;
+
+      accountCreatedGet(req as Request, res as Response);
+
+      expect(res.render).to.have.been.calledWith("account-created/index.njk", {
+        serviceType: "MANDATORY",
+        name: "test client name",
+        strategicAppChannel: true,
+      });
+    });
   });
   describe("accountCreatedPost", () => {
     it("should redirect to auth code", async () => {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -202,6 +202,9 @@
     "reEnterEmailAccount": {
       "paragraph1": "Defnyddiwch yr un cyfeiriad e-bost a ddefnyddiwyd y tro diwethaf i chi fewngofnodi i’r ap hwn. Mae hyn er mwyn cadw’ch gwybodaeth yn ddiogel.",
       "enterYourEmailAddressError": "Rhowch yr un cyfeiriad e-bost a ddefnyddiwyd gennych y tro diwethaf i chi fewngofnodi i’r ap hwn"
+    },
+    "accountCreated": {
+      "text": "Nawr parhewch i ddefnyddio’r ap."
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -202,6 +202,9 @@
     "reEnterEmailAccount": {
       "paragraph1": "Use the same email address you used last time you signed in to this app. This is to keep your information secure.",
       "enterYourEmailAddressError": "Enter the same email address you used last time you signed in to this app"
+    },
+    "accountCreated": {
+      "text": "Now continue to use the app."
     }
   },
   "pages": {


### PR DESCRIPTION
## What

Introduces app specific content for the account created screen. This follows [approach 2](https://github.com/govuk-one-login/architecture/blob/main/adr/0193-embedding-web-frontends-in-mobile-apps.md#approach-2--shared-pages) described in the ADR which uses logic in the template. 

### Screenshots 

<details>

<summary>English</summary>

<img width="322" alt="English" src="https://github.com/user-attachments/assets/638d001e-4087-46eb-b634-ff65835268b1">

</details>

<details>

<summary>Welsh</summary>

<img width="322" alt="Welsh" src="https://github.com/user-attachments/assets/91a9544a-b8cc-4101-b504-dfb3e6ad36dd">


</details>

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.
