### PR TITLE
BAU: remove old rate limiting config variables

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -306,24 +306,6 @@ variable "alb_idle_timeout" {
   default     = 60
 }
 
-variable "rate_limited_endpoints" {
-  description = "**DEPRECATED** List of endpoints that should be rate limited by session and IP"
-  type        = list(string)
-  default     = []
-}
-
-variable "rate_limited_endpoints_rate_limit_period" {
-  description = "**DEPRECATED** Period in seconds for rate limiting for rate limited endpoints"
-  type        = number
-  default     = 120
-}
-
-variable "rate_limited_endpoints_requests_per_period" {
-  description = "**DEPRECATED** Number of requests per period allowed for rate limited endpoints"
-  type        = number
-  default     = 100000
-}
-
 variable "ip_endpoint_rate_limiting_configuration" {
   description = "Configuration to rate limit endpoints by IP"
   type = list(object({
@@ -351,17 +333,6 @@ variable "ip_endpoint_rate_limiting_configuration" {
     condition     = length(var.ip_endpoint_rate_limiting_configuration) == 0 || alltrue([for config in var.ip_endpoint_rate_limiting_configuration : config.limit >= 10])
     error_message = "limit must be >= 10."
   }
-}
-
-locals {
-  // for transition to new-style configuration. remove once all environments have had variables updated
-  ip_endpoint_rate_limiting_configuration = length(var.ip_endpoint_rate_limiting_configuration) > 0 ? var.ip_endpoint_rate_limiting_configuration : [
-    {
-      endpoints             = var.rate_limited_endpoints
-      evaluation_window_sec = var.rate_limited_endpoints_rate_limit_period
-      limit                 = var.rate_limited_endpoints_requests_per_period
-    }
-  ]
 }
 
 variable "aps_session_endpoint_rate_limiting_configuration" {
@@ -392,18 +363,6 @@ variable "aps_session_endpoint_rate_limiting_configuration" {
     error_message = "limit must be >= 10."
   }
 }
-
-locals {
-  // for transition to new-style configuration. remove once all environments have had variables updated
-  aps_session_endpoint_rate_limiting_configuration = length(var.aps_session_endpoint_rate_limiting_configuration) > 0 ? var.aps_session_endpoint_rate_limiting_configuration : [
-    {
-      endpoints             = var.rate_limited_endpoints
-      evaluation_window_sec = var.rate_limited_endpoints_rate_limit_period
-      limit                 = var.rate_limited_endpoints_requests_per_period
-    }
-  ]
-}
-
 
 variable "service_down_page" {
   type        = bool

--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -75,7 +75,7 @@ resource "aws_wafv2_web_acl" "frontend_cloudfront_waf_web_acl" {
   }
 
   dynamic "rule" {
-    for_each = local.ip_endpoint_rate_limiting_configuration
+    for_each = var.ip_endpoint_rate_limiting_configuration
     content {
       name     = "BlockMoreThan${rule.value.limit}RequestsFromIpPer${rule.value.evaluation_window_sec}Seconds"
       priority = 20 + rule.key
@@ -167,7 +167,7 @@ resource "aws_wafv2_web_acl" "frontend_cloudfront_waf_web_acl" {
   }
 
   dynamic "rule" {
-    for_each = local.aps_session_endpoint_rate_limiting_configuration
+    for_each = var.aps_session_endpoint_rate_limiting_configuration
     content {
       name     = "BlockMoreThan${rule.value.limit}RequestsFromOneApsSessionPer${rule.value.evaluation_window_sec}Seconds"
       priority = 30 + rule.key
@@ -467,7 +467,7 @@ resource "aws_wafv2_web_acl" "frontend_cloudfront_waf_web_acl" {
 
   lifecycle {
     precondition {
-      condition     = length(local.ip_endpoint_rate_limiting_configuration) + length(local.aps_session_endpoint_rate_limiting_configuration) < 9
+      condition     = length(var.ip_endpoint_rate_limiting_configuration) + length(var.aps_session_endpoint_rate_limiting_configuration) < 9
       error_message = "There can't be more than 9 endpoint_rate_limiting_configuration (quota is shared between IP and APS session)"
     }
   }


### PR DESCRIPTION
## What

All the rate limiting config has now been migrated to the new format, so these old variables are no longer needed.

After this is merged, `/deploy/$env/{rate_limited_endpoints,rate_limited_endpoints_rate_limit_period,rate_limited_endpoints_requests_per_period}`
should be deleted.

## How to review

1. Code review
2. Confirm `aps_session_endpoint_rate_limiting_configuration` and `ip_endpoint_rate_limiting_configuration` variables are present in all
   environments' SecretsManager secrets
