### PR TITLE
AUT-3920: Redirect back to enter mfa pages

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -343,3 +343,8 @@ export const WEB_TO_MOBILE_ERROR_MESSAGE_MAPPINGS: Record<string, string> = {
   "pages.reEnterEmailAccount.enterYourEmailAddressError":
     "mobileAppPages.reEnterEmailAccount.enterYourEmailAddressError",
 };
+
+export const CANNOT_CHANGE_HOW_GET_SECURITY_CODES_ACTION = {
+  HELP_DELETE_ACCOUNT: "help-to-delete-account",
+  RETRY_SECURITY_CODE: "retry-security-code",
+};

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -761,10 +761,20 @@ const authStateMachine = createMachine(
         },
       },
       [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES]: {
-        type: "final",
+        on: {
+          [USER_JOURNEY_EVENTS.VERIFY_MFA]: [PATH_NAMES.ENTER_MFA],
+          [USER_JOURNEY_EVENTS.VERIFY_AUTH_APP_CODE]: [
+            PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+          ],
+        },
       },
       [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL]: {
-        type: "final",
+        on: {
+          [USER_JOURNEY_EVENTS.VERIFY_MFA]: [PATH_NAMES.ENTER_MFA],
+          [USER_JOURNEY_EVENTS.VERIFY_AUTH_APP_CODE]: [
+            PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+          ],
+        },
       },
     },
   },

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -153,6 +153,7 @@ export function enterPasswordPost(
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
     req.session.user.isPasswordChangeRequired = isPasswordChangeRequired;
+    req.session.user.mfaMethodType = userLogin.data.mfaMethodType;
 
     if (isPasswordChangeRequired && supportAccountInterventions()) {
       const accountInterventionsResponse =

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -1,11 +1,16 @@
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import sinon from "sinon";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
-import { PATH_NAMES } from "../../../app.constants";
+import {
+  CANNOT_CHANGE_HOW_GET_SECURITY_CODES_ACTION,
+  MFA_METHOD_TYPE,
+  PATH_NAMES,
+} from "../../../app.constants";
 import { expect } from "chai";
 import { Request, Response } from "express";
 import {
   cannotChangeSecurityCodesGet,
+  cannotChangeSecurityCodesPost,
   ipvCallbackGet,
 } from "../ipv-callback-controller";
 import {
@@ -200,6 +205,32 @@ describe("ipv callback controller", () => {
 
         expect(res.render).to.have.calledWith(
           "ipv-callback/index-cannot-change-how-get-security-codes.njk"
+        );
+      });
+    });
+
+    describe("cannotChangeSecurityCodePost", () => {
+      it("should redirect to enter sms mfa page when sms mfa user selects 'ry entering a security code again with the method you already have set up' radio button", async () => {
+        req.path = PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES;
+        req.body.cannotChangeHowGetSecurityCodeAction =
+          CANNOT_CHANGE_HOW_GET_SECURITY_CODES_ACTION.RETRY_SECURITY_CODE;
+        req.session.user.mfaMethodType = MFA_METHOD_TYPE.SMS;
+
+        await cannotChangeSecurityCodesPost(req as Request, res as Response);
+
+        expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_MFA);
+      });
+
+      it("should redirect to enter auth app mfa page when auth app mfa user selects 'ry entering a security code again with the method you already have set up' radio button", async () => {
+        req.path = PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES;
+        req.body.cannotChangeHowGetSecurityCodeAction =
+          CANNOT_CHANGE_HOW_GET_SECURITY_CODES_ACTION.RETRY_SECURITY_CODE;
+        req.session.user.mfaMethodType = MFA_METHOD_TYPE.AUTH_APP;
+
+        await cannotChangeSecurityCodesPost(req as Request, res as Response);
+
+        expect(res.redirect).to.have.calledWith(
+          PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
         );
       });
     });

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -101,10 +101,6 @@ describe("Integration:: ipv callback", () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
     });
 
-    after(() => {
-      nock.cleanAll();
-    });
-
     afterEach(() => {
       app = undefined;
       sinon.restore();

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -16,6 +16,10 @@ describe("Integration:: ipv callback", () => {
   let baseApi: string;
   let sessionMiddleware: any;
 
+  before(async () => {
+    process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+  });
+
   after(() => {
     delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
   });
@@ -24,7 +28,6 @@ describe("Integration:: ipv callback", () => {
     before(async () => {
       decache("../../../app");
       decache("../../../middleware/session-middleware");
-      process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
       baseApi = process.env.FRONTEND_API_BASE_URL;
       sessionMiddleware = require("../../../middleware/session-middleware");
 
@@ -97,10 +100,6 @@ describe("Integration:: ipv callback", () => {
   });
 
   describe("cannot change how get security codes", () => {
-    before(async () => {
-      process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
-    });
-
     afterEach(() => {
       app = undefined;
       sinon.restore();

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export interface UserSession {
   isSignInJourney?: boolean;
   isVerifyEmailCodeResendRequired?: boolean;
   channel?: string;
+  mfaMethodType?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What

- If a user selects "Try entering a security code again with the method you already have set up" in the cannot-change-how-get-security-codes page they will be redirected to the OTP challenge screen again. They are not sent another MFA code.
- Enter mfa attempt counts persist for both MFA types on the back end.
- Mfamethod type has been stored on a user's session from the enter password stage where it is retrieved from the db in order to know which OTP challenge screen they will be redirected to.

## How to review

1. Code Review
2. Tail cloud watch logs for chosen MFA method handler (VerifyMfaCodeHandler for auth app, VerifyCodeHandler for SMS)
3. Run against dev and run through a sign in journey up to MFA challenge, enter an invalid code, then select 'Problems with the code?' -> 'change how you get security codes'
4. Select error response in IPV stub and continue
5. Enter invalid code again
6. Open new stub and go through sign in journey up to MFA, entering an incorrect code again
7. See that the count has been incorrect code count has been incremented from 0 to 3 in cloudwatch 

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.
