### PR TITLE
AUT-3690: Re-enable canary in build and staging

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -81,12 +81,12 @@ Conditions:
     Fn::And:
       - !Condition UseECSCanaryDeploymentStack
       - Fn::Or:
-          # - Fn::Equals:
-          #     - !Ref Environment
-          #     - "build"
-          # - Fn::Equals:
-          #     - !Ref Environment
-          #     - "staging"
+          - Fn::Equals:
+              - !Ref Environment
+              - "build"
+          - Fn::Equals:
+              - !Ref Environment
+              - "staging"
           - Fn::Equals:
               - !Ref Environment
               - "integration"


### PR DESCRIPTION
## What

Deploy ECS canary phase 2
Revert "AUT-3690: Deploy ECS canary components - phase1" 
This reverts commit d243c643e5e8677c95d66b0b555926cc28fe0341. 
Activates CodeDeploy as the DeploymentController

Issue: [AUT-3690]

[AUT-3690]: https://govukverify.atlassian.net/browse/AUT-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ