### PR TITLE
AUT-3690: Remove unsupported nested if from basic-auth sidecar definition

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -950,20 +950,12 @@ Resources:
                     - SwitchToMigratedZone
                     - !FindInMap [
                         EnvironmentConfiguration,
-                        !If [
-                          UseSubEnvironment,
-                          !Ref SubEnvironment,
-                          !Ref Environment,
-                        ],
+                        !Ref Environment,
                         migratedDomain,
                       ]
                     - !FindInMap [
                         EnvironmentConfiguration,
-                        !If [
-                          UseSubEnvironment,
-                          !Ref SubEnvironment,
-                          !Ref Environment,
-                        ],
+                        !Ref Environment,
                         transitionalDomain,
                       ]
               Secrets:


### PR DESCRIPTION
## What

Remove unsupported nested if from basic-auth sidecar definition
Issue: [AUT-3690]

## How to review

Can only be reproduced when enabling basic-auth sidecar in any of the env: build to integration