### PR TITLE
DFC-718: Add missing data attributes to trigger navigation tracking

### DIFF
--- a/src/components/account-creation/resend-mfa-code/index.njk
+++ b/src/components/account-creation/resend-mfa-code/index.njk
@@ -31,7 +31,11 @@
         {{ govukButton({
         "text": "pages.resendMfaCode.continue" | translate,
         "type": "Submit",
-        "preventDoubleClick": true
+        "preventDoubleClick": true,
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
     </form>

--- a/src/components/account-intervention/password-reset-required/index.njk
+++ b/src/components/account-intervention/password-reset-required/index.njk
@@ -15,7 +15,11 @@
     {{ govukButton({
       "text": "general.continue.label" | translate,
       "type": "Submit",
-      "preventDoubleClick": true
+      "preventDoubleClick": true,
+      attributes: {
+          "data-nav": "true",
+          "data-link": "/undefined"
+      }
     }) }}
 
     </form>

--- a/src/components/account-not-found/index-mandatory.njk
+++ b/src/components/account-not-found/index-mandatory.njk
@@ -33,7 +33,11 @@
 {{ govukButton({
     "text": "pages.accountNotFoundMandatory.createAccountButtonText" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
 }) }}
 
 <p class="govuk-body">

--- a/src/components/account-not-found/index-one-login.njk
+++ b/src/components/account-not-found/index-one-login.njk
@@ -36,7 +36,11 @@
     "text": "pages.accountNotFoundOneLogin.signInToServiceButtonText" | translate,
     "value": "sign-in-to-a-service",
     "name": "optionSelected",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/check-your-email"
+    }
 }) }}
 
 <p class="govuk-body">

--- a/src/components/account-not-found/index-optional.njk
+++ b/src/components/account-not-found/index-optional.njk
@@ -31,7 +31,11 @@
 {{ govukButton({
     "text": "pages.accountNotFoundOptional.createAccountButtonText" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
 }) }}
 
 <p class="govuk-body">

--- a/src/components/account-recovery/change-security-codes-confirmation/index.njk
+++ b/src/components/account-recovery/change-security-codes-confirmation/index.njk
@@ -20,7 +20,11 @@
 {{ govukButton({
       "text": "general.continue.label" | translate,
       "type": "Submit",
-      "preventDoubleClick": true
+      "preventDoubleClick": true,
+      attributes: {
+          "data-nav": "true",
+          "data-link": "/undefined"
+      }
     }) }}
 
 </form>

--- a/src/components/account-recovery/check-your-email-security-codes/index.njk
+++ b/src/components/account-recovery/check-your-email-security-codes/index.njk
@@ -53,7 +53,11 @@
     {{ govukButton({
       "text": "general.continue.label" | translate,
       "type": "Submit",
-      "preventDoubleClick": true
+      "preventDoubleClick": true,
+      attributes: {
+          "data-nav": "true",
+          "data-link": "/undefined"
+      }
     }) }}
 
     {{ govukDetails({

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -52,7 +52,11 @@
     {{ govukButton({
       "text": "general.continue.label" | translate,
       "type": "Submit",
-      "preventDoubleClick": true
+      "preventDoubleClick": true,
+      attributes: {
+          "data-nav": "true",
+          "data-link": "/undefined"
+      }
     }) }}
 
     {{ govukDetails({

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -66,7 +66,11 @@
     {{ govukButton({
       "text": "general.continue.label" | translate,
       "type": "Submit",
-      "preventDoubleClick": true
+      "preventDoubleClick": true,
+      attributes: {
+          "data-nav": "true",
+          "data-link": "/undefined"
+      }
     }) }}
 
     {{ govukDetails({

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -499,7 +499,9 @@
             "type": "submit",
             "preventDoubleClick": true,
             attributes: {
-                "id": "save-cookie-settings"
+                "id": "save-cookie-settings",
+                "data-nav": "true",
+                "data-link": "/undefined"
             }
         }) }}
 

--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -12,7 +12,11 @@
 
     {{ govukButton({
         "text": "error.error404.content.govUKHomepageButtonText" | translate,
-        "type": "Submit",
+        "type": "Submit",,
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        },
         "href": "error.error404.content.govUKHomepageButtonHref" | translate
     }) }}
 

--- a/src/components/common/errors/session-expired.njk
+++ b/src/components/common/errors/session-expired.njk
@@ -13,7 +13,11 @@
 {{ govukButton({
 "text": "error.timeoutError.content.govUKHomepageButtonText" | translate,
 "type": "Submit",
-"href": "error.timeoutError.content.govUKHomepageButtonHref" | translate
+"href": "error.timeoutError.content.govUKHomepageButtonHref" | translate,
+attributes: {
+    "data-nav": "true",
+    "data-link": "/undefined"
+}
 }) }}
 
 {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}

--- a/src/components/common/footer/support.njk
+++ b/src/components/common/footer/support.njk
@@ -43,7 +43,11 @@
 {{ govukButton({
   "text": 'pages.support.section1.supportTypeRadios.continueButtonText' | translate,
   "type": "Submit",
-  "preventDoubleClick": true
+  "preventDoubleClick": true,
+  attributes: {
+      "data-nav": "true",
+      "data-link": "/undefined"
+  }
 }) }}
 
 </form>

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -92,7 +92,11 @@
 {{ govukButton({
     "text": "pages.contactUsPublic.continueLabel" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
 }) }}
 
 </form>

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -52,7 +52,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
     </form>

--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -49,7 +49,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
     </form>

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -35,7 +35,11 @@
     {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
   }) }}
 
   </form>

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -43,7 +43,11 @@
 {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/check-your-email"
+    }
 }) }}
 
 </form>

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -35,7 +35,11 @@
 {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
 }) }}
 
 </form>

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -44,7 +44,11 @@
     {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
 }) }}
 
 </form>

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -67,7 +67,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
     </form>

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -62,7 +62,11 @@
     {{ govukButton({
   "text": "general.continue.label" | translate,
   "type": "Submit",
-  "preventDoubleClick": true
+  "preventDoubleClick": true,
+  attributes: {
+      "data-nav": "true",
+      "data-link": "/undefined"
+  }
   }) }}
 
     {{ govukDetails({

--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -42,7 +42,11 @@
     {{ govukButton({
         "text": "general.continue.label" | translate,
         "type": "Submit",
-        "preventDoubleClick": true
+        "preventDoubleClick": true,
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
 <p class="govuk-body">

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -36,7 +36,11 @@
 {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
 }) }}
 
 <p class="govuk-body">

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -78,7 +78,11 @@
     {{ govukButton({
   "text": "general.continue.label" | translate,
   "type": "Submit",
-  "preventDoubleClick": true
+  "preventDoubleClick": true,
+  attributes: {
+      "data-nav": "true",
+      "data-link": "/undefined"
+  }
   }) }}
 
   </form>

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -37,7 +37,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
     </form>

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -40,7 +40,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
     </form>

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -28,8 +28,10 @@
         "type": "Submit",
         "preventDoubleClick": true,
          attributes: {
-            "id": "resend-email-code"
-         }
+            "id": "resend-email-code",
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
     </form>

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -34,7 +34,11 @@
         {{ govukButton({
         "text": "pages.resendMfaCode.continue" | translate,
         "type": "Submit",
-        "preventDoubleClick": true
+        "preventDoubleClick": true,
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
     </form>

--- a/src/components/reset-password-2fa-auth-app/index.njk
+++ b/src/components/reset-password-2fa-auth-app/index.njk
@@ -45,7 +45,11 @@
     {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
-    "preventDoubleClick": true
+    "preventDoubleClick": true,
+    attributes: {
+        "data-nav": "true",
+        "data-link": "/undefined"
+    }
   }) }}
 
   </form>

--- a/src/components/reset-password-2fa-sms/index.njk
+++ b/src/components/reset-password-2fa-sms/index.njk
@@ -53,7 +53,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
         {{ govukDetails({

--- a/src/components/reset-password-check-email/index-reset-password-resend-code.njk
+++ b/src/components/reset-password-check-email/index-reset-password-resend-code.njk
@@ -21,7 +21,11 @@
     {{ govukButton({
         "text": 'pages.resendMfaCode.continue' | translate,
         "type": "Submit",
-        "preventDoubleClick": true
+        "preventDoubleClick": true,
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
 </form>

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -69,7 +69,11 @@
         {{ govukButton({
         "text": 'pages.resetPasswordCheckEmail.buttonText' | translate,
         "type": "Submit",
-        "preventDoubleClick": true
+        "preventDoubleClick": true,
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
     </form>

--- a/src/components/reset-password/index.njk
+++ b/src/components/reset-password/index.njk
@@ -59,7 +59,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
     </form>

--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -71,7 +71,11 @@
 {{ govukButton({
   "text": 'pages.getSecurityCodes.continueButtonText' | translate,
   "type": "Submit",
-  "preventDoubleClick": true
+  "preventDoubleClick": true,
+  attributes: {
+      "data-nav": "true",
+      "data-link": "/undefined"
+  }
 }) }}
 
 </form>

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -73,7 +73,11 @@
         {{ govukButton({
             "text": "general.continue.label" | translate,
             "type": "Submit",
-            "preventDoubleClick": true
+            "preventDoubleClick": true,
+            attributes: {
+                "data-nav": "true",
+                "data-link": "/undefined"
+            }
         }) }}
 
         <p class="govuk-body">

--- a/src/components/sign-in-or-create/index-mobile.njk
+++ b/src/components/sign-in-or-create/index-mobile.njk
@@ -18,7 +18,9 @@
             text: 'mobileAppPages.signIn.button' | translate,
             classes: "govuk-button--primary",
             attributes: {
-                "id": "sign-in-button"
+                "id": "sign-in-button",
+                "data-nav": "true",
+                "data-link": "/enter-email"
             }
         }) }}
 

--- a/src/components/updated-terms-conditions/index.njk
+++ b/src/components/updated-terms-conditions/index.njk
@@ -26,7 +26,11 @@
         "preventDoubleClick": true,
         "classes": 'govuk-button--inverse',
         "name": "termsAndConditionsResult",
-        "value": "accept"
+        "value": "accept",
+        attributes: {
+            "data-nav": "true",
+            "data-link": "/undefined"
+        }
     }) }}
 
     <br >


### PR DESCRIPTION
## What

The initial implementation of GA4 missed some hooks required to fire the navigation tracker from a button. This PR adds the `data-link` and `data-nav` HTML attributes to the govuk buttons on each page

The `data-link` value for the majority of pages has been defined as `/undefined`. As the authentication journey has a number of branching paths, this has been discussed with the Analytics team and approved by Sam Evatt.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->