### PR TITLE
AUT-3943: switch signin.staging DNS to secure pipeline frontend

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -173,9 +173,13 @@ Conditions:
   SwitchToMigratedZone:
     Fn::And:
       - !Condition MaintainMigratedZoneRecords
-      - Fn::Equals:
-          - !Ref Environment
-          - "placeholder"
+      - Fn::Or:
+          - Fn::Equals:
+              - !Ref Environment
+              - "placeholder"
+          - Fn::Equals:
+              - !Ref Environment
+              - "staging"
 
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html


### PR DESCRIPTION
## What

AUT-3943: switch signin.staging DNS to secure pipeline frontend
POC: migrate DNS while ECS blue/green is disabled

Issue: [AUT-3943]


[AUT-3943]: https://govukverify.atlassian.net/browse/AUT-3943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ