### PR TITLE
AUT-3921: Change content for mfa reset with IPV

### DIFF
--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -95,6 +95,7 @@ export function enterAuthenticatorAppCodeGet(
 
     return res.render(templateName, {
       isAccountRecoveryPermitted: isAccountRecoveryPermittedForUser,
+      supportMfaResetWithIpv: supportMfaResetWithIpv(),
       mfaResetPath,
     });
   };

--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -56,12 +56,18 @@
 
     {% if isAccountRecoveryPermitted === true or isAccountRecoveryPermitted === "true" %}
         {% set detailsHTML %}
+        {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+            <p class="govuk-body">
+                {{'pages.enterAuthenticatorAppCode.details.text1MfaResetWithIpv' | translate}}
+                <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2MfaResetWithIpv'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+            </p>
+        {% else %}
             <p class="govuk-body">
                 {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
                 <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
             </p>
+        {% endif %}
         {% endset %}
-
         {{ govukDetails({
             summaryText: 'pages.enterAuthenticatorAppCode.details.summary' | translate,
             html: detailsHTML

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -42,10 +42,17 @@
 
   {% if isAccountRecoveryPermitted === true or isAccountRecoveryPermitted === "true" %}
     {% set detailsHTML %}
+      {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+      <p class="govuk-body">
+        {{'pages.enterAuthenticatorAppCode.details.text1MfaResetWithIpv' | translate}}
+        <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2MfaResetWithIpv'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+      </p>
+      {% else %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
         <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
       </p>
+      {% endif %}
     {% endset %}
 
     {{ govukDetails({

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -71,6 +71,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: true,
+          supportMfaResetWithIpv: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -88,6 +89,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: false,
+          supportMfaResetWithIpv: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -123,6 +125,7 @@ describe("enter authenticator app code controller", () => {
         UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME,
         {
           isAccountRecoveryPermitted: true,
+          supportMfaResetWithIpv: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -142,6 +145,7 @@ describe("enter authenticator app code controller", () => {
         ENTER_AUTH_APP_CODE_DEFAULT_TEMPLATE_NAME,
         {
           isAccountRecoveryPermitted: true,
+          supportMfaResetWithIpv: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -161,6 +165,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: true,
+          supportMfaResetWithIpv: true,
           mfaResetPath: PATH_NAMES.MFA_RESET_WITH_IPV,
         }
       );

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -94,6 +94,7 @@ export function enterMfaGet(
       phoneNumber: req.session.user.redactedPhoneNumber,
       supportAccountRecovery: req.session.user.isAccountRecoveryPermitted,
       mfaResetPath: mfaResetPath,
+      supportMfaResetWithIpv: supportMfaResetWithIpv(),
     });
   };
 }

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -50,13 +50,21 @@
                    rel="noreferrer noopener">{{ 'pages.enterMfa.details.sendCodeLinkText'| translate }}</a>
                 {{ 'pages.enterMfa.details.text 2' | translate }}
             </p>
-            {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
-                <p class="govuk-body">
-                    {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
-                    <a href={{ mfaResetPath }} class="govuk-link"
-                       rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
-                </p>
-            {% endif %}
+                {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
+                    {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+                        <p class="govuk-body">
+                            {{ 'pages.enterMfa.details.changeGetSecurityCodesTextWithIpv' | translate }}
+                            <a href={{ mfaResetPath }} class="govuk-link"
+                               rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesWithIpvLinkText'| translate }}</a>.
+                        </p>
+                    {% else %}
+                        <p class="govuk-body">
+                            {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
+                            <a href={{ mfaResetPath }} class="govuk-link"
+                               rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
+                        </p>
+                    {% endif %}
+                {% endif %}
         {% endset %}
 
         {{ govukDetails({

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -51,11 +51,19 @@
     </p>
 
     {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
+      {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+        <p class="govuk-body">
+          {{ 'pages.enterMfa.details.changeGetSecurityCodesTextWithIpv' | translate }}
+          <a href={{ mfaResetPath }} class="govuk-link"
+             rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesWithIpvLinkText'| translate }}</a>.
+        </p>
+        {% else %}
         <p class="govuk-body">
             {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
             <a href={{ mfaResetPath }} class="govuk-link"
                rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
         </p>
+      {% endif %}
     {% endif %}
     {% endset %}
 

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -74,6 +74,7 @@ describe("enter mfa controller", () => {
         supportAccountRecovery: false,
         mfaResetPath:
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
+        supportMfaResetWithIpv: false,
       });
     });
 
@@ -90,6 +91,7 @@ describe("enter mfa controller", () => {
         supportAccountRecovery: true,
         mfaResetPath:
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
+        supportMfaResetWithIpv: false,
       });
     });
 
@@ -151,6 +153,7 @@ describe("enter mfa controller", () => {
         phoneNumber: TEST_PHONE_NUMBER,
         supportAccountRecovery: true,
         mfaResetPath: PATH_NAMES.MFA_RESET_WITH_IPV,
+        supportMfaResetWithIpv: true,
       });
     });
   });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -586,7 +586,9 @@
         "sendCodeLinkHref": "/resend-code",
         "text 2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn.",
         "changeGetSecurityCodesText": "Os na allwch gyrchu’r rhif ffôn ar gyfer eich GOV.UK One Login, gallwch ",
-        "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch"
+        "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch",
+        "changeGetSecurityCodesTextWithIpv": "Os nad oes gennych fynediad i’ch ap dilysu mwyach, ",
+        "changeGetSecurityCodesWithIpvLinkText": "gwiriwch a allwch newid sut rydych yn cael codau diogelwch"
       },
       "upliftRequired": {
         "title": "Rhowch god diogelwch i barhau",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2526,6 +2526,8 @@
         "summary": "Nid oes gennyf fynediad i’r ap dilysydd",
         "text1": "Gallwch newid sut ",
         "text2": "gallwch gael codau diogelwch yn ddiogel",
+        "text1MfaResetWithIpv": "Os nad oes gennych fynediad i’ch ap dilysu mwyach, ",
+        "text2MfaResetWithIpv": "gwiriwch a allwch newid sut rydych yn cael codau diogelwch",
         "text3": "."
       },
       "upliftRequired": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2526,6 +2526,8 @@
         "summary": "I do not have access to the authenticator app",
         "text1": "You can securely ",
         "text2": "change how you get security codes",
+        "text1MfaResetWithIpv": "If you no longer have access to your authenticator app, ",
+        "text2MfaResetWithIpv": "check if you can change how you get security codes",
         "text3": "."
       },
       "upliftRequired": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -586,7 +586,9 @@
         "sendCodeLinkHref": "/resend-code",
         "text 2": " if the code is not working or you did not receive it.",
         "changeGetSecurityCodesText": "If you cannot access the phone number for your GOV.UK One Login, you can securely ",
-        "changeGetSecurityCodesLinkText": "change how you get security codes"
+        "changeGetSecurityCodesLinkText": "change how you get security codes",
+        "changeGetSecurityCodesTextWithIpv": "If you no longer have access to this phone number,  ",
+        "changeGetSecurityCodesWithIpvLinkText": "check if you can change how you get security codes"
       },
       "upliftRequired": {
         "title": "Enter a security code to continue",


### PR DESCRIPTION
## What
Made content changes for MFA screens to reflect that MFA relies on approval from IPV.

SMS MFA:
<img width="1728" alt="Screenshot 2025-01-15 at 17 02 41" src="https://github.com/user-attachments/assets/da13e0a2-b14e-46ee-98ca-1aa9b47b13cb" />

AUTH APP MFA:
<img width="1728" alt="Screenshot 2025-01-15 at 17 01 33" src="https://github.com/user-attachments/assets/14c4546e-7295-4c0b-ae1e-fe67c5ec7eae" />

Changes to the acceptance tests have been made to reflect these changes. They are commented out currently, to be uncommented when MFA_RESET_WITH_IPV is turned on.

Happy for this to be merged in my absence if no changes need to be made.

## How to review

1. Code Review
2. Go through sign in journey up to MFA page: 

- Check that for SMS you see: 'If you no longer have access to this phone number, check if you can change how you get security codes.'

- Check that for AUTH_APP you see: 'If you no longer have access to your authenticator app, check if you can change how you get security codes.'

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
