### PR TITLE
AUT-3693: Integration old cloudfront and frontend ALB DNS names

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -283,6 +283,8 @@ Mappings:
       frontendTaskDefinitionCpu: 512
       frontendTaskDefinitionMemory: 1024
       cloudwatchLogRetentionInDays: 30
+      oldCloudFrontDistributionDomain: "d3dw1x63k50a79.cloudfront.net"
+      oldALBDNSName: "integration-frontend-1951285918.eu-west-2.elb.amazonaws.com"
       orchToAuthSigningPublicKey: |
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7
@@ -396,6 +398,11 @@ Resources:
           Value: govuk-one-login/authentication-frontend/cloudformation/deploy/template.yaml
 
   FrontendECSService:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3056
     Type: AWS::ECS::Service
     DependsOn: ApplicationLoadBalancerListenerHTTPS
     Properties:


### PR DESCRIPTION
## What

Integration environment old CloudFront distribution and old frontend ALB DNS names added to the EnvironmentConfiguration.
Prerequisite step before DNS migration

Issue: [AUT-3693]

[AUT-3693]: https://govukverify.atlassian.net/browse/AUT-3693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ