### PR TITLE
Aut 3824: Implement authentication callback

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -148,6 +148,7 @@ export const API_ENDPOINTS = {
   CHECK_REAUTH_USER: "/check-reauth-user",
   CHECK_EMAIL_FRAUD_BLOCK: "/check-email-fraud-block",
   MFA_RESET_AUTHORIZE: "/mfa-reset-authorize",
+  REVERIFICATION_RESULT: "/reverification-result",
 };
 
 export const ERROR_MESSAGES = {

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -1,8 +1,28 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
+import { ReverificationResultInterface } from "./types";
+import { logger } from "../../utils/logger";
+import { reverificationResultService } from "./reverification-result-service";
 
-export function ipvCallbackGet(): ExpressRouteFunc {
+export function ipvCallbackGet(
+  service: ReverificationResultInterface = reverificationResultService()
+): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    res.status(200).send("Got to ipv callback");
+    const { email } = req.session.user;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const result = await service.getReverificationResult(
+      sessionId,
+      clientSessionId,
+      persistentSessionId,
+      req,
+      email
+    );
+
+    logger.info(
+      `Reverification result for session id ${res.locals.sessionId} is success: ${result.success}`
+    );
+
+    res.status(200).send("Received successful reverification result");
   };
 }

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -12,12 +12,21 @@ export function ipvCallbackGet(
     const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
+    const code = req.query.code;
+
+    if (code === undefined) {
+      throw new BadRequestError("Request query missing auth code param", 400);
+    } else if (typeof code !== "string") {
+      throw new BadRequestError("Invalid auth code param type", 400);
+    }
+
     const result = await service.getReverificationResult(
       sessionId,
       clientSessionId,
       persistentSessionId,
       req,
-      email
+      email,
+      code
     );
 
     logger.info(

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -3,6 +3,7 @@ import { ExpressRouteFunc } from "../../types";
 import { ReverificationResultInterface } from "./types";
 import { logger } from "../../utils/logger";
 import { reverificationResultService } from "./reverification-result-service";
+import { BadRequestError } from "../../utils/error";
 
 export function ipvCallbackGet(
   service: ReverificationResultInterface = reverificationResultService()
@@ -22,6 +23,10 @@ export function ipvCallbackGet(
     logger.info(
       `Reverification result for session id ${res.locals.sessionId} is success: ${result.success}`
     );
+
+    if (!result.success) {
+      throw new BadRequestError(result.data.message, result.data.code);
+    }
 
     res.status(200).send("Received successful reverification result");
   };

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -2,9 +2,14 @@ import * as express from "express";
 import { asyncHandler } from "../../utils/async";
 import { PATH_NAMES } from "../../app.constants";
 import { ipvCallbackGet } from "./ipv-callback-controller";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
 
 const router = express.Router();
 
-router.get(PATH_NAMES.IPV_CALLBACK, asyncHandler(ipvCallbackGet()));
+router.get(
+  PATH_NAMES.IPV_CALLBACK,
+  validateSessionMiddleware,
+  asyncHandler(ipvCallbackGet())
+);
 
 export { router as ipvCallbackRouter };

--- a/src/components/ipv-callback/reverification-result-service.ts
+++ b/src/components/ipv-callback/reverification-result-service.ts
@@ -17,7 +17,8 @@ export function reverificationResultService(
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    email: string
+    email: string,
+    code: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const config = getInternalRequestConfigWithSecurityHeaders(
       {
@@ -31,7 +32,7 @@ export function reverificationResultService(
 
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.REVERIFICATION_RESULT,
-      { email },
+      { email, code },
       config
     );
 

--- a/src/components/ipv-callback/reverification-result-service.ts
+++ b/src/components/ipv-callback/reverification-result-service.ts
@@ -1,4 +1,7 @@
-import { ReverificationResultInterface } from "./types";
+import {
+  ReverificationResultInterface,
+  ReverificationResultResponse,
+} from "./types";
 import {
   createApiResponse,
   getInternalRequestConfigWithSecurityHeaders,
@@ -19,7 +22,7 @@ export function reverificationResultService(
     req: Request,
     email: string,
     code: string
-  ): Promise<ApiResponseResult<DefaultApiResponse>> {
+  ): Promise<ApiResponseResult<ReverificationResultResponse>> {
     const config = getInternalRequestConfigWithSecurityHeaders(
       {
         sessionId: sessionId,
@@ -36,7 +39,7 @@ export function reverificationResultService(
       config
     );
 
-    return createApiResponse<DefaultApiResponse>(response);
+    return createApiResponse<ReverificationResultResponse>(response);
   };
 
   return {

--- a/src/components/ipv-callback/reverification-result-service.ts
+++ b/src/components/ipv-callback/reverification-result-service.ts
@@ -1,0 +1,44 @@
+import { ReverificationResultInterface } from "./types";
+import {
+  createApiResponse,
+  getInternalRequestConfigWithSecurityHeaders,
+  http,
+  Http,
+} from "../../utils/http";
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { API_ENDPOINTS } from "../../app.constants";
+import { Request } from "express";
+
+export function reverificationResultService(
+  axios: Http = http
+): ReverificationResultInterface {
+  const getReverificationResult = async function (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request,
+    email: string
+  ): Promise<ApiResponseResult<DefaultApiResponse>> {
+    const config = getInternalRequestConfigWithSecurityHeaders(
+      {
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        persistentSessionId: persistentSessionId,
+      },
+      req,
+      API_ENDPOINTS.REVERIFICATION_RESULT
+    );
+
+    const response = await axios.client.post<DefaultApiResponse>(
+      API_ENDPOINTS.REVERIFICATION_RESULT,
+      { email },
+      config
+    );
+
+    return createApiResponse<DefaultApiResponse>(response);
+  };
+
+  return {
+    getReverificationResult,
+  };
+}

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -1,0 +1,40 @@
+import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
+import sinon from "sinon";
+import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { PATH_NAMES } from "../../../app.constants";
+import { expect } from "chai";
+import { Request, Response } from "express";
+import { ReverificationResultInterface } from "../types";
+import { ipvCallbackGet } from "../ipv-callback-controller";
+
+const fakeReverificationResultService = {
+  getReverificationResult: sinon.fake.returns({
+    success: true,
+    data: {},
+  }),
+} as unknown as ReverificationResultInterface;
+
+describe("ipv callback controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = createMockRequest(PATH_NAMES.IPV_CALLBACK);
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("get should return a 200 when the reverification result is successful", async () => {
+    await ipvCallbackGet(fakeReverificationResultService)(
+      req as Request,
+      res as Response
+    );
+
+    expect(fakeReverificationResultService.getReverificationResult).to.have.been
+      .called;
+    expect(res.status).to.have.been.calledWith(200);
+  });
+});

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -6,13 +6,20 @@ import { expect } from "chai";
 import { Request, Response } from "express";
 import { ReverificationResultInterface } from "../types";
 import { ipvCallbackGet } from "../ipv-callback-controller";
+import { BadRequestError } from "../../../utils/error";
 
-const fakeReverificationResultService = {
-  getReverificationResult: sinon.fake.returns({
-    success: true,
-    data: {},
-  }),
-} as unknown as ReverificationResultInterface;
+const fakeReverificationResultService = (success: boolean) => {
+  const failureData = {
+    code: 500,
+    message: "Internal error occurred in backend",
+  };
+  return {
+    getReverificationResult: sinon.fake.returns({
+      success: success,
+      data: success ? {} : failureData,
+    }),
+  } as unknown as ReverificationResultInterface;
+};
 
 describe("ipv callback controller", () => {
   let req: RequestOutput;
@@ -28,13 +35,31 @@ describe("ipv callback controller", () => {
   });
 
   it("get should return a 200 when the reverification result is successful", async () => {
-    await ipvCallbackGet(fakeReverificationResultService)(
+    const fakeServiceReturningSuccess = fakeReverificationResultService(true);
+    await ipvCallbackGet(fakeServiceReturningSuccess)(
       req as Request,
       res as Response
     );
 
-    expect(fakeReverificationResultService.getReverificationResult).to.have.been
+    expect(fakeServiceReturningSuccess.getReverificationResult).to.have.been
       .called;
     expect(res.status).to.have.been.calledWith(200);
+  });
+
+  it("get should raise error when reverification result is not successful", async () => {
+    const fakeServiceReturningFailure = fakeReverificationResultService(false);
+
+    await expect(
+      ipvCallbackGet(fakeServiceReturningFailure)(
+        req as Request,
+        res as Response
+      )
+    ).to.be.rejectedWith(
+      BadRequestError,
+      "500:Internal error occurred in backend"
+    );
+
+    expect(fakeServiceReturningFailure.getReverificationResult).to.have.been
+      .called;
   });
 });

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -17,7 +17,7 @@ const fakeReverificationResultService = (success: boolean) => {
   return {
     getReverificationResult: sinon.fake.returns({
       success: success,
-      data: success ? {} : failureData,
+      data: success ? { sub: "some-sub", success: true } : failureData,
     }),
   } as unknown as ReverificationResultInterface;
 };

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -44,10 +44,10 @@ describe("Integration:: ipv callback", () => {
   it("should return basic response when ipv callback requested", async () => {
     nock(baseApi).post(API_ENDPOINTS.REVERIFICATION_RESULT).once().reply(200);
 
-    await request(
-      app,
-      (test) => test.get(PATH_NAMES.IPV_CALLBACK).expect(200),
-      { expectAnalyticsPropertiesMatchSnapshot: false }
-    );
+    const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+
+    await request(app, (test) => test.get(requestPath).expect(200), {
+      expectAnalyticsPropertiesMatchSnapshot: false,
+    });
   });
 });

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -1,15 +1,18 @@
 import { describe } from "mocha";
 import decache from "decache";
 import { request, sinon } from "../../../../test/utils/test-utils";
-import { PATH_NAMES } from "../../../app.constants";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
 import express from "express";
+import nock from "nock";
 
 describe("Integration:: ipv callback", () => {
   let app: express.Application;
+  let baseApi: string;
 
   before(async () => {
     process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
-    decache("../../../../app");
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
     sinon
       .stub(sessionMiddleware, "validateSessionMiddleware")
@@ -26,6 +29,7 @@ describe("Integration:: ipv callback", () => {
 
         next();
       });
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     app = await require("../../../app").createApp();
   });
@@ -33,9 +37,13 @@ describe("Integration:: ipv callback", () => {
   after(() => {
     app = undefined;
     delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
+    nock.cleanAll();
+    sinon.restore();
   });
 
   it("should return basic response when ipv callback requested", async () => {
+    nock(baseApi).post(API_ENDPOINTS.REVERIFICATION_RESULT).once().reply(200);
+
     await request(
       app,
       (test) => test.get(PATH_NAMES.IPV_CALLBACK).expect(200),

--- a/src/components/ipv-callback/tests/reverification-result-service.test.ts
+++ b/src/components/ipv-callback/tests/reverification-result-service.test.ts
@@ -47,13 +47,14 @@ describe("reverification result service", () => {
       clientSessionId,
       diPersistentSessionId,
       req,
-      email
+      email,
+      "12345"
     );
 
     const expectedApiCallDetails = {
       expectedPath: API_ENDPOINTS.REVERIFICATION_RESULT,
       expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
-      expectedBody: { email },
+      expectedBody: { email, code: "12345" },
     };
 
     checkApiCallMadeWithExpectedBodyAndHeaders(

--- a/src/components/ipv-callback/tests/reverification-result-service.test.ts
+++ b/src/components/ipv-callback/tests/reverification-result-service.test.ts
@@ -1,0 +1,66 @@
+import { describe } from "mocha";
+import sinon, { SinonStub } from "sinon";
+import {
+  checkApiCallMadeWithExpectedBodyAndHeaders,
+  expectedHeadersFromCommonVarsWithSecurityHeaders,
+  requestHeadersWithIpAndAuditEncoded,
+  resetApiKeyAndBaseUrlEnvVars,
+  setupApiKeyAndBaseUrlEnvVars,
+} from "../../../../test/helpers/service-test-helper";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
+import { Http } from "../../../utils/http";
+import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { commonVariables } from "../../../../test/helpers/common-test-variables";
+import { reverificationResultService } from "../reverification-result-service";
+import { ReverificationResultInterface } from "../types";
+
+describe("reverification result service", () => {
+  const http = new Http();
+  const service: ReverificationResultInterface =
+    reverificationResultService(http);
+  let postStub: SinonStub;
+  const { sessionId, clientSessionId, email, diPersistentSessionId } =
+    commonVariables;
+  const req = createMockRequest(PATH_NAMES.IPV_CALLBACK, {
+    headers: requestHeadersWithIpAndAuditEncoded,
+  });
+  const axiosResponse = Promise.resolve({
+    data: {},
+    status: 200,
+    statusText: "OK",
+  });
+
+  beforeEach(() => {
+    setupApiKeyAndBaseUrlEnvVars();
+    postStub = sinon.stub(http.client, "post");
+    postStub.resolves(axiosResponse);
+  });
+
+  afterEach(() => {
+    postStub.reset();
+    resetApiKeyAndBaseUrlEnvVars();
+  });
+
+  it("successfully calls reverification result API", async () => {
+    const result = await service.getReverificationResult(
+      sessionId,
+      clientSessionId,
+      diPersistentSessionId,
+      req,
+      email
+    );
+
+    const expectedApiCallDetails = {
+      expectedPath: API_ENDPOINTS.REVERIFICATION_RESULT,
+      expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+      expectedBody: { email },
+    };
+
+    checkApiCallMadeWithExpectedBodyAndHeaders(
+      result,
+      postStub,
+      true,
+      expectedApiCallDetails
+    );
+  });
+});

--- a/src/components/ipv-callback/types.ts
+++ b/src/components/ipv-callback/types.ts
@@ -7,6 +7,7 @@ export interface ReverificationResultInterface {
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    email: string
+    email: string,
+    code: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>; //TODO add type
 }

--- a/src/components/ipv-callback/types.ts
+++ b/src/components/ipv-callback/types.ts
@@ -1,6 +1,11 @@
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
 import { Request } from "express";
 
+export interface ReverificationResultResponse extends DefaultApiResponse {
+  sub: string;
+  success: boolean;
+}
+
 export interface ReverificationResultInterface {
   getReverificationResult: (
     sessionId: string,
@@ -9,5 +14,5 @@ export interface ReverificationResultInterface {
     req: Request,
     email: string,
     code: string
-  ) => Promise<ApiResponseResult<DefaultApiResponse>>; //TODO add type
+  ) => Promise<ApiResponseResult<ReverificationResultResponse>>;
 }

--- a/src/components/ipv-callback/types.ts
+++ b/src/components/ipv-callback/types.ts
@@ -1,0 +1,12 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { Request } from "express";
+
+export interface ReverificationResultInterface {
+  getReverificationResult: (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request,
+    email: string
+  ) => Promise<ApiResponseResult<DefaultApiResponse>>; //TODO add type
+}


### PR DESCRIPTION
## What

Adds to the existing dummy callback endpoint, to call the reverification result lambda. This is the next step in implementing the mfa reset with identity journey, and covers off step 10/11 in the flow diagram linked in the epic.

## How to review

For example:

1. Code Review
1. Deploy to dev alongside [this api branch](https://github.com/govuk-one-login/authentication-api/tree/AUT-3824/temporarily-hardcode-success-in-reverification-result). 
1. Run through an mfa reset journey with the network tab open on dev tools. See that on callback from the stub to the frontend, we now make a further call to the backend's reverification endpoint, and that this is successful and successfully displays the "reverification result success" message added in this PR. Verify the reverification result lambda was called in the aws console if non obvious from dev tools.