### PR TITLE
BAU: Remove Chai As Promised Dependency

### DIFF
--- a/dev-check-environment.js
+++ b/dev-check-environment.js
@@ -1,6 +1,4 @@
 const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-chai.use(chaiAsPromised);
 chai.config.truncateThreshold = 0;
 const { expect } = chai;
 
@@ -40,7 +38,13 @@ describe("environment", function () {
 
     it("should be importable by jose", async function () {
       if (key === undefined) return this.skip();
-      await expect(jose.importSPKI(key, "ES256"), "jose could not import the PEM. Other failing tests may help you identify why").to.not.be.rejected;
+      try {
+        await jose.importSPKI(key, "ES256");
+      } catch (error) {
+        expect.fail(
+          `jose could not import the PEM. Other failing tests may help you identify why. Message: ${error.message}`
+        );
+      }
     });
 
     it("should not contain '\\n'", function () {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",
-    "@types/chai-as-promised": "^7.1.5",
     "@types/cheerio": "^0.22.31",
     "@types/cookie-parser": "^1.4.2",
     "@types/csurf": "^1.11.2",
@@ -128,7 +127,6 @@
     "@typescript-eslint/eslint-plugin": "^8.13.0",
     "@typescript-eslint/parser": "^8.13.0",
     "chai": "^4.3.6",
-    "chai-as-promised": "^7.1.1",
     "chai-http": "^5.1.1",
     "cheerio": "^1.0.0-rc.10",
     "concurrently": "^9.0.1",

--- a/src/components/account-recovery/check-your-email-security-codes/tests/send-email-otp-middleware.test.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/send-email-otp-middleware.test.ts
@@ -7,6 +7,7 @@ import { sendEmailOtp } from "../send-email-otp-middleware";
 import { SendNotificationServiceInterface } from "../../../common/send-notification/types";
 import { BadRequestError } from "../../../../utils/error";
 import { ERROR_CODES } from "../../../common/constants";
+import { strict as assert } from "assert";
 
 describe("sendEmailOTPMiddleware", () => {
   let req: Partial<Request>;
@@ -79,13 +80,16 @@ describe("sendEmailOTPMiddleware", () => {
       }),
     } as unknown as SendNotificationServiceInterface;
 
-    await expect(
-      sendEmailOtp(fakeNotificationService)(
-        req as Request,
-        res as Response,
-        next as NextFunction
-      )
-    ).to.be.rejectedWith(BadRequestError, "999999999999999:test error message");
+    await assert.rejects(
+      async () =>
+        sendEmailOtp(fakeNotificationService)(
+          req as Request,
+          res as Response,
+          next as NextFunction
+        ),
+      BadRequestError,
+      "999999999999999:test error message"
+    );
 
     expect(next).to.not.be.called;
   });

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -11,6 +11,7 @@ import { CreatePasswordServiceInterface } from "../types";
 import { PATH_NAMES } from "../../../app.constants";
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { strict as assert } from "assert";
 
 describe("create-password controller", () => {
   let req: RequestOutput;
@@ -58,9 +59,9 @@ describe("create-password controller", () => {
         req.body.password = "password1";
         req.session.user = undefined;
 
-        await expect(
-          createPasswordPost(fakeService)(req as Request, res as Response)
-        ).to.be.rejectedWith(
+        await assert.rejects(
+          async () =>
+            createPasswordPost(fakeService)(req as Request, res as Response),
           TypeError,
           "Cannot read properties of undefined (reading 'email')"
         );
@@ -75,9 +76,9 @@ describe("create-password controller", () => {
         req.body = undefined;
         req.session.user.email = "joe.bloggs@test.com";
 
-        await expect(
-          createPasswordPost(fakeService)(req as Request, res as Response)
-        ).to.be.rejectedWith(
+        await assert.rejects(
+          async () =>
+            createPasswordPost(fakeService)(req as Request, res as Response),
           TypeError,
           "Cannot read properties of undefined (reading 'password')"
         );
@@ -93,9 +94,12 @@ describe("create-password controller", () => {
         req.body.password = "password1";
         req.session.user.email = "joe.bloggs@test.com";
 
-        await expect(
-          createPasswordPost(fakeService)(req as Request, res as Response)
-        ).to.be.rejectedWith(Error, "Internal server error");
+        await assert.rejects(
+          async () =>
+            createPasswordPost(fakeService)(req as Request, res as Response),
+          Error,
+          "Internal server error"
+        );
         expect(fakeService.signUpUser).to.have.been.called;
       });
     });

--- a/src/components/doc-checking-app/tests/doc-checking-app-controller.test.ts
+++ b/src/components/doc-checking-app/tests/doc-checking-app-controller.test.ts
@@ -9,6 +9,7 @@ import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { PATH_NAMES } from "../../../app.constants";
 import { docCheckingAppGet } from "../doc-checking-app-controller";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { strict as assert } from "assert";
 
 describe("doc checking app controller", () => {
   let req: RequestOutput;
@@ -51,9 +52,12 @@ describe("doc checking app controller", () => {
         }),
       } as unknown as DocCheckingAppInterface;
 
-      await expect(
-        docCheckingAppGet(fakeService)(req as Request, res as Response)
-      ).to.be.rejectedWith("1222:Error occurred");
+      await assert.rejects(
+        async () =>
+          docCheckingAppGet(fakeService)(req as Request, res as Response),
+        Error,
+        "1222:Error occurred"
+      );
     });
   });
 });

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -17,6 +17,7 @@ import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { CheckReauthServiceInterface } from "../../check-reauth-users/types";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
+import { strict as assert } from "assert";
 
 describe("enter email controller", () => {
   let req: RequestOutput;
@@ -206,9 +207,12 @@ describe("enter email controller", () => {
         userExists: sinon.fake.throws(error),
       };
 
-      await expect(
-        enterEmailPost(fakeService)(req as Request, res as Response)
-      ).to.be.rejectedWith(Error, "Internal server error");
+      await assert.rejects(
+        async () =>
+          enterEmailPost(fakeService)(req as Request, res as Response),
+        Error,
+        "Internal server error"
+      );
       expect(fakeService.userExists).to.have.been.calledOnce;
     });
 
@@ -219,9 +223,9 @@ describe("enter email controller", () => {
 
       req.session.user = undefined;
 
-      await expect(
-        enterEmailPost(fakeService)(req as Request, res as Response)
-      ).to.be.rejectedWith(
+      await assert.rejects(
+        async () =>
+          enterEmailPost(fakeService)(req as Request, res as Response),
         TypeError,
         "Cannot set properties of undefined (setting 'email')"
       );

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -20,6 +20,7 @@ import { accountInterventionsFakeHelper } from "../../../../test/helpers/account
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 import { ReauthJourneyError } from "../../../utils/error";
+import { strict as assert } from "assert";
 
 describe("enter password controller", () => {
   let req: RequestOutput;
@@ -410,13 +411,16 @@ describe("enter password controller", () => {
         sendMfaCode: sinon.fake(),
       };
 
-      await expect(
-        enterPasswordPost(
-          false,
-          fakeService,
-          fakeMfaService
-        )(req as Request, res as Response)
-      ).to.be.rejectedWith(Error, "Internal server error");
+      await assert.rejects(
+        async () =>
+          enterPasswordPost(
+            false,
+            fakeService,
+            fakeMfaService
+          )(req as Request, res as Response),
+        Error,
+        "Internal server error"
+      );
       expect(fakeService.loginUser).to.have.been.calledOnce;
     });
 

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -13,6 +13,7 @@ import { PATH_NAMES } from "../../../app.constants";
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { ERROR_CODES } from "../../common/constants";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { strict as assert } from "assert";
 
 const OLD_ENV = process.env;
 
@@ -103,12 +104,15 @@ describe("enter phone number controller", () => {
 
       req.body.email = "test.test.com";
 
-      await expect(
-        enterPhoneNumberPost(fakeNotificationService)(
-          req as Request,
-          res as Response
-        )
-      ).to.be.rejectedWith(Error, "Internal server error");
+      await assert.rejects(
+        async () =>
+          enterPhoneNumberPost(fakeNotificationService)(
+            req as Request,
+            res as Response
+          ),
+        Error,
+        "Internal server error"
+      );
 
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
     });

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -8,6 +8,7 @@ import { ReverificationResultInterface } from "../types";
 import { ipvCallbackGet } from "../ipv-callback-controller";
 import { BadRequestError } from "../../../utils/error";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
+import { strict as assert } from "assert";
 
 const fakeReverificationResultService = (success: boolean) => {
   const failureData = {
@@ -70,12 +71,12 @@ describe("ipv callback controller", () => {
   it("get should raise error when reverification result is not successful", async () => {
     const fakeServiceReturningFailure = fakeReverificationResultService(false);
 
-    await expect(
-      ipvCallbackGet(fakeServiceReturningFailure)(
-        req as Request,
-        res as Response
-      )
-    ).to.be.rejectedWith(
+    await assert.rejects(
+      async () =>
+        ipvCallbackGet(fakeServiceReturningFailure)(
+          req as Request,
+          res as Response
+        ),
       BadRequestError,
       "500:Internal error occurred in backend"
     );
@@ -100,12 +101,15 @@ describe("ipv callback controller", () => {
       const fakeServiceReturningSuccess = fakeReverificationResultService(true);
       req.query = testCase.query;
 
-      await expect(
-        ipvCallbackGet(fakeServiceReturningSuccess)(
-          req as Request,
-          res as Response
-        )
-      ).to.be.rejectedWith(BadRequestError, testCase.expectedMessage);
+      await assert.rejects(
+        async () =>
+          ipvCallbackGet(fakeServiceReturningSuccess)(
+            req as Request,
+            res as Response
+          ),
+        BadRequestError,
+        testCase.expectedMessage
+      );
     }
   });
 });

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
@@ -7,6 +7,7 @@ import { expect } from "chai";
 import { MfaResetAuthorizeInterface } from "../types";
 import { Request, Response } from "express";
 import { BadRequestError } from "../../../utils/error";
+import { strict as assert } from "assert";
 
 const IPV_DUMMY_URL =
   "https://test-idp-url.com/callback?code=123-4ddkk0sdkkd-ad";
@@ -58,12 +59,15 @@ describe("mfa reset with ipv controller", () => {
     });
 
     it("should throw a BadRequestError when the request made to the MFA Reset Authorize endpoint is not successful", async () => {
-      await expect(
-        mfaResetWithIpvGet(fakeMfaResetAuthorizeService(false))(
-          req as Request,
-          res as Response
-        )
-      ).to.be.rejectedWith(BadRequestError, "500:Test error message");
+      await assert.rejects(
+        async () =>
+          mfaResetWithIpvGet(fakeMfaResetAuthorizeService(false))(
+            req as Request,
+            res as Response
+          ),
+        BadRequestError,
+        "500:Test error message"
+      );
     });
   });
 });

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
@@ -18,6 +18,7 @@ import { SendNotificationServiceInterface } from "../../common/send-notification
 import { VerifyMfaCodeInterface } from "../../enter-authenticator-app-code/types";
 import * as journey from "../../common/journey/journey";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { strict as assert } from "assert";
 
 describe("setup-authenticator-app controller", () => {
   let req: RequestOutput;
@@ -219,12 +220,15 @@ describe("setup-authenticator-app controller", () => {
         }),
       } as unknown as VerifyMfaCodeInterface;
 
-      await expect(
-        setupAuthenticatorAppPost(fakeMfAService)(
-          req as Request,
-          res as Response
-        )
-      ).to.be.rejectedWith(BadRequestError, "1234:error");
+      await assert.rejects(
+        async () =>
+          setupAuthenticatorAppPost(fakeMfAService)(
+            req as Request,
+            res as Response
+          ),
+        BadRequestError,
+        "1234:error"
+      );
     });
   });
 });

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -1,7 +1,6 @@
 import chai from "chai";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
-import chaiAsPromised from "chai-as-promised";
 import { jestSnapshotPlugin } from "mocha-chai-jest-snapshot";
 import supertest, { Test } from "supertest";
 import { expectAnalyticsPropertiesMatchSnapshot } from "../helpers/expect-response-helpers";
@@ -9,7 +8,6 @@ import TestAgent = require("supertest/lib/agent");
 
 chai.should();
 chai.use(sinonChai);
-chai.use(chaiAsPromised);
 chai.use(jestSnapshotPlugin());
 
 const expect = chai.expect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1740,13 +1740,6 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/chai-as-promised@^7.1.5":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.8.tgz#f2b3d82d53c59626b5d6bbc087667ccb4b677fe9"
-  integrity sha512-ThlRVIJhr69FLlh6IctTXFkmhtP3NpMZ2QGq69StYLyKZFp/HOp1VdKZj7RvfNWYYcJ1xlbLGLLWj1UvP5u/Gw==
-  dependencies:
-    "@types/chai" "*"
-
 "@types/chai@*", "@types/chai@^4.3.0":
   version "4.3.0"
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz"
@@ -2741,13 +2734,6 @@ caniuse-lite@^1.0.30001646:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz#31218de3463fabb44d0b7607b652e56edf2e2355"
   integrity sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==
 
-chai-as-promised@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz"
-  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
-  dependencies:
-    check-error "^1.0.2"
-
 chai-http@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-5.1.1.tgz#de3435e19b9e5ef235c186673da10b823e6c76f1"
@@ -2795,7 +2781,7 @@ charset@^1.0.1:
   resolved "https://registry.yarnpkg.com/charset/-/charset-1.0.1.tgz#8d59546c355be61049a8fa9164747793319852bd"
   integrity sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg==
 
-check-error@^1.0.2, check-error@^1.0.3:
+check-error@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
   integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==


### PR DESCRIPTION
## What

This removes chai as promised as a dependency. This is because:
a) the latest version of chai-as-promised only works with ESM, which we're not using and would be a pain to convert.
b) chai-as-promised is somewhat deprecated since e.g. mocha introduced async support, and their documentation suggests to only use it in the case of not using a test framework with async support: [https://www.npmjs.com/package/chai-as-promised#working-with-non-promisefriendly-test-runners
](https://www.npmjs.com/package/chai-as-promised#working-with-non-promisefriendly-test-runners)


It has the added benefit of reducing our dependencies!

## How to review

1. Code Review
1. See all the tests here are passing. You might want to break a few of them locally and see them still fail too - I did this as I was going but a spot check wouldn't hurt :-) 
1. Verify that running the local startup script still works

## Related PRs

Means that we can close [this](https://github.com/govuk-one-login/authentication-frontend/pull/2351) and never faff around with dependabots for these dependencies again!