### PR TITLE
BAU: Adding lifecycle ignore for header var

### DIFF
--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -16,6 +16,13 @@ resource "aws_cloudformation_stack" "cloudfront" {
     StandardLoggingEnabled       = true
     LogDestination               = var.cloudfront_WafAcl_Logdestination
   }
+  # Ignoring OriginCloakingHeader & PreviousOriginCloakingHeader parameter changes until it is actually changed.
+  # Cloud-front Template has set NoEcho on these parameter so terraform continually detects changes though there is no change in value read via secret manager store
+  # Imp Note : We will need to remove the below lifecycle if we want to change the Header string in CloudFront custom origin.
+  lifecycle {
+    ignore_changes = [parameters["OriginCloakingHeader"], parameters["PreviousOriginCloakingHeader"]]
+  }
+
 }
 
 resource "aws_cloudformation_stack" "cloudfront-monitoring" {


### PR DESCRIPTION
## What

Adding lifecycle ignore for header var because Cloud-front Template has set NoEcho on these parameter so terraform continually detects changes though there is no change in value read via secret manager store

![image](https://github.com/user-attachments/assets/3dafa4c4-b18c-4dea-a213-20f9c50b1334)


## How to review

1. Code Review
