### PR TITLE
BAU: Cloudfront WAF improvements

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,6 +30,9 @@ jobs:
           cache: "yarn"
           cache-dependency-path: "yarn.lock"
 
+      - name: 🏗️ Set up Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+
       - name: Install dependencies
         run: yarn install
 

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -1,16 +1,11 @@
-environment             = "authdev2"
-common_state_bucket     = "di-auth-development-tfstate"
-aws_region              = "eu-west-2"
-account_management_fqdn = "acc-mgmt-fg.authdev2.sandpit.auth.ida.digital.cabinet-office.gov.uk"
-oidc_api_fqdn           = "oidc.authdev2.sandpit.account.gov.uk"
-frontend_fqdn           = "signin.authdev2.sandpit.account.gov.uk"
-frontend_api_fqdn       = "auth.authdev2.sandpit.account.gov.uk"
-service_domain          = "authdev2.sandpit.account.gov.uk"
-zone_id                 = "Z062000928I8D7S9X1OVA"
-session_expiry          = 300000
-gtm_id                  = ""
-redis_node_size         = "cache.t2.micro"
-vpc_environment         = "dev"
+environment         = "authdev2"
+common_state_bucket = "di-auth-development-tfstate"
+aws_region          = "eu-west-2"
+service_domain      = "authdev2.sandpit.account.gov.uk"
+session_expiry      = 300000
+gtm_id              = ""
+redis_node_size     = "cache.t2.micro"
+vpc_environment     = "dev"
 
 service_down_page         = false
 service_down_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository"
@@ -39,11 +34,6 @@ deployment_max_percent          = 200
 frontend_auto_scaling_min_count = 1
 frontend_auto_scaling_max_count = 2
 ecs_desired_count               = 1
-
-# cloudfront flag
-cloudfront_auth_frontend_enabled = true
-cloudfront_auth_dns_enabled      = true
-
 
 alb_idle_timeout = 30
 

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -62,3 +62,24 @@ dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:Dyn
 
 ua_enabled              = "true"
 analytics_cookie_domain = ".sandpit.account.gov.uk"
+
+ip_endpoint_rate_limiting_configuration = [
+  {
+    endpoints             = ["/check-your-email", "/check-your-phone"]
+    evaluation_window_sec = 300
+    limit                 = 100
+  },
+  {
+    endpoints             = ["/test-endpoint"]
+    evaluation_window_sec = 60
+    limit                 = 10
+  }
+]
+
+aps_session_endpoint_rate_limiting_configuration = [
+  {
+    endpoints             = ["/check-your-email", "/check-your-phone"]
+    evaluation_window_sec = 300
+    limit                 = 100
+  }
+]

--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -13,15 +13,6 @@ resource "aws_wafv2_ip_set" "cf_gds_ip_set" {
     "217.196.229.81/32",
     "51.149.8.0/25",   # (GDS and CO VPN)
     "51.149.8.128/29", # (BYOD VPN only)
-    # The following are Pentesters, requested on AUT-2360
-    "51.142.180.30/32",
-    "185.120.72.241/32",
-    "185.120.72.242/32",
-    "185.120.72.243/32",
-    # The following are Pentesters, requested on AUT-2596
-    "3.9.227.33/32",
-    "18.132.149.145/32"
-
   ]
 }
 


### PR DESCRIPTION
## What

Details in the individual commits.

TL;DR: rate limits now apply to endpoints individually, config format has changed

## How to review

- Code Review

1. Deploy to an environment without making any changes to the tfvars: observe that the configuration is translated to the new format
2. Update the values of `{aps_session,ip}_endpoint_rate_limiting_configuration` tfvars, observe that your new values are used instead
3. I guess you could do some brute-forcing, to check whether the rules actually work. If the syntax is right, they will work, though.
