### PR TITLE
AUT-3689: Build old cloudfront and frontend ALB DNS names

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -240,6 +240,8 @@ Mappings:
       frontendTaskDefinitionCpu: 512
       frontendTaskDefinitionMemory: 1024
       cloudwatchLogRetentionInDays: 7
+      oldCloudFrontDistributionDomain: "dqgh68jqbv9m7.cloudfront.net"
+      oldALBDNSName: "build-frontend-41183120.eu-west-2.elb.amazonaws.com"
       orchToAuthSigningPublicKey: |
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr


### PR DESCRIPTION
## What

Build environment old CloudFront distribution and old frontend ALB DNS names added to the EnvironmentConfiguration. 
Prerequisite step before DNS migration

Issue: [AUT-3689]

[AUT-3689]: https://govukverify.atlassian.net/browse/AUT-3689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ