### PR TITLE
AUT-3978: Add local orch stub

### DIFF
--- a/Dockerfile-stub
+++ b/Dockerfile-stub
@@ -11,6 +11,7 @@ COPY --chown=node:node yarn.lock ./
 RUN yarn install
 
 COPY --chown=node:node dev-app.js ./
+COPY --chown=node:node dev-app-orchstub.js ./
 
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ The startup script will do this for you so just run this command:
 ./startup.sh -l
 ```
 
+### Using the locally runnning service to test the application
+
+This application will normally be started on port 3000 locally.
+
+However, you cannot hit this directly to run through a local journey since we require an OIDC client in order to use the application.
+
+We have stub clients for local use that are spun up via the startup script that you should instead use.
+
+These are:
+
+- The RP stub (which then goes via orchestration) - normally running on port 2000. Note this cannot now be used if running against authdev1, authdev2 or dev environments.
+- The RP stub configured to not request MFA - normally running on port 5000. The same caveat about environments above applies.
+- An orchestration stub which goes directly to the frontend - normally running on port 3002. You must use this if running against dev, authdev1 or authdev2 backends.
+
+Hitting any one of these stubs will perform the relevant OIDC flows in the background and redirect you to the frontend running at localhost:3000.
+
 ### General guidance on starting the application
 
 When starting for the first time, or after a clean, the frontend will take a few minutes to start as node needs to install all the dependencies.

--- a/dev-app-orchstub.js
+++ b/dev-app-orchstub.js
@@ -1,0 +1,83 @@
+// THIS IS FOR DEV TESTING ONLY
+
+const express = require("express");
+const pino = require("pino");
+const axios = require("axios").default;
+const url = require("url");
+
+require("dotenv").config();
+const logger = pino({ level: process.env.LOG_LEVEL || "info" });
+
+const app = express();
+const port = process.env.PORT || 3002;
+const frontendPort = process.env.FRONTEND_PORT || 3000;
+const stub_url =
+  process.env.STUB_URL || "https://orchstub-authdev1.signin.dev.account.gov.uk";
+
+const getCookieValue = (cookie, cookieName) => {
+  let value;
+  cookie.forEach((item) => {
+    const name = item.split("=")[0].toLowerCase().trim();
+    if (name.indexOf(cookieName) !== -1) {
+      value = item.split("=")[1];
+    }
+  });
+  return value;
+};
+
+const setGsCookie = (orchStubResponse, res) => {
+  let sessionCookieValue;
+  const sessionCookie = orchStubResponse.headers["set-cookie"][0];
+  if (sessionCookie) {
+    sessionCookieValue = getCookieValue(sessionCookie.split(";"), "gs");
+    res.cookie("gs", sessionCookieValue, {
+      maxAge: new Date(new Date().getTime() + 60 * 60000),
+    });
+  }
+};
+
+const setLngCookie = (orchStubResponse, res) => {
+  let lngCookieValue;
+  const lngCookie = orchStubResponse.headers["set-cookie"][2];
+  if (lngCookie) {
+    lngCookieValue = getCookieValue(lngCookie.split(";"), "lng");
+    res.cookie("lng", lngCookieValue, {
+      maxAge: new Date(new Date().getTime() + 60 * 60000),
+    });
+  }
+};
+
+const buildRedirectURL = (response) => {
+  const location = url.parse(response.headers.location, true);
+  logger.info(`orch response location is: ${JSON.stringify(location)}`);
+
+  const params = new URLSearchParams(location.query);
+  const redirectUri = new URL(`http://localhost:${frontendPort}/authorize`);
+  redirectUri.search = params.toString();
+  return redirectUri;
+};
+
+app.get("/", async (req, res) => {
+  // call orch stub
+  const orchStubResponse = await axios.post(
+    stub_url,
+    "reauthenticate=&level=Cl.Cm&authenticated=no&authenticatedLevel=Cl.Cm&channel=none",
+    {
+      validateStatus: (status) => {
+        return status === 302;
+      },
+      maxRedirects: 0,
+    }
+  );
+
+  setGsCookie(orchStubResponse, res);
+  setLngCookie(orchStubResponse, res);
+  const redirectUrl = buildRedirectURL(orchStubResponse);
+  res.redirect(redirectUrl.toString());
+});
+
+app.listen(port, () => {
+  logger.info("TEST APP TO REDIRECT FOR NEW SESSION : DEV ONLY");
+  logger.info(`RUNNING ON http://localhost:${port}`);
+  logger.info(`FRONTEND PORT: ${frontendPort}`);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,5 +57,19 @@ services:
     networks:
       - di-net
 
+  di-auth-stub-orchstub:
+    image: *stub-image-name
+    pull_policy: never
+    ports:
+      - "${DOCKER_DOCKER_STUB_ORCHSTUB_PORT:-3002}:${DOCKER_DOCKER_STUB_ORCHSTUB_PORT:-3002}"
+    environment:
+      PORT: ${DOCKER_DOCKER_STUB_ORCHSTUB_PORT:-3002}
+    command:
+      - yarn
+      - dummy-server-orchstub
+    restart: on-failure
+    networks:
+      - di-net
+
 networks:
   di-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - "${DOCKER_DOCKER_STUB_ORCHSTUB_PORT:-3002}:${DOCKER_DOCKER_STUB_ORCHSTUB_PORT:-3002}"
     environment:
       PORT: ${DOCKER_DOCKER_STUB_ORCHSTUB_PORT:-3002}
+      DEPLOYMENT_NAME: ${DEPLOYMENT_NAME}
     command:
       - yarn
       - dummy-server-orchstub

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts -e **/all.js && cp node_modules/govuk-frontend/govuk/all.js dist/public/scripts && cp node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js dist/public/scripts && cp node_modules/@govuk-one-login/spinner/spinner-app.js dist/public/scripts",
     "dev": "tsc && concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\"",
     "dummy-server": "node dev-app.js | pino-pretty",
+    "dummy-server-orchstub": "node dev-app-orchstub.js | pino-pretty",
     "depcheck": "depcheck",
     "lint": "eslint . ",
     "minfiy-build-js": "uglifyjs src/assets/javascript/application.js -o src/assets/javascript/application.js -c -m && uglifyjs src/assets/javascript/cookies.js -o src/assets/javascript/cookies.js -c -m && uglifyjs src/assets/javascript/showPassword.js -o src/assets/javascript/showPassword.js -c -m",

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -361,6 +361,15 @@ def get_static_variables_from_remote(
                 "ORCH_TO_AUTH_SIGNING_KEY": state_getter.get_ecs_task_environment_value(
                     "ORCH_TO_AUTH_SIGNING_KEY"
                 ),
+                "ORCH_STUB_TO_AUTH_AUDIENCE": state_getter.get_ecs_task_environment_value(
+                    "ORCH_STUB_TO_AUTH_AUDIENCE"
+                ),
+                "ORCH_STUB_TO_AUTH_CLIENT_ID": state_getter.get_ecs_task_environment_value(
+                    "ORCH_STUB_TO_AUTH_CLIENT_ID"
+                ),
+                "ORCH_STUB_TO_AUTH_SIGNING_KEY": state_getter.get_ecs_task_environment_value(
+                    "ORCH_STUB_TO_AUTH_SIGNING_KEY"
+                ),
             },
         },
     ]

--- a/startup.sh
+++ b/startup.sh
@@ -67,6 +67,7 @@ set -o allexport && source .env && set +o allexport
 
 # shellcheck source=./scripts/export_aws_creds.sh
 source "${DIR}/scripts/export_aws_creds.sh"
+unset AWS_PROFILE
 
 if [ "${ACTION_LOCAL:-0}" == "1" ]; then
   echo "Starting frontend local service..."


### PR DESCRIPTION
## What

As part of splitting from orch, we can no longer rely on having the full set of orch infrastructure in our dev environments (dev, authdev1, authdev2). Therefore, rather than having an RP stub for running locally, we need an orch stub.

This introduces an orch stub that will run when running the startup script. Currently it runs on a different port to the local RP stub, so this will need to be remembered when testing locally. Eventually we should be able to remove the local RP stub entirely.

Note that currently, at the end of the journey when we hand back to the stub, you will hit an internal server error. The journey has successfully worked, but because the stub is trying to read cookies (and when running through a journey locally your cookies will be stored against a different domain) you will hit an error at the last stage. This is similar to what happens when running the RP stub locally against sandpit. We can do some work to fix this at some point, but I'm considering it out of scope for now since it mirrors the existing behaviour of the RP stub.

## How to review

1. Code Review
1. For each of the environments in the dev account ('dev', 'authdev1' and 'authdev2') run `./scripts/create-env-file.sh [env]`. Then run the startup script and see that you can run through a sign up or sign in journey (starting on localhost port 3002) successfully. Note that you will not be able to hit the final stub page (you will hit an error at the end) which is similar to how we do not hit the stub page when running locally against e.g. sandpit.
1. Repeat for sandpit on localhost port 3002 and see that you hit an appropriate error, but via port 2000 the journey works as normal.
