### PR TITLE
AUT-3858: Use `encodeURIComponent()` to encode cookie values

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -144,7 +144,6 @@ export function authorizeGet(
         secure: true,
         httpOnly: false,
         domain: res.locals.analyticsCookieDomain,
-        encode: String,
       });
 
       if (

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -121,7 +121,6 @@ describe("authorize controller", () => {
           }),
           secure: true,
           httpOnly: false,
-          encode: String,
         })
       );
       expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
@@ -334,7 +333,6 @@ describe("authorize controller", () => {
         sinon.match({
           secure: true,
           httpOnly: false,
-          encode: String,
         })
       );
       expect(res.redirect).to.have.calledWith(

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -48,7 +48,6 @@ export function cookiesPost(req: Request, res: Response): void {
     secure: true,
     httpOnly: false,
     domain: res.locals.analyticsCookieDomain,
-    encode: String,
   });
   res.locals.originalReferer = sanitize(req.body.originalReferer);
   res.locals.analyticsConsent = consentValue === "true";

--- a/src/components/common/cookies/tests/cookies-controller.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller.test.ts
@@ -64,7 +64,6 @@ describe("cookies controller", () => {
           sinon.match({
             secure: true,
             httpOnly: false,
-            encode: String,
           })
         );
       });
@@ -105,7 +104,6 @@ describe("cookies controller", () => {
           sinon.match({
             secure: true,
             httpOnly: false,
-            encode: String,
           })
         );
       });
@@ -135,7 +133,6 @@ describe("cookies controller", () => {
           sinon.match({
             secure: true,
             httpOnly: false,
-            encode: String,
           })
         );
 


### PR DESCRIPTION
## What

We had used `String()` to override the default encoding function used by the `cookie` library, but that meant we were saving raw JSON as cookie values. This is disallowed by [IETF RFC 6265](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1) as it contains, at a minimum, the double quote character.

While browsers tend to be lenient about this, it is a problem now as the `cookie` library has been updated to more closely follow the RFC, which means it will error if passed a disallowed character. We need to be compliant in order to upgrade our `express` version, which uses the updated `cookie` library.

Instead we switch to using the default `cookie` encode option, `encodeURIComponent()`, which will replace the disallowed characters with a different encoding.

The change does not impact users who had previously set the cookie preferences with the non-encoded mechanism. This repository itself does not use the value of the cookie preference itself. It only sets the value.

Explicit consent is checked via the cookie before G4A is initialised by the frontend analytics package. [This takes the cookie and decodes the value using decodeURIComponent](https://github.com/govuk-one-login/govuk-one-login-frontend/blob/b154baa1fbc6daa1c1df5d20aade9f880356115e/packages/frontend-analytics/src/cookie/cookie.ts#L138).

`decodeURIComponent` behaves the same when passed an encoded string and non-encoded string, see `decodeURIComponent('{"analytics":true}') === decodeURIComponent('%7B%22analytics%22%3Atrue%7D')`.

## How to review

1. Code review
2. Make the following change to stop the local stub automatically setting the cookie consent
```
diff --git a/dev-app.js b/dev-app.js
index b659389f..ad1a7e85 100644
--- a/dev-app.js
+++ b/dev-app.js
@@ -30,7 +30,6 @@ function createAuthorizeRequest() {
       `&state=${randomBytes(32).toString("base64url")}` +
       `&nonce=${randomBytes(32).toString("base64url")}` +
       `&client_id=${process.env.TEST_CLIENT_ID}` +
-      "&cookie_consent=accept" +
       "&_ga=test" +
       ui_locales,
     process.env.API_BASE_URL
```
3. Start the server locally and visit http://localhost:2000/
4. Clear all cookies on the domain
5. Visit http://localhost:2000/ again
6. See the `_ga` & `_gid` cookies are not saved
7. Click "Accept analytics cookies" in the cookie banner
8. Reload the page
9. See the `_ga` & `_gid` cookies are saved
10. See the `cookies_preferences_set` cookie value is `%7B%22analytics%22%3Atrue%7D`
11. Go to http://localhost:3000/cookies
12. At the bottom of the page, select "Do not use cookies that measure how I use GOV.UK One Login" and submit the form.
13. See the `_ga` & `_gid` cookies have been removed
14. See the `cookies_preferences_set` cookie value is `%7B%22analytics%22%3Afalse%7D`
15. Reload the page and see no change
16. Select "Use cookies that measure how I use GOV.UK One Login" and submit the form.
17. See the `_ga` & `_gid` cookies are saved
18. See the `cookies_preferences_set` cookie value is `%7B%22analytics%22%3Atrue%7D`