### PR TITLE
AUT-3962: Allow going back after starting MFA reset with IPV

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -759,6 +759,13 @@ const authStateMachine = createMachine(
             },
           ],
         },
+        meta: {
+          optionalPaths: [
+            PATH_NAMES.MFA_RESET_WITH_IPV,
+            PATH_NAMES.ENTER_MFA,
+            PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+          ],
+        },
       },
       [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES]: {
         on: {


### PR DESCRIPTION
## What

Once a user has started the MFA reset with IPV, they are taken to IPV. Here we enable support for going back to the previous MFA entry page (be it SMS or App).

We do this by allowing users in the `IPV_CALLBACK` state to be able to optionally go to the `ENTER_MFA` & `ENTER_AUTHENTICATOR_APP_CODE` states.

`MFA_RESET_WITH_IPV` is also required as an optional for `IPV_CALLBACK` to allow forward progression to MFA reset with IPV having already gone back on the MFA code entry pages.

## How to review

1. Code Review
1. Run locally against `dev`
1. See for users of both SMS and app based MFA you can see the IPV stub, then click the browser back button to see the previous page.
1. You can continue the journey from there for SMS code entry, but App code entry has a problem already captured in AUT-4005

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2494, which was reverted
