### PR TITLE
Aut 3826/create cannot change security codes page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -67,6 +67,7 @@ export const PATH_NAMES = {
   ERROR_PAGE: "/error",
   SECURITY_CODE_ENTERED_EXCEEDED: "/security-code-entered-exceeded",
   CHANGE_SECURITY_CODES: "/change-security-codes",
+  CANNOT_CHANGE_SECURITY_CODES: "/cannot-change-security-codes",
   CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES: "/check-email-change-security-codes",
   CHANGE_SECURITY_CODES_CONFIRMATION: "/change-codes-confirmed",
   PASSWORD_RESET_REQUIRED: "/password-reset-required",

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -59,6 +59,8 @@ const USER_JOURNEY_EVENTS = {
   COMMON_PASSWORD_AND_AIS_STATUS: "COMMON_PASSWORD_AND_AIS_STATUS",
   IPV_REVERIFICATION_INIT: "IPV_REVERIFICATION_INIT",
   IPV_REVERIFICATION_COMPLETED: "IPV_REVERIFICATION_COMPLETED",
+  IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE:
+    "IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE",
 };
 
 const authStateMachine = createMachine(
@@ -744,7 +746,15 @@ const authStateMachine = createMachine(
               target: [PATH_NAMES.GET_SECURITY_CODES],
             },
           ],
+          [USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE]: [
+            {
+              target: [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES],
+            },
+          ],
         },
+      },
+      [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES]: {
+        type: "final",
       },
     },
   },

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -2,15 +2,15 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitleName = "You cannot change how you get security codes" %}
+{% set pageTitleName = 'pages.cannotChangeHowGetSecurityCodeMfaReset.title' | translate %}
 
 {% block content %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">You cannot change how you get security codes</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.header' | translate}}</h1>
 
-  <p class="govuk-body">You can only sign into your GOV.UK One Login using the method you already have set up to get security codes.</p>
-  <p class="govuk-body">If you’ve permanently lost access to this method, you should delete your GOV.UK One Login so you can create a new one.</p>
+  <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph1' | translate}}</p>
+  <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph2' | translate}}</p>
 
-  <h2 class="govuk-heading-m">What would you like to do?</h2>
+  <h2 class="govuk-heading-m">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.header' | translate}}</h2>
 
   {{ govukRadios({
       name: "cannot_change_how_get_security_code_action",
@@ -20,16 +20,16 @@
       items: [
           {
               value: "help-to-delete-account",
-              text: "Get help to delete your GOV.UK One Login from the support team",
+              text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option1Text' | translate,
               id: "help-to-delete-account",
               checked: false,
               hint: {
-                text: "Call or use webchat to contact the GOV.UK One Login team"
+                text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option1Hint' | translate
               }
           },
           {
               value: "retry-security-code",
-              text: "Try entering a security code again with the method you already have set up",
+              text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option2Text' | translate,
               id: "retry-security-code",
               checked: false
           }

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -1,0 +1,5 @@
+{% extends "common/layout/base.njk" %}
+
+{% block content %}
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">Hello world</h1>
+{% endblock %}

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -1,5 +1,45 @@
 {% extends "common/layout/base.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitleName = "You cannot change how you get security codes" %}
 
 {% block content %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">Hello world</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">You cannot change how you get security codes</h1>
+
+  <p class="govuk-body">You can only sign into your GOV.UK One Login using the method you already have set up to get security codes.</p>
+  <p class="govuk-body">If you’ve permanently lost access to this method, you should delete your GOV.UK One Login so you can create a new one.</p>
+
+  <h2 class="govuk-heading-m">What would you like to do?</h2>
+
+  {{ govukRadios({
+      name: "cannot_change_how_get_security_code_action",
+      attributes: {
+          "id": "radio-cannot-change-how-get-security-code-action"
+      },
+      items: [
+          {
+              value: "help-to-delete-account",
+              text: "Get help to delete your GOV.UK One Login from the support team",
+              id: "help-to-delete-account",
+              checked: false,
+              hint: {
+                text: "Call or use webchat to contact the GOV.UK One Login team"
+              }
+          },
+          {
+              value: "retry-security-code",
+              text: "Try entering a security code again with the method you already have set up",
+              id: "retry-security-code",
+              checked: false
+          }
+      ]
+  }) }}
+
+  {{ govukButton({
+    "text": "general.continue.label" | translate,
+    "type": "Submit",
+    "preventDoubleClick": true
+  }) }}
+
 {% endblock %}

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -50,3 +50,10 @@ export function ipvCallbackGet(
     );
   };
 }
+
+export function cannotChangeSecurityCodesGet(
+  req: Request,
+  res: Response
+): void {
+  res.render("ipv-callback/index-cannot-change-how-get-security-codes.njk");
+}

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -10,7 +10,6 @@ import { reverificationResultService } from "./reverification-result-service";
 import { BadRequestError } from "../../utils/error";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { PATH_NAMES } from "../../app.constants";
 
 export function ipvCallbackGet(
   service: ReverificationResultInterface = reverificationResultService()
@@ -51,7 +50,15 @@ export function ipvCallbackGet(
           REVERIFICATION_ERROR_CODE.IDENTITY_CHECK_INCOMPLETE,
         ].includes(result.data.failure_code)
       ) {
-        return res.redirect(PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES);
+        return res.redirect(
+          await getNextPathAndUpdateJourney(
+            req,
+            req.path,
+            USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE,
+            {},
+            sessionId
+          )
+        );
       }
       throw new Error(result.data.failure_code);
     }

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -1,7 +1,10 @@
 import * as express from "express";
 import { asyncHandler } from "../../utils/async";
 import { PATH_NAMES } from "../../app.constants";
-import { ipvCallbackGet } from "./ipv-callback-controller";
+import {
+  cannotChangeSecurityCodesGet,
+  ipvCallbackGet,
+} from "./ipv-callback-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
@@ -12,6 +15,12 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   asyncHandler(ipvCallbackGet())
+);
+
+router.get(
+  PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES,
+  validateSessionMiddleware,
+  cannotChangeSecurityCodesGet
 );
 
 export { router as ipvCallbackRouter };

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -20,6 +20,7 @@ router.get(
 router.get(
   PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES,
   validateSessionMiddleware,
+  allowUserJourneyMiddleware,
   cannotChangeSecurityCodesGet
 );
 

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -5,10 +5,14 @@ import { PATH_NAMES } from "../../../app.constants";
 import { expect } from "chai";
 import { Request, Response } from "express";
 import { ReverificationResultInterface } from "../types";
-import { ipvCallbackGet } from "../ipv-callback-controller";
+import {
+  cannotChangeSecurityCodesGet,
+  ipvCallbackGet,
+} from "../ipv-callback-controller";
 import { BadRequestError } from "../../../utils/error";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 import { strict as assert } from "assert";
+import { describe } from "mocha";
 
 const fakeReverificationResultService = (success: boolean) => {
   const failureData = {
@@ -48,68 +52,84 @@ describe("ipv callback controller", () => {
     sinon.restore();
   });
 
-  it("get should redirect to GET_SECURITY_CODES when the reverification result is successful", async () => {
-    const fakeServiceReturningSuccess = fakeReverificationResultService(true);
-    await ipvCallbackGet(fakeServiceReturningSuccess)(
-      req as Request,
-      res as Response
-    );
-
-    expect(
-      fakeServiceReturningSuccess.getReverificationResult
-    ).to.have.been.calledWith(
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req,
-      email,
-      AUTH_CODE
-    );
-    expect(res.redirect).to.have.been.calledWith(PATH_NAMES.GET_SECURITY_CODES);
-  });
-
-  it("get should raise error when reverification result is not successful", async () => {
-    const fakeServiceReturningFailure = fakeReverificationResultService(false);
-
-    await assert.rejects(
-      async () =>
-        ipvCallbackGet(fakeServiceReturningFailure)(
-          req as Request,
-          res as Response
-        ),
-      BadRequestError,
-      "500:Internal error occurred in backend"
-    );
-
-    expect(fakeServiceReturningFailure.getReverificationResult).to.have.been
-      .called;
-  });
-
-  it("get should raise error when auth code param is missing or invalid", async () => {
-    const missingOrInvalidQueries = [
-      {
-        query: {},
-        expectedMessage: "400:Request query missing auth code param",
-      },
-      {
-        query: { code: ["string-in-a-list"] },
-        expectedMessage: "400:Invalid auth code param type",
-      },
-    ];
-
-    for (const testCase of missingOrInvalidQueries) {
+  describe("ipv callback get", () => {
+    it("get should redirect to GET_SECURITY_CODES when the reverification result is successful", async () => {
       const fakeServiceReturningSuccess = fakeReverificationResultService(true);
-      req.query = testCase.query;
+      await ipvCallbackGet(fakeServiceReturningSuccess)(
+        req as Request,
+        res as Response
+      );
+
+      expect(
+        fakeServiceReturningSuccess.getReverificationResult
+      ).to.have.been.calledWith(
+        sessionId,
+        clientSessionId,
+        diPersistentSessionId,
+        req,
+        email,
+        AUTH_CODE
+      );
+      expect(res.redirect).to.have.been.calledWith(
+        PATH_NAMES.GET_SECURITY_CODES
+      );
+    });
+
+    it("get should raise error when reverification result is not successful", async () => {
+      const fakeServiceReturningFailure =
+        fakeReverificationResultService(false);
 
       await assert.rejects(
         async () =>
-          ipvCallbackGet(fakeServiceReturningSuccess)(
+          ipvCallbackGet(fakeServiceReturningFailure)(
             req as Request,
             res as Response
           ),
         BadRequestError,
-        testCase.expectedMessage
+        "500:Internal error occurred in backend"
       );
-    }
+
+      expect(fakeServiceReturningFailure.getReverificationResult).to.have.been
+        .called;
+    });
+
+    it("get should raise error when auth code param is missing or invalid", async () => {
+      const missingOrInvalidQueries = [
+        {
+          query: {},
+          expectedMessage: "400:Request query missing auth code param",
+        },
+        {
+          query: { code: ["string-in-a-list"] },
+          expectedMessage: "400:Invalid auth code param type",
+        },
+      ];
+
+      for (const testCase of missingOrInvalidQueries) {
+        const fakeServiceReturningSuccess =
+          fakeReverificationResultService(true);
+        req.query = testCase.query;
+
+        await assert.rejects(
+          async () =>
+            ipvCallbackGet(fakeServiceReturningSuccess)(
+              req as Request,
+              res as Response
+            ),
+          BadRequestError,
+          testCase.expectedMessage
+        );
+      }
+    });
+  });
+
+  describe("cannotChangeSecurityCodeGet", () => {
+    it("should render the correct template", () => {
+      cannotChangeSecurityCodesGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "ipv-callback/index-cannot-change-how-get-security-codes.njk"
+      );
+    });
   });
 });

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -61,4 +61,25 @@ describe("Integration:: ipv callback", () => {
       }
     );
   });
+
+  it("should redirect to CANNOT_CHANGE_SECURITY_CODES when the reverification result is successful", async () => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.REVERIFICATION_RESULT)
+      .once()
+      .reply(200, { success: false, failure_code: "no_identity_available" });
+
+    const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+
+    await request(
+      app,
+      (test) =>
+        test
+          .get(requestPath)
+          .expect(302)
+          .expect("Location", PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES),
+      {
+        expectAnalyticsPropertiesMatchSnapshot: false,
+      }
+    );
+  });
 });

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -42,7 +42,10 @@ describe("Integration:: ipv callback", () => {
   });
 
   it("should redirect to GET_SECURITY_CODES when the reverification result is successful", async () => {
-    nock(baseApi).post(API_ENDPOINTS.REVERIFICATION_RESULT).once().reply(200);
+    nock(baseApi)
+      .post(API_ENDPOINTS.REVERIFICATION_RESULT)
+      .once()
+      .reply(200, { success: true });
 
     const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
 

--- a/src/components/ipv-callback/types.ts
+++ b/src/components/ipv-callback/types.ts
@@ -1,9 +1,35 @@
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
 import { Request } from "express";
 
-export interface ReverificationResultResponse extends DefaultApiResponse {
+export interface ReverificationResultSuccessResponse
+  extends DefaultApiResponse {
   sub: string;
-  success: boolean;
+  success: true;
+}
+
+export interface ReverificationResultFailedResponse extends DefaultApiResponse {
+  sub: string;
+  success: false;
+  failure_code: REVERIFICATION_ERROR_CODE;
+  failure_description: string;
+}
+
+export enum REVERIFICATION_ERROR_CODE {
+  NO_IDENTITY_AVAILABLE = "no_identity_available",
+  IDENTITY_CHECK_INCOMPLETE = "identity_check_incomplete",
+  IDENTITY_CHECK_FAILED = "identity_check_failed",
+  IDENTITY_DID_NOT_MATCH = "identity_did_not_match",
+}
+
+export type ReverificationResultResponse =
+  | ReverificationResultFailedResponse
+  | ReverificationResultSuccessResponse;
+
+export function isReverificationResultFailedResponse(
+  response: ReverificationResultResponse
+): response is ReverificationResultFailedResponse {
+  const responseAsFailed = response as ReverificationResultFailedResponse;
+  return responseAsFailed.success !== undefined && !responseAsFailed.success;
 }
 
 export interface ReverificationResultInterface {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -664,6 +664,18 @@
         "govukLinkText": "hafan GOV.UK"
       }
     },
+    "cannotChangeHowGetSecurityCodeMfaReset": {
+      "title": "Ni allwch newid sut rydych yn cael codau diogelwch",
+      "header": "Ni allwch newid sut rydych yn cael codau diogelwch",
+      "paragraph1": "Gallwch ond mewngofnodi i’ch GOV.UK One Login drwy ddefnyddio’r dull rydych eisoes wedi’i sefydlu i gael codau diogelwch.",
+      "paragraph2": "Os ydych wedi colli mynediad i’r dull hwn yn barhaol, dylech ddileu eich GOV.UK One Login er mwyn i chi allu creu un newydd.",
+      "radios": {
+        "header": "Beth hoffech chi ei wneud?",
+        "option1Text": "Cael help i ddileu eich GOV.UK One Login gan y tîm cymorth",
+        "option1Hint": "Ffoniwch neu defnyddiwch gwe-sgwrs i gysylltu â’r tîm GOV.UK One Login",
+        "option2Text": "Ceisiwch roi cod diogelwch i mewn eto gyda’r dull rydych eisoes wedi’i sefydlu"
+      }
+    },
     "changeSecurityCodesConfirmation": {
       "title": "Rydych wedi newid sut rydych yn cael codau diogelwch",
       "header": "Rydych wedi newid sut rydych yn cael codau diogelwch",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -664,6 +664,18 @@
         "govukLinkText": "GOV.UK homepage"
       }
     },
+    "cannotChangeHowGetSecurityCodeMfaReset": {
+      "title": "You cannot change how you get security codes",
+      "header": "You cannot change how you get security codes",
+      "paragraph1": "You can only sign into your GOV.UK One Login using the method you already have set up to get security codes.",
+      "paragraph2": "If you’ve permanently lost access to this method, you should delete your GOV.UK One Login so you can create a new one.",
+      "radios": {
+        "header": "What would you like to do?",
+        "option1Text": "Get help to delete your GOV.UK One Login from the support team",
+        "option1Hint": "Call or use webchat to contact the GOV.UK One Login team",
+        "option2Text": "Try entering a security code again with the method you already have set up"
+      }
+    },
     "changeSecurityCodesConfirmation": {
       "title": "You’ve changed how you get security codes",
       "header": "You’ve changed how you get security codes",


### PR DESCRIPTION
## What

Adds a new page for when a user cannot change their security codes in the new journey that goes via the IPV reverification route.

If IPV indicates that either the user has no stored identity, or that the check was incomplete, we render this page.

This page contains the relevant content and elements, but these don't currently do anything, so effectively for now it's a landing page. Subsequent tickets will cover off the behaviour of any of the options on this page being selected.

For now, in the other error cases we throw an exception. This will be updated in a subsequent ticket / PR, but for now we are just handling the above cases.

The route will only be deployed in environments where we have the new journey turned on.


## New page screenshots

| English | Welsh|
|----|---|
|<img width="1001" alt="Screenshot 2024-12-13 at 17 01 45" src="https://github.com/user-attachments/assets/827941d6-b9ed-4ca6-8f66-2ced9ec0f731" />|<img width="983" alt="Screenshot 2024-12-13 at 17 01 56" src="https://github.com/user-attachments/assets/1091a942-32b9-410c-b6e4-68770776b302" />|



## How to review

1. Code Review
1. Deploy to dev
1. Run through an mfa reset journey. See that when you select a relevant error code to be returned on the stub, this page is returned.

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.
