### PR TITLE
AUT-3806: Move initialisation code to load handler

### DIFF
--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -30,7 +30,6 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
 (function (w) {
   "use strict";
   function appInit() {
-    window.GOVUKFrontend.initAll();
     var cookies = window.GOVSignIn.Cookies();
 
     if (window.DI.analyticsGa4.cookie.hasConsentForAnalytics()) {
@@ -46,9 +45,18 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
     }
   }
 
+  w.DI.analyticsUa.init = appInit;
+})(window);
+
+window.addEventListener("load", (event) => {
+  window.GOVUKFrontend.initAll();
   initEnterPhoneNumber();
 
-  if (w.GOVUK && w.GOVUK.Modules && w.GOVUK.Modules.ShowPassword) {
+  if (
+    window.GOVUK &&
+    window.GOVUK.Modules &&
+    window.GOVUK.Modules.ShowPassword
+  ) {
     var modules = document.querySelectorAll('[data-module="show-password"]');
 
     for (var i = 0, l = modules.length; i < l; i++) {
@@ -57,6 +65,4 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
       }
     }
   }
-
-  w.DI.analyticsUa.init = appInit;
-})(window);
+});

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -1,28 +1,3 @@
-function initFeedbackRadioButtons() {
-  var feedbackRadioButtons = Array.prototype.slice.call(
-    document.querySelectorAll('input[name="feedbackContact"]')
-  );
-  var container = document.querySelector("#contact-details-container");
-  feedbackRadioButtons.forEach(function (element) {
-    element.addEventListener(
-      "click",
-      function (event) {
-        if (event.target.value === "true") {
-          container.classList.remove("govuk-!-display-none");
-        } else {
-          container.classList.add("govuk-!-display-none");
-          var elements = container.getElementsByTagName("input");
-          for (var i = 0; i < elements.length; i++) {
-            if (elements[i].type == "text") {
-              elements[i].value = "";
-            }
-          }
-        }
-      }.bind(this)
-    );
-  });
-}
-
 var onIntNumberSelected = function (intPhoneNumberCheckbox, phoneNumberInput) {
   if (intPhoneNumberCheckbox.checked) {
     phoneNumberInput.value = "";
@@ -71,7 +46,6 @@ window.DI.analyticsUa = window.DI.analyticsUa || {};
     }
   }
 
-  initFeedbackRadioButtons();
   initEnterPhoneNumber();
 
   if (w.GOVUK && w.GOVUK.Modules && w.GOVUK.Modules.ShowPassword) {


### PR DESCRIPTION
## What

This PR does two things: 

1. Moves client-side JavaScript initialisation code that does not relate to analytics or cookie content out of the `appInit()` function and into a `load` event handler. 
2. Removes a redundant client-side function `initFeedbackRadioButtons` that acts on DOM elements not present in the codebase

## Why 

To address a client-side bug identified in `DEV` where interacting with the "I do not have a UK mobile number" checkbox did not reveal / hide the component that allows users to enter an international phone number. Investigation revealed that this was because the relevant initialisation was tied to Google Analytics (specifically, the call to `window.DI.analyticsUa.init`)

## How to review

1. Code Review, commit-by-commit
1. Deploy branch to Dev and run through an account creation journey. You should find that:
    i. interacting with the "I do not have a UK mobile number" works as expected
    ii. Password entry fields are accompanied by a "Show / Hide" button
