### PR TITLE
AUT-3951: Add validation for radio buttons on cannot change security codes page

### DIFF
--- a/src/components/ipv-callback/cannot-change-how-get-security-codes-validation.ts
+++ b/src/components/ipv-callback/cannot-change-how-get-security-codes-validation.ts
@@ -7,9 +7,14 @@ export function validateCannotChangeHowGetSecurityCodesActionRequest(): Validati
     body("cannotChangeHowGetSecurityCodeAction")
       .if(body("cannotChangeHowGetSecurityCodeAction").not().equals("true"))
       .notEmpty()
-      .withMessage(
-        "Select what you would like to do"
-      ),
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.cannotChangeHowGetSecurityCodeMfaReset.radios.radioValidationError",
+          {
+            value,
+          }
+        );
+      }),
     validateBodyMiddleware(
       "ipv-callback/index-cannot-change-how-get-security-codes.njk"
     ),

--- a/src/components/ipv-callback/cannot-change-how-get-security-codes-validation.ts
+++ b/src/components/ipv-callback/cannot-change-how-get-security-codes-validation.ts
@@ -1,0 +1,17 @@
+import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
+import { ValidationChainFunc } from "../../types";
+import { body } from "express-validator";
+
+export function validateCannotChangeHowGetSecurityCodesActionRequest(): ValidationChainFunc {
+  return [
+    body("cannotChangeHowGetSecurityCodeAction")
+      .if(body("cannotChangeHowGetSecurityCodeAction").not().equals("true"))
+      .notEmpty()
+      .withMessage(
+        "Select what you would like to do"
+      ),
+    validateBodyMiddleware(
+      "ipv-callback/index-cannot-change-how-get-security-codes.njk"
+    ),
+  ];
+}

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -41,7 +41,7 @@
             }
         ],
         errorMessage: {
-            text: "Select what you would like to do"
+            text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.radioValidationError' | translate
         } if errors["cannotChangeHowGetSecurityCodeAction"]
     }) }}
 

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -1,45 +1,55 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitleName = 'pages.cannotChangeHowGetSecurityCodeMfaReset.title' | translate %}
 
 {% block content %}
+  {% include "common/errors/errorSummary.njk" %}
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.header' | translate}}</h1>
 
   <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph1' | translate}}</p>
   <p class="govuk-body">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.paragraph2' | translate}}</p>
 
-  <h2 class="govuk-heading-m">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.header' | translate}}</h2>
+  <form action="/cannot-change-security-codes" method="post">
 
-  {{ govukRadios({
-      name: "cannot_change_how_get_security_code_action",
-      attributes: {
-          "id": "radio-cannot-change-how-get-security-code-action"
-      },
-      items: [
-          {
-              value: "help-to-delete-account",
-              text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option1Text' | translate,
-              id: "help-to-delete-account",
-              checked: false,
-              hint: {
-                text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option1Hint' | translate
-              }
-          },
-          {
-              value: "retry-security-code",
-              text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option2Text' | translate,
-              id: "retry-security-code",
-              checked: false
-          }
-      ]
-  }) }}
+  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+    <h2 class="govuk-heading-m">{{'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.header' | translate}}</h2>
+
+    {{ govukRadios({
+        name: "cannotChangeHowGetSecurityCodeAction",
+        attributes: {
+            "id": "radio-cannot-change-how-get-security-code-action"
+        },
+        items: [
+            {
+                value: "help-to-delete-account",
+                text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option1Text' | translate,
+                id: "help-to-delete-account",
+                checked: false,
+                hint: {
+                  text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option1Hint' | translate
+                }
+            },
+            {
+                value: "retry-security-code",
+                text: 'pages.cannotChangeHowGetSecurityCodeMfaReset.radios.option2Text' | translate,
+                id: "retry-security-code",
+                checked: false
+            }
+        ],
+        errorMessage: {
+            text: "Select what you would like to do"
+        } if errors["cannotChangeHowGetSecurityCodeAction"]
+    }) }}
 
   {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
   }) }}
+  </form>
 
 {% endblock %}

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -81,3 +81,10 @@ export function cannotChangeSecurityCodesGet(
 ): void {
   res.render("ipv-callback/index-cannot-change-how-get-security-codes.njk");
 }
+
+export function cannotChangeSecurityCodesPost(
+  req: Request,
+  res: Response
+): void {
+  res.send("In development");
+}

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -3,10 +3,12 @@ import { asyncHandler } from "../../utils/async";
 import { PATH_NAMES } from "../../app.constants";
 import {
   cannotChangeSecurityCodesGet,
+  cannotChangeSecurityCodesPost,
   ipvCallbackGet,
 } from "./ipv-callback-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { validateCannotChangeHowGetSecurityCodesActionRequest } from "./cannot-change-how-get-security-codes-validation";
 
 const router = express.Router();
 
@@ -22,6 +24,14 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   cannotChangeSecurityCodesGet
+);
+
+router.post(
+  PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  validateCannotChangeHowGetSecurityCodesActionRequest(),
+  cannotChangeSecurityCodesPost
 );
 
 export { router as ipvCallbackRouter };

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -1,85 +1,184 @@
 import { describe } from "mocha";
 import decache from "decache";
-import { request, sinon } from "../../../../test/utils/test-utils";
+import { expect, request, sinon } from "../../../../test/utils/test-utils";
 import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
 import express from "express";
 import nock from "nock";
+import * as cheerio from "cheerio";
 
 describe("Integration:: ipv callback", () => {
   let app: express.Application;
   let baseApi: string;
-
-  before(async () => {
-    process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
-    decache("../../../app");
-    decache("../../../middleware/session-middleware");
-    const sessionMiddleware = require("../../../middleware/session-middleware");
-    sinon
-      .stub(sessionMiddleware, "validateSessionMiddleware")
-      .callsFake(function (req: any, res: any, next: any): void {
-        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
-
-        req.session.user = {
-          email: "test@test.com",
-          phoneNumber: "7867",
-          journey: {
-            nextPath: PATH_NAMES.IPV_CALLBACK,
-          },
-        };
-
-        next();
-      });
-    baseApi = process.env.FRONTEND_API_BASE_URL;
-
-    app = await require("../../../app").createApp();
-  });
+  let sessionMiddleware: any;
 
   after(() => {
-    app = undefined;
     delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
-    nock.cleanAll();
-    sinon.restore();
   });
 
-  it("should redirect to GET_SECURITY_CODES when the reverification result is successful", async () => {
-    nock(baseApi)
-      .post(API_ENDPOINTS.REVERIFICATION_RESULT)
-      .once()
-      .reply(200, { success: true });
+  describe("ipv callback", () => {
+    before(async () => {
+      decache("../../../app");
+      decache("../../../middleware/session-middleware");
+      process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+      baseApi = process.env.FRONTEND_API_BASE_URL;
+      sessionMiddleware = require("../../../middleware/session-middleware");
 
-    const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+      sinon
+        .stub(sessionMiddleware, "validateSessionMiddleware")
+        .callsFake(function (req: any, res: any, next: any): void {
+          res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
 
-    await request(
-      app,
-      (test) =>
-        test
-          .get(requestPath)
-          .expect(302)
-          .expect("Location", PATH_NAMES.GET_SECURITY_CODES),
-      {
-        expectAnalyticsPropertiesMatchSnapshot: false,
-      }
-    );
+          req.session.user = {
+            email: "test@test.com",
+            phoneNumber: "7867",
+            journey: {
+              nextPath: PATH_NAMES.IPV_CALLBACK,
+            },
+          };
+
+          next();
+        });
+
+      app = await require("../../../app").createApp();
+    });
+
+    after(() => {
+      app = undefined;
+      nock.cleanAll();
+      sinon.restore();
+    });
+
+    it("should redirect to GET_SECURITY_CODES when the reverification result is successful", async () => {
+      nock(baseApi)
+        .post(API_ENDPOINTS.REVERIFICATION_RESULT)
+        .once()
+        .reply(200, { success: true });
+
+      const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+
+      await request(
+        app,
+        (test) =>
+          test
+            .get(requestPath)
+            .expect(302)
+            .expect("Location", PATH_NAMES.GET_SECURITY_CODES),
+        {
+          expectAnalyticsPropertiesMatchSnapshot: false,
+        }
+      );
+    });
+
+    it("should redirect to CANNOT_CHANGE_SECURITY_CODES when the reverification result is successful", async () => {
+      nock(baseApi)
+        .post(API_ENDPOINTS.REVERIFICATION_RESULT)
+        .once()
+        .reply(200, { success: false, failure_code: "no_identity_available" });
+
+      const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+
+      await request(
+        app,
+        (test) =>
+          test
+            .get(requestPath)
+            .expect(302)
+            .expect("Location", PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES),
+        {
+          expectAnalyticsPropertiesMatchSnapshot: false,
+        }
+      );
+    });
   });
 
-  it("should redirect to CANNOT_CHANGE_SECURITY_CODES when the reverification result is successful", async () => {
-    nock(baseApi)
-      .post(API_ENDPOINTS.REVERIFICATION_RESULT)
-      .once()
-      .reply(200, { success: false, failure_code: "no_identity_available" });
+  describe("cannot change how get security codes", () => {
+    let token: string | string[];
+    let cookies: string;
 
-    const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+    before(async () => {
+      decache("../../../app");
+      decache("../../../middleware/session-middleware");
+      process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+      sessionMiddleware = require("../../../middleware/session-middleware");
 
-    await request(
-      app,
-      (test) =>
-        test
-          .get(requestPath)
-          .expect(302)
-          .expect("Location", PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES),
-      {
-        expectAnalyticsPropertiesMatchSnapshot: false,
-      }
-    );
+      sinon
+        .stub(sessionMiddleware, "validateSessionMiddleware")
+        .callsFake(function (req: any, res: any, next: any): void {
+          res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+          req.session.user = {
+            email: "test@test.com",
+            phoneNumber: "7867",
+            journey: {
+              nextPath: PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES,
+            },
+          };
+
+          next();
+        });
+
+      app = await require("../../../app").createApp();
+
+      await request(
+        app,
+        (test) => test.get(PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES),
+        {
+          expectAnalyticsPropertiesMatchSnapshot: false,
+        }
+      ).then((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+    });
+
+    after(() => {
+      app = undefined;
+      nock.cleanAll();
+      sinon.restore();
+    });
+
+    it("returns a dummy page when an option is selected", async () => {
+      await request(
+        app,
+        (test) => test.post(PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES),
+        {
+          expectAnalyticsPropertiesMatchSnapshot: false,
+        }
+      )
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          cannotChangeHowGetSecurityCodeAction: "help-to-delete-account",
+        })
+        .expect(function (res) {
+          expect(res.text).to.equals("In development");
+        })
+        .expect(200);
+    });
+
+    it("returns a validation error when no option is selected", async () => {
+      await request(
+        app,
+        (test) => test.post(PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES),
+        {
+          expectAnalyticsPropertiesMatchSnapshot: false,
+        }
+      )
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          cannotChangeHowGetSecurityCodeAction: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect(
+            $("#cannotChangeHowGetSecurityCodeAction-error").text()
+          ).to.contains("Select what you would like to do");
+        })
+        .expect(400);
+    });
   });
 });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -673,7 +673,8 @@
         "header": "Beth hoffech chi ei wneud?",
         "option1Text": "Cael help i ddileu eich GOV.UK One Login gan y tîm cymorth",
         "option1Hint": "Ffoniwch neu defnyddiwch gwe-sgwrs i gysylltu â’r tîm GOV.UK One Login",
-        "option2Text": "Ceisiwch roi cod diogelwch i mewn eto gyda’r dull rydych eisoes wedi’i sefydlu"
+        "option2Text": "Ceisiwch roi cod diogelwch i mewn eto gyda’r dull rydych eisoes wedi’i sefydlu",
+        "radioValidationError": "Dewiswch beth hoffech chi ei wneud"
       }
     },
     "changeSecurityCodesConfirmation": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -673,7 +673,8 @@
         "header": "What would you like to do?",
         "option1Text": "Get help to delete your GOV.UK One Login from the support team",
         "option1Hint": "Call or use webchat to contact the GOV.UK One Login team",
-        "option2Text": "Try entering a security code again with the method you already have set up"
+        "option2Text": "Try entering a security code again with the method you already have set up",
+        "radioValidationError": "Select what you would like to do"
       }
     },
     "changeSecurityCodesConfirmation": {


### PR DESCRIPTION
Adds form validation for the radio buttons on this new page.

## Screenshots

| English | Welsh |
| ----- |-----|
|<img width="567" alt="Screenshot 2024-12-19 at 15 27 10" src="https://github.com/user-attachments/assets/592dc69b-1e66-41cc-a47e-345950bfd9d9" />|<img width="587" alt="Screenshot 2024-12-19 at 15 27 20" src="https://github.com/user-attachments/assets/f9104773-fba3-4b96-a143-492dc769def2" />|

## How to review

1. Code Review
1. Run locally and see the validation error when not choosing an option. To get to the page easily, you can temporarily comment out the session middleware and journey middleware for the ipv callback routes, and directly hit http://localhost:3000/cannot-change-security-codes

## Checklist


- [ ] A UCD review has been performed.

