### PR TITLE
AUT-3857: Update strategic app content for password lockout

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -246,3 +246,10 @@
     border-bottom: 0;
   }
 }
+
+.strategic-app-retry-options {
+  a:first-child {
+    display: inline-block;
+    @include govuk-responsive-margin(2, "bottom");
+  }
+}

--- a/src/components/enter-password/index-account-locked.njk
+++ b/src/components/enter-password/index-account-locked.njk
@@ -17,7 +17,11 @@
 <p class="govuk-body">{{'pages.accountLocked.bulletPointSection.title' | translate}}</p>
 <ul class="govuk-list govuk-list--bullet">
     <li><a href="/reset-password-request" class="govuk-link">{{'pages.accountLocked.bulletPointSection.first' | translate}}</a></li>
-    <li>{{'pages.accountLocked.bulletPointSection.second' | translate}}</li>
+    {% if strategicAppChannel === true %}
+        <li>{{'mobileAppPages.accountLocked.bulletPointSection.second' | translate}}</li>
+    {% else %}
+        <li>{{'pages.accountLocked.bulletPointSection.second' | translate}}</li>
+    {% endif %}
 </ul>
 
 {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}

--- a/src/components/enter-password/index-sign-in-retry-blocked.njk
+++ b/src/components/enter-password/index-sign-in-retry-blocked.njk
@@ -16,11 +16,19 @@
 <p class="govuk-body">{{'pages.signInRetryBlocked.paragraph' | translate}}</p>
 
 <h2 class="govuk-heading-m">{{'pages.signInRetryBlocked.subHeader' | translate}}</h2>
+{% if strategicAppChannel === true %}
+    <p class="govuk-body strategic-app-retry-options">
+        <a href="/reset-password-request" class="govuk-link">{{ 'mobileAppPages.signInRetryBlocked.whatCanYouDo.resetYourPassword' | translate }}</a>
+        <span class="govuk-visually-hidden">.</span><br>
+        {{ 'mobileAppPages.signInRetryBlocked.whatCanYouDo.waitAndTryAgain' | translate }}
+    </p>
+{% else %}
 <p class="govuk-body">{{'pages.signInRetryBlocked.bulletPointSection.title' | translate}}</p>
 <ul class="govuk-list govuk-list--bullet">
-    <li><a href="/reset-password-request" class="govuk-link">{{'pages.signInRetryBlocked.bulletPointSection.first' | translate}}</a></li>
+    <li><a href="/reset-password-request" class="govuk-link">{{ 'pages.signInRetryBlocked.bulletPointSection.first' | translate }}</a></li>
     <li>{{'pages.signInRetryBlocked.bulletPointSection.second' | translate}}</li>
 </ul>
+{% endif %}
 
 {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "e020dd02-2f97-46f9-9b26-c98730c89d73", loggedInStatus: false, dynamic: false })}}
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -210,6 +210,12 @@
       "bulletPointSection": {
         "second": "arhoswch am 2 awr, yna rhowch gynnig arall"
       }
+    },
+    "signInRetryBlocked": {
+      "whatCanYouDo": {
+        "resetYourPassword": "Ailosod eich cyfrinair",
+        "waitAndTryAgain": "Gallwch hefyd aros am 2 awr, yna rhowch gynnig arall."
+      }
     }
   },
   "pages": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -205,6 +205,11 @@
     },
     "accountCreated": {
       "text": "Nawr parhewch i ddefnyddio’r ap."
+    },
+    "accountLocked": {
+      "bulletPointSection": {
+        "second": "arhoswch am 2 awr, yna rhowch gynnig arall"
+      }
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -203,8 +203,14 @@
       "paragraph1": "Use the same email address you used last time you signed in to this app. This is to keep your information secure.",
       "enterYourEmailAddressError": "Enter the same email address you used last time you signed in to this app"
     },
+
     "accountCreated": {
       "text": "Now continue to use the app."
+    },
+    "accountLocked": {
+      "bulletPointSection": {
+        "second": "wait 2 hours, then try again"
+      }
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -203,13 +203,18 @@
       "paragraph1": "Use the same email address you used last time you signed in to this app. This is to keep your information secure.",
       "enterYourEmailAddressError": "Enter the same email address you used last time you signed in to this app"
     },
-
     "accountCreated": {
       "text": "Now continue to use the app."
     },
     "accountLocked": {
       "bulletPointSection": {
         "second": "wait 2 hours, then try again"
+      }
+    },
+    "signInRetryBlocked": {
+      "whatCanYouDo": {
+        "resetYourPassword": "Reset your password",
+        "waitAndTryAgain": "You can also wait 2 hours, then try again."
       }
     }
   },


### PR DESCRIPTION
## What

Introduces content specific to lockout scenarios encountered during sign in journeys in the strategic app channel. These include: 

### Encountering lockout scenarios

- [x] User enters wrong password too many times (Scenario 1)
- [x] User enters their 2FA code incorrectly too many times (Scenario 2)
- [x] User asks to resend the security code too many times (Scenario 3)

### Attempting sign in while a lockout remains active

- [x] Attempted sign in after lockout resulting from Scenario 1
- [x] Attempted sign in after lockout resulting from Scenario 2
- [x] Attempted sign in after lockout resulting from Scenario 3

Note: changes to achieve some of these were actually introduced in an earlier Pull Request [#2313](https://github.com/govuk-one-login/authentication-frontend/pull/2313) because templates are shared.

### Screenshots

#### User enters wrong password too many times (Scenario 1)

<details>

<summary>English</summary>

<img width="296" alt="English" src="https://github.com/user-attachments/assets/710de5f7-6baf-4f5c-a4c6-759bfff34603">

</details>

<details>

<summary>Welsh</summary>

<img width="296" alt="Welsh" src="https://github.com/user-attachments/assets/a736c606-b064-484b-8948-e9349f9f9708">

</details>

#### User enters their 2FA code incorrectly too many times (Scenario 2)

<details>

<summary>English</summary>

<img width="296" alt="English" src="https://github.com/user-attachments/assets/c1f256f9-78b8-48f2-8820-61b5f2e6ca80">

</details>

<details>

<summary>Welsh</summary>

<img width="296" alt="Welsh" src="https://github.com/user-attachments/assets/591f6353-15b5-457c-96b1-daf2716e7f98">

</details>

#### User asks to resend the security code too many times (Scenario 3)

<details>

<summary>English</summary>

<img width="296" alt="English" src="https://github.com/user-attachments/assets/512a3791-46bc-444d-a951-732818808bbd">


</details>

<details>

<summary>Welsh</summary>


<img width="296" alt="Welsh" src="https://github.com/user-attachments/assets/d8c32915-c6b9-4189-951c-f385e211e0de">

</details>

#### Attempted sign in after lockout resulting from Scenario 1 

<details>

<summary>English</summary>

<img width="296" alt="English" src="https://github.com/user-attachments/assets/79856560-45c9-4f4e-a0c6-2bd9c3b4ebe6">


</details>

<details>

<summary>Welsh</summary>

<img width="296" alt="Welsh" src="https://github.com/user-attachments/assets/7dfa9fb2-9ceb-444e-9165-7d90e9fde465">

</details>

#### Attempted sign in after lockout resulting from Scenario 2

<details>

<summary>English</summary>

<img width="296" alt="English" src="https://github.com/user-attachments/assets/844ebcbf-d88a-4338-b480-51a3ca1648be">


</details>

<details>

<summary>Welsh</summary>

<img width="296" alt="Welsh" src="https://github.com/user-attachments/assets/2e6f60bf-f4ae-4ab2-9243-4368651a5758">

</details>

#### Attempted sign in after lockout resulting from Scenario 3

<details>

<summary>English</summary>

<img width="296" alt="English" src="https://github.com/user-attachments/assets/7e70f235-cd3d-482e-88d7-cdefb4535569">

</details>

<details>

<summary>Welsh</summary>

<img width="296" alt="Welsh" src="https://github.com/user-attachments/assets/24732475-e8b7-4d3b-9514-1ec47a03426f">

</details>

## How to review

Code review, commit-by-commit. 

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.
