### PR TITLE
BAU: Add `@typescript-eslint/*` dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,9 @@ updates:
       npm-otplib-dependencies:
         patterns:
           - "@otplib/*"
+      npm-typescript-eslint-dependencies:
+        patterns:
+          - "@typescript-eslint/*"
       npm-patch-dependencies:
         update-types:
           - patch


### PR DESCRIPTION
## What

There are two `@typescript-eslint/*` packages we use that should have the same version number when bumped.

This change will mean dependabot PRs are raised for these together, reducing the maintenance workload.

## How to review

1. Code Review
