### PR TITLE
AUT-3694: Prod old cloudfront and frontend ALB DNS names

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -303,6 +303,8 @@ Mappings:
       frontendTaskDefinitionCpu: 512
       frontendTaskDefinitionMemory: 1024
       cloudwatchLogRetentionInDays: 30
+      oldCloudFrontDistributionDomain: "d1sj2b5tywgixi.cloudfront.net"
+      oldALBDNSName: "production-frontend-1140310834.eu-west-2.elb.amazonaws.com"
       orchToAuthSigningPublicKey: |
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5


### PR DESCRIPTION
## What

Production environment old CloudFront distribution and old frontend ALB DNS names added to the EnvironmentConfiguration.
Prerequisite step before DNS migration

Issue: [AUT-3694]

## How to review

Compare the values of `oldCloudFrontDistributionDomain` and `oldALBDNSName` in this template with
- CloudFront distribution domain as seen via AWS console
- EC2 -> load balancers -> production-frontend DNS name
- OR signin.account.gov.uk Route53 hosted zone entries

[AUT-3694]: https://govukverify.atlassian.net/browse/AUT-3694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ