### PR TITLE
BAU: Group all eslint dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,9 @@ updates:
       npm-otplib-dependencies:
         patterns:
           - "@otplib/*"
-      npm-typescript-eslint-dependencies:
+      npm-eslint-dependencies:
         patterns:
-          - "@typescript-eslint/*"
+          - "*eslint*"
       npm-patch-dependencies:
         update-types:
           - patch


### PR DESCRIPTION
## What

All dependabot PRs for eslint and related dependencies are grouped together.

This allows us to reduce the workload managing closely related dependencies.

A previous attempt grouped typescript-eslint packages, whereas this expands the group for all eslint packages we use.

For example, these PRs are open at the time of drafting this:
- https://github.com/govuk-one-login/authentication-frontend/pull/2318
- https://github.com/govuk-one-login/authentication-frontend/pull/2317

## How to review

1. Code Review

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/2307
