### PR TITLE
Revert "BAU: Send Cloudfront logs to Splunk"

### DIFF
--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -1,20 +1,19 @@
 resource "aws_cloudformation_stack" "cloudfront" {
   name = "${var.environment}-auth-fe-cloudfront"
   #using fixed version of cloudfron disturbution template for now
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-distribution/template.yaml?versionId=jZcckkadQOPteu3t24UktqjOehImqD1K"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-distribution/template.yaml?versionId=._qPLI5sbnZN3T3jHF7fezX8BT6fK3j3"
 
   capabilities = ["CAPABILITY_NAMED_IAM"]
 
   parameters = {
-    DistributionAlias            = local.frontend_fqdn
-    CloudFrontCertArn            = aws_acm_certificate.cloudfront_frontend_certificate.arn
     AddWWWPrefix                 = var.Add_WWWPrefix
+    CloudFrontCertArn            = aws_acm_certificate.cloudfront_frontend_certificate.arn
+    CloudFrontWafACL             = aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl.arn
+    DistributionAlias            = local.frontend_fqdn
     FraudHeaderEnabled           = var.Fraud_Header_Enabled
     OriginCloakingHeader         = var.auth_origin_cloakingheader
     PreviousOriginCloakingHeader = var.previous_auth_origin_cloakingheader
-    CloudFrontWafACL             = aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl.arn
     StandardLoggingEnabled       = true
-    ForwardAccessLogsToSplunk    = var.cloudfront_ForwardAccessLogsToSplunk
     LogDestination               = var.cloudfront_WafAcl_Logdestination
   }
 

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -4,10 +4,9 @@ redis_node_size     = "cache.m4.xlarge"
 service_down_page   = true
 
 # cloudfront enabled flag
-cloudfront_auth_frontend_enabled     = true
-cloudfront_auth_dns_enabled          = true
-cloudfront_WafAcl_Logdestination     = "csls_cw_logs_destination_prodpython"
-cloudfront_ForwardAccessLogsToSplunk = true
+cloudfront_auth_frontend_enabled = true
+cloudfront_auth_dns_enabled      = true
+cloudfront_WafAcl_Logdestination = "csls_cw_logs_destination_prodpython"
 
 frontend_auto_scaling_v2_enabled                    = true
 frontend_task_definition_cpu                        = 512

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -412,12 +412,6 @@ variable "cloudfront_WafAcl_Logdestination" {
   default     = "none"
   description = "CSLS logging destinatiin for logging Cloufront CloakingOriginWebACL WAf logs "
 }
-
-variable "cloudfront_ForwardAccessLogsToSplunk" {
-  type        = bool
-  default     = false
-  description = "Enables forwarding of cloudfront access logs to Splunk. Bucket ARN must be added to CSLS's subscription after first deployment"
-}
 #end of cloudfront variable
 
 variable "language_toggle_enabled" {


### PR DESCRIPTION
Reverts govuk-one-login/authentication-frontend#2458

The new cloudformation introduces standard 500 pages, so we will need to do something different somewhere.

For now, not doing this is the right thing to do.