### PR TITLE
DO NOT MERGE: AUT-3880: Update govuk-frontend to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "express-session": "^1.17.2",
     "express-validator": "^6.13.0",
     "globals": "^15.12.0",
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "^4.9.0",
     "helmet": "8.0.0",
     "i18next": "^23.16.4",
     "i18next-fs-backend": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4094,10 +4094,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz"
-  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
+govuk-frontend@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.9.0.tgz#a09068130fa087e67de25956940cb8280a364372"
+  integrity sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==
 
 graceful-fs@^4.1.15:
   version "4.2.8"


### PR DESCRIPTION
## What

Update govuk-frontend to 4.9.0.

This is part of a co-ordinated update of the Crown Copyright logo.

Merge this PR only at the appropriate time.

Before

<img width="202" alt="Screenshot 2024-12-04 at 11 39 40" src="https://github.com/user-attachments/assets/ed106803-2ad7-43fc-9b06-aea0dc078be1">

After

<img width="175" alt="Screenshot 2024-12-04 at 11 39 48" src="https://github.com/user-attachments/assets/d4b5ca5b-47f5-42a1-b4a1-8c17bddff44c">

## How to review

1. Code Review
1. Deploy to a dev environment with `./deploy-authdev.sh` or run the frontend application locally.
1. Compare the Crown Copyright logo in the footer of pages with the current live version to check that they are different.
1. Run regression tests as required.

## Checklist

- [x] A UCD review has been performed.
