### PR TITLE
AUT-3754: Make blocking code async

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -7,5 +7,6 @@ declare namespace Express {
     t: TFunction;
     csrfToken?: () => string;
     log: pino.Logger;
+    generatedSessionId?: string;
   }
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "qrcode": "^1.5.0",
     "redis": "^4.6.13",
     "uglify-js": "^3.14.5",
+    "uid-safe": "^2.1.5",
     "uuid": "^11.0.2",
     "xss": "^1.0.10",
     "xstate": "^4.26.1"
@@ -124,6 +125,7 @@
     "@types/sinon": "^17.0.3",
     "@types/sinon-chai": "^3.2.8",
     "@types/supertest": "^6.0.2",
+    "@types/uid-safe": "^2.1.5",
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "@typescript-eslint/parser": "^8.13.0",
     "chai": "^4.3.6",

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -6,12 +6,12 @@ import {
 } from "../config";
 import { generateNonce } from "../utils/strings";
 
-export function setLocalVarsMiddleware(
+export async function setLocalVarsMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
-): void {
-  res.locals.scriptNonce = generateNonce();
+): Promise<void> {
+  res.locals.scriptNonce = await generateNonce();
   res.locals.accountManagementUrl = getAccountManagementUrl();
   res.locals.analyticsCookieDomain = getAnalyticsCookieDomain();
   res.locals.languageToggleEnabled = getLanguageToggleEnabled();

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "crypto";
+import { promisify } from "util";
 import xss from "xss";
 
 export function containsNumber(value: string): boolean {
@@ -13,8 +14,10 @@ export function redactPhoneNumber(value: string): string | undefined {
   return value ? value.trim().slice(value.length - 4) : undefined;
 }
 
-export function generateNonce(): string {
-  return randomBytes(16).toString("hex");
+const asyncRandomBytes = promisify(randomBytes);
+
+export async function generateNonce(): Promise<string> {
+  return (await asyncRandomBytes(16)).toString("hex");
 }
 
 export function sanitize(value: string): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2078,6 +2078,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
+"@types/uid-safe@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@types/uid-safe/-/uid-safe-2.1.5.tgz#32b27c6f1a9022a29762cf7c4350891dd7b154e2"
+  integrity sha512-RwEfbxqXKEay2b5p8QQVllfnMbVPUZChiKKZ2M6+OSRRmvr4HTCCUZTWhr/QlmrMnNE0ViNBBbP1+5plF9OGRw==
+
 "@types/uuid@^9.0.1":
   version "9.0.8"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
@@ -6571,7 +6576,7 @@ uglify-js@^3.14.5:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-uid-safe@2.1.5, uid-safe@~2.1.5:
+uid-safe@2.1.5, uid-safe@^2.1.5, uid-safe@~2.1.5:
   version "2.1.5"
   resolved "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz"
   integrity sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==


### PR DESCRIPTION
Per https://github.com/govuk-one-login/architecture/blob/913c04af8b57e2cdce07c4b242a409690852d527/rfc/0083-express-on-ecs.md#too-many-connections, this makes some blocking calls async

- nonce generation
- session ID generation

Both "inspired" by changes in ipv-core-front.

This has been tested in sandpit
