### PR TITLE
Aut 3824/add ipv callback to state machine

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -57,6 +57,7 @@ const USER_JOURNEY_EVENTS = {
   PERMANENTLY_BLOCKED_INTERVENTION: "PERMANENTLY_BLOCKED_INTERVENTION",
   PASSWORD_RESET_INTERVENTION: "PASSWORD_RESET_INTERVENTION",
   COMMON_PASSWORD_AND_AIS_STATUS: "COMMON_PASSWORD_AND_AIS_STATUS",
+  IPV_REVERIFICATION_INIT: "IPV_REVERIFICATION_INIT",
 };
 
 const authStateMachine = createMachine(
@@ -726,6 +727,16 @@ const authStateMachine = createMachine(
         type: "final",
       },
       [PATH_NAMES.UNAVAILABLE_TEMPORARY]: {
+        type: "final",
+      },
+      [PATH_NAMES.MFA_RESET_WITH_IPV]: {
+        on: {
+          [USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT]: [
+            { target: [PATH_NAMES.IPV_CALLBACK] },
+          ],
+        },
+      },
+      [PATH_NAMES.IPV_CALLBACK]: {
         type: "final",
       },
     },

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -3,12 +3,14 @@ import { asyncHandler } from "../../utils/async";
 import { PATH_NAMES } from "../../app.constants";
 import { ipvCallbackGet } from "./ipv-callback-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
 
 router.get(
   PATH_NAMES.IPV_CALLBACK,
   validateSessionMiddleware,
+  allowUserJourneyMiddleware,
   asyncHandler(ipvCallbackGet())
 );
 

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -3,6 +3,8 @@ import { mfaResetAuthorizeService } from "./mfa-reset-authorize-service";
 import { ExpressRouteFunc } from "../../types";
 import { Request, Response } from "express";
 import { BadRequestError } from "../../utils/error";
+import { getNextPathAndUpdateJourney } from "../common/constants";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 
 export function mfaResetWithIpvGet(
   service: MfaResetAuthorizeInterface = mfaResetAuthorizeService()
@@ -22,6 +24,14 @@ export function mfaResetWithIpvGet(
     if (!result.success) {
       throw new BadRequestError(result.data.message, result.data.code);
     }
+
+    getNextPathAndUpdateJourney(
+      req,
+      req.path,
+      USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT,
+      null,
+      sessionId
+    );
 
     const ipvCoreURL = result.data.authorize_url;
 

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
@@ -48,6 +48,15 @@ describe("mfa reset with ipv controller", () => {
       expect(res.redirect).to.have.been.calledWith(IPV_DUMMY_URL);
     });
 
+    it("should set the next path as ipv callback", async () => {
+      await mfaResetWithIpvGet(fakeMfaResetAuthorizeService(true))(
+        req as Request,
+        res as Response
+      );
+
+      expect(req.session.user.journey.nextPath).to.eq(PATH_NAMES.IPV_CALLBACK);
+    });
+
     it("should throw a BadRequestError when the request made to the MFA Reset Authorize endpoint is not successful", async () => {
       await expect(
         mfaResetWithIpvGet(fakeMfaResetAuthorizeService(false))(


### PR DESCRIPTION
## What

Adds the ipv mfa reset and ipv callback routes to the state machine, to ensure that a user cannot arbitrarily transition to the ipv callback route e.g. by changing the url

## How to review

1. Code Review
1. Deploy to dev 
1. Run through an mfa reset journey and see that the journey still works
1. Start a new journey and try to hit the ipv callback endpoint out of journey. See that this is not allowed by the state machine (user should be redirected back to the page they came from e.g. /signin-or-create)
1. Compare this e.g. to running main locally and hitting the endpoint out of journey (you'll need the mfa reset with ipv feature flag turned onto have the route available)

