### PR TITLE
AUT-3930: Add `/cannot-change-security-codes-identity-fail` page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -68,6 +68,8 @@ export const PATH_NAMES = {
   SECURITY_CODE_ENTERED_EXCEEDED: "/security-code-entered-exceeded",
   CHANGE_SECURITY_CODES: "/change-security-codes",
   CANNOT_CHANGE_SECURITY_CODES: "/cannot-change-security-codes",
+  CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL:
+    "/cannot-change-security-codes-identity-fail",
   CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES: "/check-email-change-security-codes",
   CHANGE_SECURITY_CODES_CONFIRMATION: "/change-codes-confirmed",
   PASSWORD_RESET_REQUIRED: "/password-reset-required",

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -61,6 +61,8 @@ const USER_JOURNEY_EVENTS = {
   IPV_REVERIFICATION_COMPLETED: "IPV_REVERIFICATION_COMPLETED",
   IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE:
     "IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE",
+  IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH:
+    "IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH",
 };
 
 const authStateMachine = createMachine(
@@ -751,9 +753,17 @@ const authStateMachine = createMachine(
               target: [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES],
             },
           ],
+          [USER_JOURNEY_EVENTS.IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH]: [
+            {
+              target: [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL],
+            },
+          ],
         },
       },
       [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES]: {
+        type: "final",
+      },
+      [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL]: {
         type: "final",
       },
     },

--- a/src/components/ipv-callback/cannot-change-how-get-security-codes-validation.ts
+++ b/src/components/ipv-callback/cannot-change-how-get-security-codes-validation.ts
@@ -1,6 +1,7 @@
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { body } from "express-validator";
+import { PATH_NAMES } from "../../app.constants";
 
 export function validateCannotChangeHowGetSecurityCodesActionRequest(): ValidationChainFunc {
   return [
@@ -16,7 +17,14 @@ export function validateCannotChangeHowGetSecurityCodesActionRequest(): Validati
         );
       }),
     validateBodyMiddleware(
-      "ipv-callback/index-cannot-change-how-get-security-codes.njk"
+      "ipv-callback/index-cannot-change-how-get-security-codes.njk",
+      (req) => ({
+        variant:
+          req.path === PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL
+            ? "identityFailed"
+            : "incomplete",
+        formPostPath: req.path,
+      })
     ),
   ];
 }

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -9,6 +9,10 @@
   {% include "common/errors/errorSummary.njk" %}
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.header' | translate}}</h1>
 
+  {% if variant === "identityFailed" %}
+    <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.identityFailedPreamble' | translate}}</p>
+  {% endif %}
+
   <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph1' | translate}}</p>
   <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph2' | translate}}</p>
 

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -16,7 +16,7 @@
   <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph1' | translate}}</p>
   <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph2' | translate}}</p>
 
-  <form action="/cannot-change-security-codes" method="post">
+  <form action="{{ formPostPath }}" method="post">
 
   <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -94,6 +94,7 @@ export function cannotChangeSecurityCodesGet(
       req.path === PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL
         ? "identityFailed"
         : "incomplete",
+    formPostPath: req.path,
   });
 }
 

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -10,6 +10,7 @@ import { reverificationResultService } from "./reverification-result-service";
 import { BadRequestError } from "../../utils/error";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { PATH_NAMES } from "../../app.constants";
 
 const ERROR_TO_EVENT_MAP = new Map<string, string>();
 ERROR_TO_EVENT_MAP.set(
@@ -19,6 +20,14 @@ ERROR_TO_EVENT_MAP.set(
 ERROR_TO_EVENT_MAP.set(
   REVERIFICATION_ERROR_CODE.IDENTITY_CHECK_INCOMPLETE,
   USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE
+);
+ERROR_TO_EVENT_MAP.set(
+  REVERIFICATION_ERROR_CODE.IDENTITY_CHECK_FAILED,
+  USER_JOURNEY_EVENTS.IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH
+);
+ERROR_TO_EVENT_MAP.set(
+  REVERIFICATION_ERROR_CODE.IDENTITY_DID_NOT_MATCH,
+  USER_JOURNEY_EVENTS.IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH
 );
 
 export function ipvCallbackGet(

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -89,7 +89,12 @@ export function cannotChangeSecurityCodesGet(
   req: Request,
   res: Response
 ): void {
-  res.render("ipv-callback/index-cannot-change-how-get-security-codes.njk");
+  res.render("ipv-callback/index-cannot-change-how-get-security-codes.njk", {
+    variant:
+      req.path === PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL
+        ? "identityFailed"
+        : "incomplete",
+  });
 }
 
 export function cannotChangeSecurityCodesPost(

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -34,4 +34,11 @@ router.post(
   cannotChangeSecurityCodesPost
 );
 
+router.get(
+  PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  cannotChangeSecurityCodesGet
+);
+
 export { router as ipvCallbackRouter };

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -41,4 +41,12 @@ router.get(
   cannotChangeSecurityCodesGet
 );
 
+router.post(
+  PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  validateCannotChangeHowGetSecurityCodesActionRequest(),
+  cannotChangeSecurityCodesPost
+);
+
 export { router as ipvCallbackRouter };

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -667,6 +667,7 @@
     "cannotChangeHowGetSecurityCodeMfaReset": {
       "title": "Ni allwch newid sut rydych yn cael codau diogelwch",
       "header": "Ni allwch newid sut rydych yn cael codau diogelwch",
+      "identityFailedPreamble": "Mae hyn oherwydd bod problem cadarnhau eich hunaniaeth.",
       "paragraph1": "Gallwch ond mewngofnodi i’ch GOV.UK One Login drwy ddefnyddio’r dull rydych eisoes wedi’i sefydlu i gael codau diogelwch.",
       "paragraph2": "Os ydych wedi colli mynediad i’r dull hwn yn barhaol, dylech ddileu eich GOV.UK One Login er mwyn i chi allu creu un newydd.",
       "radios": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -667,6 +667,7 @@
     "cannotChangeHowGetSecurityCodeMfaReset": {
       "title": "You cannot change how you get security codes",
       "header": "You cannot change how you get security codes",
+      "identityFailedPreamble": "This is because there was a problem confirming your identity.",
       "paragraph1": "You can only sign into your GOV.UK One Login using the method you already have set up to get security codes.",
       "paragraph2": "If you’ve permanently lost access to this method, you should delete your GOV.UK One Login so you can create a new one.",
       "radios": {


### PR DESCRIPTION
## What

This page can only be accessed by failing to complete an IPV re-verification journey which returns error codes `identity_check_failed` or `identity_did_not_match`.

It renders the existing failure page template and add the extra preamble required to explain the identity check failed.

| Welsh | English |
| --- | --- |
| ![Screenshot 2024-12-19 at 15 50 44](https://github.com/user-attachments/assets/020e83ed-411d-4ba9-acc7-8112e6ad206b) | ![Screenshot 2024-12-19 at 15 50 40](https://github.com/user-attachments/assets/12eb63ed-6968-4552-8423-c35f78d7833b) |

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to dev
1. For each new error code, IPV re-verification journey that will fail
1. See the correct page rendered

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.
