### PR TITLE
AUT-3962: Allow going back after starting MFA reset with IPV

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -735,10 +735,36 @@ const authStateMachine = createMachine(
         type: "final",
       },
       [PATH_NAMES.MFA_RESET_WITH_IPV]: {
+        /**
+         * The next page after MFA_RESET_WITH_IPV is a URL to IPV (which is
+         * outside the state machine). Once the user has finished their IPV
+         * journey the user is sent to our IPV_CALLBACK path (which is managed
+         * by the state machine). We want to allow the user to go back from IPV,
+         * back to their MFA code entry pages.
+         *
+         * allowUserJourneyMiddleware will redirect to the first page in the
+         * IPV_REVERIFICATION_INIT array below where the condition is true,
+         * if the user is not on either the page returned from this array or
+         * any of the optionalPaths below.
+         *
+         * While it seems that IPV_CALLBACK should be the next path marked in
+         * the array, this does not allow the user to return to their enter MFA
+         * code page. This happens because the allowUserJourneyMiddleware kicks
+         * in when they are on their MFA code page and says they need to be on
+         * the IPV_CALLBACK page instead, and are incorrectly redirected there
+         * (only IPV should be directing users to IPV_CALLBACK).
+         */
         on: {
           [USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT]: [
-            { target: [PATH_NAMES.IPV_CALLBACK] },
+            { target: [PATH_NAMES.ENTER_MFA], cond: "requiresMFASMSCode" },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresMFAAuthAppCode",
+            },
           ],
+        },
+        meta: {
+          optionalPaths: [PATH_NAMES.IPV_CALLBACK],
         },
       },
       [PATH_NAMES.IPV_CALLBACK]: {
@@ -804,6 +830,9 @@ const authStateMachine = createMachine(
       isIdentityRequiredAndProveIdentityWelcomeEnabled: (context) =>
         context.isIdentityRequired === true &&
         context.proveIdentityWelcomeEnabled === true,
+      requiresMFASMSCode: (context) =>
+        context.mfaMethodType === MFA_METHOD_TYPE.SMS &&
+        context.requiresTwoFactorAuth === true,
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.requiresTwoFactorAuth === true,

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -42,7 +42,10 @@ export function mfaResetWithIpvGet(
       req,
       req.path,
       USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT,
-      null,
+      {
+        mfaMethodType: req.session.user.mfaMethodType,
+        requiresTwoFactorAuth: true,
+      },
       sessionId
     );
 


### PR DESCRIPTION
## What

Once a user has started the MFA reset with IPV, they are taken to IPV. Here we enable support for going back to the previous MFA entry page (be it SMS or App).

This is done by first making the `IPV_CALLBACK` path in response to `IPV_REVERIFICATION_INIT` optional. We don't actually use the output of the state machine to drive the redirect in a0bfb6478d86d7481ad9364f34980491bee9323f. This is because the actual URL to IPV goes to an external application, not something managed by the state machine.

Instead the internal path returned after `IPV_REVERIFICATION_INIT` are the MFA code entry page for the type the user has already. This is stored in the users session and if a user navigates back from IPV to auth this last page (MFA code entry) is allowed.

## How to review

1. Code Review
1. Run locally against `dev`
1. See for users of both SMS and app based MFA you can see the IPV stub, then click the browser back button to see the previous page.
1. You can continue the journey from there for SMS code entry, but App code entry has a problem already captured in AUT-4005
