### PR TITLE
AUT-3907: Moving Authdev2 to Shared Dev shared VPC

### DIFF
--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -9,6 +9,8 @@ service_domain          = "authdev2.sandpit.account.gov.uk"
 zone_id                 = "Z062000928I8D7S9X1OVA"
 session_expiry          = 300000
 gtm_id                  = ""
+redis_node_size         = "cache.t2.micro"
+vpc_environment         = "dev"
 
 service_down_page         = false
 service_down_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository"
@@ -30,12 +32,13 @@ support_new_ipv_spinner                             = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024
-frontend_auto_scaling_v2_enabled = true
-deployment_min_healthy_percent   = 100
-deployment_max_percent           = 200
-frontend_auto_scaling_min_count  = 1
-frontend_auto_scaling_max_count  = 2
-ecs_desired_count                = 1
+frontend_auto_scaling_v2_enabled = false # Auto scaling not enabled in Authdev2 as its sharing the Dev ecs cluster
+# To enable Autoscaling in authdev2 we need to move the ecs Cluster creation from core repo to frontend repo
+deployment_min_healthy_percent  = 100
+deployment_max_percent          = 200
+frontend_auto_scaling_min_count = 1
+frontend_auto_scaling_max_count = 2
+ecs_desired_count               = 1
 
 # cloudfront flag
 cloudfront_auth_frontend_enabled = true

--- a/ci/terraform/core.tf
+++ b/ci/terraform/core.tf
@@ -1,8 +1,12 @@
+locals {
+  vpc_environment = var.vpc_environment == null ? var.environment : var.vpc_environment
+}
+
 data "terraform_remote_state" "core" {
   backend = "s3"
   config = {
     bucket      = var.common_state_bucket
-    key         = "${var.environment}-core-terraform.tfstate"
+    key         = "${local.vpc_environment}-core-terraform.tfstate"
     assume_role = var.deployer_role_arn != null ? { role_arn = var.deployer_role_arn } : null
     region      = var.aws_region
   }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -432,3 +432,9 @@ variable "support_mfa_reset_with_ipv" {
   default     = "0"
   description = "Switch to support the IPV prove identity journey when resetting the mfa"
 }
+
+variable "vpc_environment" {
+  description = "The name of the environment this environment is sharing the VPC , this var is only for Authdevs env and must be overide using Authdevs.tfvars, default value should be null always."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## What

AUT-3907: Moving Authdev2 to Shared Dev VPC & Also run Authdev2 ECS service under dev cluster 


## How to review

1. Code Review
2. Deploy to Authdev2  with `./deploy-authdev2.sh -t -p 