### PR TITLE
AUT-3838: Introduce mobile app variant for too many code requests

### DIFF
--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -8,12 +8,17 @@
 {% endif %}
 
 {% block content %}
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityRequestsExceededExpired.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.securityRequestsExceededExpired.header' | translate }}</h1>
 
-    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph1' | translate}}</p>
-    <h2 class="govuk-heading-s">{{'pages.securityRequestsExceededExpired.info.subHeading' | translate}}</h2>
-    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph2' | translate}}</p>
-    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph3' | translate}}</p>
+    <p class="govuk-body">{{ 'pages.securityRequestsExceededExpired.info.paragraph1' | translate }}</p>
+    <h2 class="govuk-heading-s">{{ 'pages.securityRequestsExceededExpired.info.subHeading' | translate }}</h2>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+    {% if strategicAppChannel === true %}
+        <p class="govuk-body">{{ 'mobileAppPages.securityRequestsExceededExpired.info.paragraph2' | translate }}</p>
+    {% else %}
+        <p class="govuk-body">{{ 'pages.securityRequestsExceededExpired.info.paragraph2' | translate }}</p>
+        <p class="govuk-body">{{ 'pages.securityRequestsExceededExpired.info.paragraph3' | translate }}</p>
+    {% endif %}
+
+    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true }) }}
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -77,6 +77,7 @@ export function securityCodeTriesExceededGet(
     isResendCodeRequest: req.query.isResendCodeRequest,
     isAccountCreationJourney: req.session.user?.isAccountCreationJourney,
     contentId: oplValues.requestedTooManyTimes.contentId,
+    strategicAppChannel: res.locals.strategicAppChannel,
   });
 }
 

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -67,6 +67,7 @@ describe("security code controller", () => {
         req.query.actionType = params.actionType;
         req.session.user.isAccountCreationJourney =
           params.isAccountCreationJourney;
+        res.locals.strategicAppChannel = true;
 
         securityCodeTriesExceededGet(req as Request, res as Response);
 
@@ -77,6 +78,7 @@ describe("security code controller", () => {
             isResendCodeRequest: undefined,
             isAccountCreationJourney: params.isAccountCreationJourney,
             contentId: params.contentId,
+            strategicAppChannel: res.locals.strategicAppChannel,
           }
         );
       });
@@ -385,6 +387,7 @@ describe("security code controller", () => {
             isAccountCreationJourney: undefined,
 
             contentId: "445409a8-2aaf-47fc-82a9-b277eca4601d",
+            strategicAppChannel: res.locals.strategicAppChannel,
           }
         );
         expect(req.session.user.codeRequestLock).to.eq(
@@ -394,11 +397,13 @@ describe("security code controller", () => {
     );
 
     it(
-      "should render index-too-many-requests.njk for MfaMaxRetries when max number of codes have been sent" +
+      "should render index-too-many-requests.njk for MfaMaxRetries when max number of codes have been sent " +
         "and user is in the sign-in journey",
       () => {
         req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
         req.session.user.isPasswordResetJourney = true;
+        res.locals.strategicAppChannel = true;
+
         securityCodeTriesExceededGet(req as Request, res as Response);
 
         expect(res.render).to.have.calledWith(
@@ -411,8 +416,8 @@ describe("security code controller", () => {
             ),
             isResendCodeRequest: undefined,
             isAccountCreationJourney: undefined,
-
             contentId: "445409a8-2aaf-47fc-82a9-b277eca4601d",
+            strategicAppChannel: res.locals.strategicAppChannel,
           }
         );
       }
@@ -424,6 +429,7 @@ describe("security code controller", () => {
       () => {
         req.query.actionType = SecurityCodeErrorType.OtpBlocked;
         req.session.user.isAccountRecoveryJourney = true;
+        res.locals.strategicAppChannel = true;
         securityCodeTriesExceededGet(req as Request, res as Response);
 
         expect(res.render).to.have.calledWith(
@@ -434,6 +440,7 @@ describe("security code controller", () => {
             isAccountCreationJourney: undefined,
 
             contentId: "445409a8-2aaf-47fc-82a9-b277eca4601d",
+            strategicAppChannel: res.locals.strategicAppChannel,
           }
         );
       }
@@ -442,6 +449,7 @@ describe("security code controller", () => {
     it("should render index-too-many-requests.njk for MfaMaxRetries when max number of codes have been sent and user is in the account creation journey", () => {
       req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
       req.session.user.isAccountCreationJourney = true;
+      res.locals.strategicAppChannel = true;
       securityCodeTriesExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
@@ -456,6 +464,7 @@ describe("security code controller", () => {
           isAccountCreationJourney: true,
 
           contentId: "445409a8-2aaf-47fc-82a9-b277eca4601d",
+          strategicAppChannel: res.locals.strategicAppChannel,
         }
       );
     });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -179,6 +179,11 @@
       "paragraph2": "Mae angen i chi fewngofnodi gyda chyfeiriad e-bost sydd â GOV.UK One Login i brofi eich hunaniaeth.",
       "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",
       "findOutMoreLinkText": "Darganfyddwch fwy am ddefnyddio GOV.UK One Login"
+    },
+    "securityRequestsExceededExpired": {
+      "info": {
+        "paragraph2": "Arhoswch am 2 awr, yna rhowch gynnig arall."
+      }
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -179,6 +179,11 @@
       "paragraph2": "You need to sign in with an email address that has a GOV.UK One Login to prove your identity.",
       "tryAnotherLinkText": "Try another email address",
       "findOutMoreLinkText": "Find out more about using GOV.UK One Login"
+    },
+    "securityRequestsExceededExpired": {
+      "info": {
+        "paragraph2": "Wait 2 hours, then try again."
+      }
     }
   },
   "pages": {


### PR DESCRIPTION
## What

Introduces mobile app specific views for pages that require different content in that channel. 

### Screenshots

#### You asked to resend the security code too many times

<details>

<summary>English</summary>

<img width="394" alt="English" src="https://github.com/user-attachments/assets/d69e085d-23a1-4e72-82b0-6a69f930a273">
</details>


<details>

<summary>Welsh</summary>

<img width="394" alt="Welsh" src="https://github.com/user-attachments/assets/c7d10a38-6876-49ce-b109-f76823c5129b">


</details>



## How to review

1. Code Review

## Checklist

- [ ] Performance analyst has been notified of the change.
- [ ] A UCD review has been performed.
- [ ] Documentation has been updated to reflect these changes.

