### PR TITLE
BAU: Allow env file creation for more environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ ci/terraform/.terraform
 src/assets/javascript/all.js
 ci/terraform/*.plan
 .infracost
+src/authentication_frontend.egg-info/
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "s3transfer",
     "six",
     "urllib3",
+    "click"
 ]
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,17 @@
+[project]
+version = "0.1.0"
+name = "authentication-frontend"
+dependencies = [
+    "boto3",
+    "botocore",
+    "jmespath",
+    "python-dateutil",
+    "python-dotenv",
+    "s3transfer",
+    "six",
+    "urllib3",
+]
+
 [tool.pylint]
 max-line-length = "88"
 disable = '''missing-module-docstring,

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -503,11 +503,18 @@ if __name__ == "__main__":
         logger.error("Deploy environment must be specified")
         sys.exit(1)
 
-    _aws_profile_name = "gds-di-development-admin"
-    _state_bucket_name = "digital-identity-dev-tfstate"
-    if re.match(r"^authdev[0-9]+$", deploy_env):
+    if deploy_env in ["sandpit", "build"]:
+        _aws_profile_name = "gds-di-development-admin"
+        _state_bucket_name = "digital-identity-dev-tfstate"
+    elif re.match(r"^authdev[0-9]+$|^dev$", deploy_env):
         _aws_profile_name = "di-auth-development-admin"
         _state_bucket_name = "di-auth-development-tfstate"
+    elif deploy_env == "staging":
+        _aws_profile_name = "di-auth-staging-admin"
+        _state_bucket_name = "di-auth-staging-tfstate"
+    else:
+        logger.error(f"Error: Unknown environment: {deploy_env}")
+        sys.exit(1)
 
     try:
         STATE_GETTER = StateGetter(deploy_env, _state_bucket_name, _aws_profile_name)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,0 @@
-boto3
-botocore
-jmespath
-python-dateutil
-python-dotenv
-s3transfer
-six
-urllib3


### PR DESCRIPTION
## What

Previously, only `authdev[0-9]+` and `build` environments were
supported. Now, we support `dev` and `staging` environments as well.

Additionally, switch dependency definition to `pyproject.toml` and use `click` for argument handling.

## How to review

1. Code review
2. `scripts/create-env-file.sh dev`
3. `scripts/create-env-file.sh staging`
