### PR TITLE
BAU: Unmask Cloud-front custom origin header

### DIFF
--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -16,13 +16,6 @@ resource "aws_cloudformation_stack" "cloudfront" {
     StandardLoggingEnabled       = true
     LogDestination               = var.cloudfront_WafAcl_Logdestination
   }
-
-  #ignoring below parameter as these parameter are been read via secret manager and terraform continually detects changes
-  # Note : we need to remove the below lifecycle if the Header are changed in Secret manager to appy new cloainking header value
-  lifecycle {
-    ignore_changes = [parameters["OriginCloakingHeader"], parameters["PreviousOriginCloakingHeader"]]
-  }
-
 }
 
 resource "aws_cloudformation_stack" "cloudfront-monitoring" {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -378,14 +378,12 @@ variable "cloudfront_zoneid" {
 
 variable "auth_origin_cloakingheader" {
   type        = string
-  sensitive   = true
   description = "This is header value for Cloufront to to verify requests are coming from the correct CloudFront distribution to ALB "
 }
 
 
 variable "previous_auth_origin_cloakingheader" {
   type        = string
-  sensitive   = true
   description = "This is previous header value when the value is rotated to ensure WAF will allow requests during rotation "
 }
 


### PR DESCRIPTION
## What

Unmask Cloud-front custom origin header this is required for Frontend migration for secure pipeline. 


## How to review

1. Code Review
2. Deploy to **Dev** Environment  
3. Make sure you are able to access the frontend  https://signin.dev.account.gov.uk/  it should give access denied (403 ) or cloud-front error 500


