### PR TITLE
AUT-3834: add basic ipv callback endpoint

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -74,6 +74,7 @@ export const PATH_NAMES = {
   UNAVAILABLE_TEMPORARY: "/unavailable-temporary",
   RESET_PASSWORD_2FA_AUTH_APP: "/reset-password-2fa-auth-app",
   MFA_RESET_WITH_IPV: "/mfa-reset-with-ipv",
+  IPV_CALLBACK: "/ipv/callback/authorize",
 };
 
 export const CONTENT_IDS: {

--- a/src/app.ts
+++ b/src/app.ts
@@ -99,6 +99,7 @@ import { applyOverloadProtection } from "./middleware/overload-protection-middle
 import { frontendVitalSignsInit } from "@govuk-one-login/frontend-vital-signs";
 import { Server } from "node:http";
 import { getAnalyticsPropertiesMiddleware } from "./middleware/get-analytics-properties-middleware";
+import { ipvCallbackRouter } from "./components/ipv-callback/ipv-callback-routes";
 import { mfaResetWithIpvRouter } from "./components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes";
 
 const APP_VIEWS = [
@@ -157,6 +158,7 @@ function registerRoutes(app: express.Application) {
   }
   if (supportMfaResetWithIpv()) {
     app.use(mfaResetWithIpvRouter);
+    app.use(ipvCallbackRouter);
   }
 }
 

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types";
+
+export function ipvCallbackGet(): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    res.status(200).send("Got to ipv callback");
+  };
+}

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -1,0 +1,10 @@
+import * as express from "express";
+import { asyncHandler } from "../../utils/async";
+import { PATH_NAMES } from "../../app.constants";
+import { ipvCallbackGet } from "./ipv-callback-controller";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.IPV_CALLBACK, asyncHandler(ipvCallbackGet()));
+
+export { router as ipvCallbackRouter };

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -1,0 +1,45 @@
+import { describe } from "mocha";
+import decache from "decache";
+import { request, sinon } from "../../../../test/utils/test-utils";
+import { PATH_NAMES } from "../../../app.constants";
+import express from "express";
+
+describe("Integration:: ipv callback", () => {
+  let app: express.Application;
+
+  before(async () => {
+    process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+    decache("../../../../app");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "7867",
+          journey: {
+            nextPath: PATH_NAMES.IPV_CALLBACK,
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+  });
+
+  after(() => {
+    app = undefined;
+    delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
+  });
+
+  it("should return basic response when ipv callback requested", async () => {
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.IPV_CALLBACK).expect(200),
+      { expectAnalyticsPropertiesMatchSnapshot: false }
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a very basic controller and route, in the case that the mfa reset with IPV feature flag is on, that responds to a callback from the authorize endpoint in IPV, and for now just responds with a basic success status. This is to enable step by step implementation, so that we can see the callback successfully working.

## How to review

1. Code Review
