### PR TITLE
AUT-3990: Disable frontend ECS Blue/green deployment

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -89,16 +89,7 @@ Conditions:
       - Fn::Or:
           - Fn::Equals:
               - !Ref Environment
-              - "build"
-          # - Fn::Equals:
-          #     - !Ref Environment
-          #     - "staging"
-          - Fn::Equals:
-              - !Ref Environment
-              - "integration"
-          - Fn::Equals:
-              - !Ref Environment
-              - "production"
+              - "placeholder"
           - Fn::Equals:
               - !Ref SubEnvironment
               - "authdev1"


### PR DESCRIPTION
## What

Disable frontend ECS Blue/green deployment
Issue: [AUT-3990]

## How to review

Env level configuration. Can only be tested on the target env. 
Deploy pipeline changes from https://github.com/govuk-one-login/authentication-infrastructure/pull/35 to the target environment `./provision-<environment>.sh -p`
Delete frontend stack and redeploy. 

[AUT-3990]: https://govukverify.atlassian.net/browse/AUT-3990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ