### PR TITLE
AUT-3937: Support form updates for international addresses

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -222,6 +222,8 @@ export const CONTACT_US_THEMES = {
   PROVING_IDENTITY_SOMETHING_ELSE: "proving_identity_something_else",
   PROVING_IDENTITY_PROBLEM_WITH_NATIONAL_INSURANCE_NUMBER:
     "proving_identity_problem_with_national_insurance_number",
+  PROVING_IDENTITY_PROBLEM_WITH_ADDRESS:
+    "proving_identity_problem_with_address",
 };
 
 export const CONTACT_US_FIELD_MAX_LENGTH = 1200;

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -79,6 +79,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.provingIdentitySomethingElse.title",
   [CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_NATIONAL_INSURANCE_NUMBER]:
     "pages.contactUsQuestions.provingIdentityProblemWithNationalInsuranceNumber.title",
+  [CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_ADDRESS]:
+    "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
@@ -495,6 +497,7 @@ export function contactUsQuestionsFormPostToSmartAgent(
         userAgent: req.get("User-Agent"),
         appErrorCode: getAppErrorCode(req.body.appErrorCode),
         country: req.body.country,
+        location: req.body.location,
       },
       feedbackContact: req.body.contact === "true",
       questions: questions,
@@ -841,6 +844,16 @@ export function getQuestionsFromFormTypeForMessageBody(
         { lng: "en" }
       ),
     },
+    provingIdentityProblemEnteringAddress: {
+      issueDescription: req.t(
+        "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.whatWereYouTryingToDo.label",
+        { lng: "en" }
+      ),
+      additionalDescription: req.t(
+        "pages.contactUsQuestions.whatHappened.header",
+        { lng: "en" }
+      ),
+    },
     provingIdentitySomethingElse: {
       issueDescription: req.t(
         "pages.contactUsQuestions.provingIdentitySomethingElse.section1.label",
@@ -1024,6 +1037,10 @@ export function getQuestionFromThemes(
     ),
     proving_identity_need_to_update_personal_information: req.t(
       "pages.contactUsQuestions.provingIdentityNeedToUpdatePersonalInformation.title",
+      { lng: "en" }
+    ),
+    proving_identity_problem_with_address: req.t(
+      "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.title",
       { lng: "en" }
     ),
     proving_identity_something_else: req.t(

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -14,6 +14,7 @@ import { logger } from "../../utils/logger";
 import {
   getServiceDomain,
   getSupportLinkUrl,
+  supportContactFormProblemWithAddress,
   supportNoPhotoIdContactForms,
 } from "../../config";
 import { contactUsServiceSmartAgent } from "./contact-us-service-smart-agent";
@@ -382,6 +383,8 @@ export function furtherInformationGet(req: Request, res: Response): void {
       validateReferer(req.query.referer as string, serviceDomain)
     ),
     supportNoPhotoIdContactForms: supportNoPhotoIdContactForms(),
+    supportContactFormProblemWithAddress:
+      supportContactFormProblemWithAddress(),
   });
 }
 
@@ -447,6 +450,9 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
       req.query.subtheme === CONTACT_US_THEMES.SUGGESTIONS_FEEDBACK
         ? "94ff0276-9791-4a74-95c4-8210ec4028f7"
         : "",
+    supportContactFormProblemWithAddress:
+      supportContactFormProblemWithAddress() ||
+      req.query.supportContactFormProblemWithAddress === "true",
   });
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -7,6 +7,7 @@ import {
   CONTACT_US_THEMES,
   CONTACT_US_COUNTRY_MAX_LENGTH,
 } from "../../app.constants";
+
 const sanitizeFreeTextValue: CustomSanitizer = function sanitizeFreeTextValue(
   value: string
 ) {
@@ -15,6 +16,24 @@ const sanitizeFreeTextValue: CustomSanitizer = function sanitizeFreeTextValue(
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
+    body("location").custom((value, { req }) => {
+      if (
+        req.body.subtheme ===
+          CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_ADDRESS &&
+        value === undefined
+      ) {
+        throw new Error(
+          req.t(
+            "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.location.errorMessage",
+            {
+              value,
+              lng: req.i18n.lng,
+            }
+          )
+        );
+      }
+      return true;
+    }),
     body("securityCodeSentMethod")
       .if(body("theme").equals("account_creation"))
       .if(check("radio_buttons").notEmpty())
@@ -185,6 +204,24 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value, lng: req.i18n.lng }
         );
       }),
+    body("location").custom((value, { req }) => {
+      if (
+        req.body.subtheme ===
+          CONTACT_US_THEMES.PROVING_IDENTITY_SOMETHING_ELSE &&
+        value === undefined
+      ) {
+        throw new Error(
+          req.t(
+            "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.location.errorMessage",
+            {
+              value,
+              lng: req.i18n.lng,
+            }
+          )
+        );
+      }
+      return true;
+    }),
     body("contact")
       .notEmpty()
       .withMessage((value, { req }) => {
@@ -277,6 +314,9 @@ export function getErrorMessageForIssueDescription(
   }
   if (theme === CONTACT_US_THEMES.SUGGESTIONS_FEEDBACK) {
     return "pages.contactUsQuestions.suggestionOrFeedback.section1.errorMessage";
+  }
+  if (subtheme === CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_ADDRESS) {
+    return "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.whatHappened.errorMessage";
   }
   if (theme === CONTACT_US_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.provingIdentity.section1.errorMessage";
@@ -456,6 +496,9 @@ export function getErrorMessageForAdditionalDescription(
   }
   if (theme === CONTACT_US_THEMES.SOMETHING_ELSE) {
     return "pages.contactUsQuestions.anotherProblem.section2.errorMessage";
+  }
+  if (subtheme === CONTACT_US_THEMES.PROVING_IDENTITY_PROBLEM_WITH_ADDRESS) {
+    return "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.whatWereYouTryingToDo.errorMessage";
   }
   if (theme === CONTACT_US_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.provingIdentity.section2.errorMessage";

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -208,6 +208,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       if (
         req.body.subtheme ===
           CONTACT_US_THEMES.PROVING_IDENTITY_SOMETHING_ELSE &&
+        req.body.supportContactFormProblemWithAddress === "true" &&
         value === undefined
       ) {
         throw new Error(
@@ -298,7 +299,10 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
     body("name").customSanitizer(sanitizeFreeTextValue),
     body("country").customSanitizer(sanitizeFreeTextValue),
     body("countryPhoneNumberFrom").customSanitizer(sanitizeFreeTextValue),
-    validateBodyMiddleware("contact-us/questions/index.njk"),
+    validateBodyMiddleware("contact-us/questions/index.njk", (req) => ({
+      supportContactFormProblemWithAddress:
+        req.body.supportContactFormProblemWithAddress === "true",
+    })),
   ];
 }
 

--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -12,6 +12,18 @@ import {
 } from "./types";
 import { CONTACT_US_THEMES } from "../../app.constants";
 
+export function prepareUserLocationTitle(residentInUK: string): string {
+  let tag = "";
+
+  if (residentInUK === "true") {
+    tag = "resident_in_uk";
+  } else if (residentInUK === "false") {
+    tag = "not_resident_in_uk";
+  }
+
+  return tag;
+}
+
 export function prepareSecurityCodeSendMethodTitle(
   securityCodeSentMethod: string
 ): string {
@@ -186,6 +198,10 @@ export function contactUsServiceSmartAgent(
 
     customAttributes["sa-security-mobile-country"] =
       contactForm.optionalData.country;
+
+    customAttributes["sa-tag-location"] = prepareUserLocationTitle(
+      contactForm.optionalData.location
+    );
 
     customAttributes["sa-tag-secondary-reason-user-selection"] =
       contactForm.themeQuestions.subthemeQuestion;

--- a/src/components/contact-us/further-information/_proving-identity-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-further-information.njk
@@ -25,10 +25,6 @@
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemUpdatingPersonalInformation' | translate
             },
             {
-                value: "proving_identity_problem_with_address",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemEnteringAddress' | translate
-            },
-            {
                 value: "proving_identity_technical_problem",
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.technicalProblem' | translate
             },
@@ -38,6 +34,17 @@
             }
         ]
     %}
+
+
+    {% if supportContactFormProblemWithAddress %}
+    {% set problem_with_address_item = {
+            value: "proving_identity_problem_with_address",
+            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemEnteringAddress' | translate
+        }
+    %}
+
+    {% set items = (items.splice(3, 0, problem_with_address_item), items) %}
+    {% endif %}
 
     {% if supportNoPhotoIdContactForms %}
     {% set no_photo_id_bank_item = {

--- a/src/components/contact-us/further-information/_proving-identity-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-further-information.njk
@@ -14,23 +14,27 @@
     {% set items = [
             {
                 value: "proving_identity_problem_answering_security_questions",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio1' | translate
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.answeringSecurityProblems' | translate
             },
             {
                 value: "proving_identity_problem_with_identity_document",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio2' | translate
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemWithPhotoId' | translate
             },
             {
                 value: "proving_identity_need_to_update_personal_information",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio3' | translate
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemUpdatingPersonalInformation' | translate
+            },
+            {
+                value: "proving_identity_problem_with_address",
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemEnteringAddress' | translate
             },
             {
                 value: "proving_identity_technical_problem",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio4' | translate
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.technicalProblem' | translate
             },
             {
                 value: "proving_identity_something_else",
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio5' | translate
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.somethingElse' | translate
             }
         ]
     %}
@@ -38,15 +42,15 @@
     {% if supportNoPhotoIdContactForms %}
     {% set no_photo_id_bank_item = {
             value: "proving_identity_problem_with_bank_building_society_details",
-            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio6' | translate
+            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemWithBankOrBuildingSociety' | translate
         }
     %}
 
     {% set no_photo_id_nin_item = {
             value: "proving_identity_problem_with_national_insurance_number",
-            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio7.label' | translate,
+            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemWithNINumber.label' | translate,
             hint: {
-                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.radio7.hint' | translate | safe
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemWithNINumber.hint' | translate | safe
             }
         }
     %}

--- a/src/components/contact-us/questions/_proving-identity-problem-entering-address.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-entering-address.njk
@@ -1,21 +1,22 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-    {{ 'pages.contactUsQuestions.provingIdentitySomethingElse.header' | translate }}
+    {{ 'pages.contactUsQuestions.provingIdentityProblemEnteringAddress.header' | translate }}
 </h1>
 
-<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{ formSubmissionUrl }}" method="post" novalidate>
 
-    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-    <input type="hidden" name="theme" value="{{theme}}"/>
-    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
-    <input type="hidden" name="backurl" value="{{backurl}}"/>
-    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
-    <input type="hidden" name="formType" value="provingIdentitySomethingElse"/>
-    <input type="hidden" name="referer" value="{{referer}}"/>
-    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <input type="hidden" name="theme" value="{{ theme }}" />
+    <input type="hidden" name="subtheme" value="{{ subtheme }}" />
+    <input type="hidden" name="backurl" value="{{ backurl }}" />
+    <input type="hidden" name="fromURL" value="{{ fromURL }}" />
+    <input type="hidden" name="formType" value="provingIdentityProblemEnteringAddress" />
+    <input type="hidden" name="referer" value="{{ referer }}" />
+
+    {% include 'contact-us/questions/_user-location-question.njk' %}
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentitySomethingElse.section1.label' | translate,
+            text: 'pages.contactUsQuestions.provingIdentityProblemEnteringAddress.whatWereYouTryingToDo.label' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
@@ -38,8 +39,11 @@
 
     {{ govukCharacterCount({
         label: {
-            text: 'pages.contactUsQuestions.provingIdentitySomethingElse.section2.label' | translate,
+            text: 'pages.contactUsQuestions.whatHappened.header' | translate,
             classes: "govuk-label--s"
+        },
+        hint: {
+            text: 'pages.contactUsQuestions.whatHappened.paragraph1' | translate
         },
         id: "additionalDescription",
         name: "additionalDescription",
@@ -65,10 +69,6 @@
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
         iconFallbackText: "Warning"
     }) }}
-
-    {% set show_location_hint = true %}
-
-    {% include 'contact-us/questions/_user-location-question.njk' %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_proving-identity-something-else.njk
+++ b/src/components/contact-us/questions/_proving-identity-something-else.njk
@@ -68,7 +68,10 @@
 
     {% set show_location_hint = true %}
 
+    {% if supportContactFormProblemWithAddress %}
     {% include 'contact-us/questions/_user-location-question.njk' %}
+    <input type="hidden" name="supportContactFormProblemWithAddress" value="true"/>
+    {% endif %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_user-location-question.njk
+++ b/src/components/contact-us/questions/_user-location-question.njk
@@ -1,0 +1,28 @@
+{{ govukRadios({
+    name: "location",
+    fieldset: {
+        legend: {
+            text: "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.location.label" | translate,
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--m"
+        }
+    },
+    hint: {
+        text: "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.location.hint" | translate
+    } if (show_location_hint),
+    items: [
+        {
+            value: "true",
+            text: "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.location.options.yes" | translate,
+            checked: location === "true"
+        },
+        {
+            value: "false",
+            text: "pages.contactUsQuestions.provingIdentityProblemEnteringAddress.location.options.no" | translate,
+            checked: location === "false"
+        }
+    ],
+    errorMessage: {
+        text: errors["location"].text
+    } if (errors["location"])
+}) }}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -143,6 +143,10 @@
         {% include 'contact-us/questions/_proving-identity-problem-with-national-insurance-number.njk' %}
     {% endif %}
 
+    {% if (theme == 'proving_identity') and (subtheme == 'proving_identity_problem_with_address') %}
+        {% include 'contact-us/questions/_proving-identity-problem-entering-address.njk' %}
+    {% endif %}
+
     {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
 
 {% endblock %}

--- a/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
+++ b/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
@@ -311,3 +311,19 @@ Object {
   "taxonomyLevel2": "feedback",
 }
 `;
+
+exports[`Integration:: contact us - public user when a user has not stated their location should return validation error when they submit the 'A problem entering your address' form 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;
+
+exports[`Integration:: contact us - public user when a user has not stated their location should return validation error when they submit the 'Another problem proving your identity' form 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "feedback",
+}
+`;

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -356,6 +356,38 @@ describe("Integration:: contact us - public user", () => {
     });
   });
 
+  describe("when a user has not stated their location", () => {
+    it("should return validation error when they submit the 'Another problem proving your identity' form", async () => {
+      const data = {
+        _csrf: token,
+        theme: "proving_identity",
+        subtheme: "proving_identity_something_else",
+        contact: "false",
+      };
+      await expectValidationErrorOnPost(
+        "/contact-us-questions",
+        data,
+        "#location-error",
+        "Select yes if you live in the UK, Channel Islands or Isle of Man"
+      );
+    });
+
+    it("should return validation error when they submit the 'A problem entering your address' form", async () => {
+      const data = {
+        _csrf: token,
+        theme: "proving_identity",
+        subtheme: "proving_identity_problem_with_address",
+        contact: "false",
+      };
+      await expectValidationErrorOnPost(
+        "/contact-us-questions",
+        data,
+        "#location-error",
+        "Select yes if you live in the UK, Channel Islands or Isle of Man"
+      );
+    });
+  });
+
   describe("when a user had a problem with their bank or building society details", () => {
     it("should return validation error when user has not selected which problem they had", async () => {
       const data = {

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -363,6 +363,7 @@ describe("Integration:: contact us - public user", () => {
         theme: "proving_identity",
         subtheme: "proving_identity_something_else",
         contact: "false",
+        supportContactFormProblemWithAddress: true,
       };
       await expectValidationErrorOnPost(
         "/contact-us-questions",
@@ -378,6 +379,7 @@ describe("Integration:: contact us - public user", () => {
         theme: "proving_identity",
         subtheme: "proving_identity_problem_with_address",
         contact: "false",
+        supportContactFormProblemWithAddress: true,
       };
       await expectValidationErrorOnPost(
         "/contact-us-questions",

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -10,7 +10,10 @@ import {
 import { PATH_NAMES, CONTACT_US_THEMES } from "../../../app.constants";
 import { RequestGet, ResponseRedirect } from "../../../types";
 
-import { supportNoPhotoIdContactForms } from "../../../config";
+import {
+  supportContactFormProblemWithAddress,
+  supportNoPhotoIdContactForms,
+} from "../../../config";
 
 describe("contact us further information controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -47,6 +50,8 @@ describe("contact us further information controller", () => {
           referer: encodeURIComponent(REFERER),
           hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${CONTACT_US_THEMES.SIGNING_IN}`,
           supportNoPhotoIdContactForms: false,
+          supportContactFormProblemWithAddress:
+            supportContactFormProblemWithAddress(),
         }
       );
     });
@@ -64,6 +69,8 @@ describe("contact us further information controller", () => {
           referer: encodeURIComponent(REFERER),
           hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${CONTACT_US_THEMES.ACCOUNT_CREATION}`,
           supportNoPhotoIdContactForms: false,
+          supportContactFormProblemWithAddress:
+            supportContactFormProblemWithAddress(),
         }
       );
     });

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -63,6 +63,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -84,6 +85,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -105,6 +107,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
 
@@ -127,6 +130,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
 
@@ -159,6 +163,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -181,6 +186,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -203,6 +209,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -225,6 +232,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -247,6 +255,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -269,6 +278,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -291,6 +301,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
   });
@@ -316,6 +327,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -338,6 +350,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'You have another problem with a phone number' radio option was chosen", () => {
@@ -361,6 +374,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -383,6 +397,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -405,6 +420,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -427,6 +443,7 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
+        supportContactFormProblemWithAddress: false,
       });
     });
 

--- a/src/components/contact-us/tests/contact-us-service.test.ts
+++ b/src/components/contact-us/tests/contact-us-service.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { getRefererTag } from "../contact-us-service-smart-agent";
+import {
+  getRefererTag,
+  prepareUserLocationTitle,
+} from "../contact-us-service-smart-agent";
 import { ContactForm } from "../types";
 
 describe("contact-us-service", () => {
@@ -55,6 +58,22 @@ describe("contact-us-service", () => {
       expect(getRefererTag(form)).to.equal(
         "Referer obtained via Triage page fromURL: https://localhost:3000/enter-email"
       );
+    });
+  });
+
+  describe("prepareUserLocationTitle", () => {
+    it("should return the UK tag variant when passed 'true'", () => {
+      expect(prepareUserLocationTitle("true")).to.equal("resident_in_uk");
+    });
+
+    it("should return the non-UK tag variant when passed 'false'", () => {
+      expect(prepareUserLocationTitle("false")).to.equal("not_resident_in_uk");
+    });
+
+    it("should return an empty string when passed something else", () => {
+      ["sooth", "falsehood", ""].forEach((i) => {
+        expect(prepareUserLocationTitle(i)).to.equal("");
+      });
     });
   });
 });

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -22,6 +22,7 @@ export interface OptionalData {
   appSessionId?: string;
   appErrorCode?: string;
   country?: string;
+  location?: string;
 }
 
 export interface Questions {
@@ -81,6 +82,7 @@ export interface SmartAgentCustomAttributes {
   "sa-security-mobile-country"?: string;
   "sa-tag-building-society"?: string;
   "sa-tag-national-insurance-number"?: string;
+  "sa-tag-location"?: string;
 }
 
 export interface SmartAgentTicket {

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::enter email should return a strategic app specific validation error when email not entered and channel is strategic app 1`] = `
-Object {
-  "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "sign in",
-}
-`;
-
 exports[`Integration::enter email should return enter email page with reauth analytics properties 1`] = `
 Object {
   "contentId": "aff1628e-177d-4afc-825b-56e926b2fc1f",

--- a/src/config.ts
+++ b/src/config.ts
@@ -198,3 +198,9 @@ export function isValidChannel(channel: string): boolean {
 export function supportMfaResetWithIpv(): boolean {
   return process.env.SUPPORT_MFA_RESET_WITH_IPV === "1";
 }
+
+export function supportContactFormProblemWithAddress(): boolean {
+  return ["local", "dev", "sandpit", "authdev1", "authdev2", "build"].includes(
+    getAppEnv()
+  );
+}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1919,13 +1919,14 @@
         "header": "Problem profi eich hunaniaeth",
         "section1": {
           "header": "Dywedwch wrthym beth ddigwyddodd",
-          "radio1": "Cawsoch broblem ateb cwestiynau diogelwch",
-          "radio2": "Cawsoch broblem gyda’ch ID gyda llun",
-          "radio3": "Mae angen i chi ddiweddaru eich gwybodaeth bersonol",
-          "radio4": "Roedd problem dechnegol (er enghraifft fe welsoch neges gwall)",
-          "radio5": "Rhywbeth arall",
-          "radio6": "Cawsoch broblem gyda’ch manylion banc neu gymdeithas adeiladu",
-          "radio7": {
+          "answeringSecurityProblems": "Cawsoch broblem ateb cwestiynau diogelwch",
+          "problemWithPhotoId": "Cawsoch broblem gyda’ch ID gyda llun",
+          "problemUpdatingPersonalInformation": "Mae angen i chi ddiweddaru eich gwybodaeth bersonol",
+          "problemEnteringAddress": "Rydych wedi cael problem rhoi eich cyfeiriad i mewn",
+          "technicalProblem": "Roedd problem dechnegol (er enghraifft fe welsoch neges gwall)",
+          "somethingElse": "Rhywbeth arall",
+          "problemWithBankOrBuildingSociety": "Cawsoch broblem gyda’ch manylion banc neu gymdeithas adeiladu",
+          "problemWithNINumber": {
             "label": "Cawsoch broblem gyda’ch rhif Yswiriant Gwladol",
             "hint": "Gallwch ddarllen mwy am gael neu ddod o hyd i’ch rhif Yswiriant Gwladol yn <a href=\"https://www.gov.uk/rhif-yswiriant-gwladol-coll\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">www.gov.uk/rhif-yswiriant-gwladol-coll</a>"
           },
@@ -2324,6 +2325,26 @@
         },
         "section2": {
           "label": "Unrhyw beth arall rydych angen dweud wrthym?"
+        }
+      },
+      "provingIdentityProblemEnteringAddress": {
+        "title": "Problem wrth roi eich cyfeiriad",
+        "header": "Problem wrth roi eich cyfeiriad",
+        "location": {
+          "label": "Ydych chi’n byw yn y DU, Ynysoedd y Sianel neu Ynys Manaw?",
+          "hint": "Mae sut y gallwch brofi eich hunaniaeth yn dibynnu ar ble rydych chi’n byw",
+          "options": {
+            "yes": "Ydw",
+            "no": "Na"
+          },
+          "errorMessage": "Dewiswch ydw os ydych chi’n byw yn y DU, Ynysoedd y Sianel neu Ynys Manaw"
+        },
+        "whatWereYouTryingToDo": {
+          "label": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Rhowch beth ddigwyddodd"
+        },
+        "whatHappened": {
+          "errorMessage": "Rhowch fwy o fanylion"
         }
       },
       "provingIdentitySomethingElse": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1919,13 +1919,14 @@
         "header": "A problem proving your identity",
         "section1": {
           "header": "Tell us what happened",
-          "radio1": "You had a problem answering security questions",
-          "radio2": "You had a problem with your photo ID",
-          "radio3": "You need to update your personal information",
-          "radio4": "There was a technical problem (for example, you saw an error message)",
-          "radio5": "Something else",
-          "radio6": "You had a problem with your bank or building society details",
-          "radio7": {
+          "answeringSecurityProblems": "You had a problem answering security questions",
+          "problemWithPhotoId": "You had a problem with your photo ID",
+          "problemUpdatingPersonalInformation": "You need to update your personal information",
+          "problemEnteringAddress": "You had a problem entering your address",
+          "technicalProblem": "There was a technical problem (for example, you saw an error message)",
+          "somethingElse": "Something else",
+          "problemWithBankOrBuildingSociety": "You had a problem with your bank or building society details",
+          "problemWithNINumber": {
             "label": "You had a problem with your National insurance number",
             "hint": "You can read more about getting or finding your National Insurance number at <a href=\"https://www.gov.uk/find-national-insurance-number\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">www.gov.uk/find-national-insurance-number</a>"
           },
@@ -2324,6 +2325,26 @@
         },
         "section2": {
           "label": "Anything else you need to tell us?"
+        }
+      },
+      "provingIdentityProblemEnteringAddress": {
+        "title": "A problem entering your address",
+        "header": "A problem entering your address",
+        "location": {
+          "label": "Do you live in the UK, Channel Islands or the Isle of Man?",
+          "hint": "How you can prove your identity depends on where you live",
+          "options": {
+            "yes": "Yes",
+            "no": "No"
+          },
+          "errorMessage": "Select yes if you live in the UK, Channel Islands or Isle of Man"
+        },
+        "whatWereYouTryingToDo": {
+          "label": "What were you trying to do?",
+          "errorMessage": "Enter what happened"
+        },
+        "whatHappened": {
+          "errorMessage": "Enter more detail"
         }
       },
       "provingIdentitySomethingElse": {


### PR DESCRIPTION
> [!WARNING]  
> Do not merge before given the go-ahead by Identity Pod (relevant contacts are in Jira ticket).

## What's proposed

Updates to contact forms that will allow users to:

1. Describe a problem with entering their address
2. State their location when describing another problem they had proving their identity 

### Feature flag

This change is hidden behind a feature flag which is enabled on build and lower envs.

In higher envs, the new form and "something else" question can be seen by knowing the right URLs:
- The `proving_identity_something_else` page requires a new query param to see the location question: `/contact-us-questions?theme=proving_identity&subtheme=proving_identity_something_else&referer=&supportContactFormProblemWithAddress=true`
- The `proving_identity_problem_with_address` page can just be opened as it would be `/contact-us-questions?theme=proving_identity&subtheme=proving_identity_problem_with_address`

### New radio option on "A problem proving your identity"

Additional "You had a problem entering your address" radio button

<details open>

<summary>Screenshots</summary>

| English      | Welsh           |
| ----------- | ----------- |
| ![A-problem-proving-your-identity-GOV-UK-One-Login-12-23-2024_11_37_AM](https://github.com/user-attachments/assets/04bc73e3-0e9d-4e71-9b19-2753ef48daaa)  |  ![Problem-profi-eich-hunaniaeth-GOV-UK-One-Login-12-23-2024_11_37_AM](https://github.com/user-attachments/assets/34ddf1d7-e375-4410-bd21-4324cc4edecb) |

</details>

### New "A problem entering your address" form

<details open>

<summary>Screenshots</summary>

| English      | Welsh           |
| ----------- | ----------- |
| ![A-problem-entering-your-address-GOV-UK-One-Login-12-23-2024_11_45_AM](https://github.com/user-attachments/assets/e492ff8b-72c4-4fd4-9416-b1e1b988769b)  |  ![Problem-wrth-roi-eich-cyfeiriad-GOV-UK-One-Login-01-02-2025_11_30_AM](https://github.com/user-attachments/assets/3584d6a2-6263-4ccb-b7c0-1026b2a4a4fb) |

</details>


<details open>

<summary>Screenshots of error state</summary>

| English      | Welsh           |
| ----------- | ----------- |
| ![Error-GOV-UK-One-Login-12-23-2024_11_50_AM](https://github.com/user-attachments/assets/eb779d23-6484-41c3-ade8-3136a1db6b82) | ![Gwall-GOV-UK-One-Login-01-02-2025_11_53_AM](https://github.com/user-attachments/assets/627d0614-1ebc-466e-81f3-7c7855e29fc3) |

</details>

### New "Do you live in the UK, Channel Islands or the Isle of Man?" section on the "Another problem proving your identity" page

<details open>

<summary>Screenshots</summary>

| English      | Welsh           |
| ----------- | ----------- |
| ![Another-problem-proving-your-identity-GOV-UK-One-Login-12-23-2024_11_54_AM](https://github.com/user-attachments/assets/3fa98a4e-0a49-4325-82d7-5b78f97a8b48)  |   ![Problem-arall-yn-profi-eich-hunaniaeth-GOV-UK-One-Login-01-02-2025_11_44_AM](https://github.com/user-attachments/assets/f98263df-e859-469b-a9da-79da87cec153) |

</details>

###  "Another problem proving your identity" page - Error state

<details open>

<summary>Screenshots</summary>

| English      | Welsh           |
| ----------- | ----------- |
| ![Error-GOV-UK-One-Login-12-23-2024_11_59_AM](https://github.com/user-attachments/assets/9ec0cd7e-a14d-468c-9a3a-72561d353a66) | ![Gwall-GOV-UK-One-Login-01-02-2025_11_47_AM](https://github.com/user-attachments/assets/9a488639-6996-4305-ac33-d564dcb807d6) |



</details>

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.


