### PR TITLE
AUT-4004: Update confirmation screen for changing security codes

### DIFF
--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -3,6 +3,7 @@ import { MFA_METHOD_TYPE } from "../../../app.constants";
 import { ExpressRouteFunc } from "../../../types";
 import { USER_JOURNEY_EVENTS } from "../../common/state-machine/state-machine";
 import { getNextPathAndUpdateJourney } from "../../common/constants";
+import { supportMfaResetWithIpv } from "../../../config";
 
 export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
@@ -13,6 +14,7 @@ export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {
         {
           mfaMethodType: type,
           phoneNumber: req.session.user.redactedPhoneNumber,
+          supportMfaResetWithIpv: supportMfaResetWithIpv(),
         }
       );
     } else {

--- a/src/components/account-recovery/change-security-codes-confirmation/index.njk
+++ b/src/components/account-recovery/change-security-codes-confirmation/index.njk
@@ -11,10 +11,19 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
 
-{% if mfaMethodType === 'SMS' %}
-    <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.info.paragraphSMS' | translate | replace("[mobile]", phoneNumber)}}</p>
-{% elseif mfaMethodType === 'AUTH_APP' %}
-    <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.info.paragraphAuthApp' | translate}}</p>
+{% if supportMfaResetWithIpv === true %}
+    <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.infoForJourneyWithIpvReset.confirmationParagraph' | translate }}</p>
+    {% if mfaMethodType === 'SMS' %}
+        <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.infoForJourneyWithIpvReset.paragraphSMS' | translate | replace("[mobile]", phoneNumber)}}</p>
+    {% elseif mfaMethodType === 'AUTH_APP' %}
+        <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.infoForJourneyWithIpvReset.paragraphAuthApp' | translate}}</p>
+    {% endif %}
+{% else %}
+    {% if mfaMethodType === 'SMS' %}
+        <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.info.paragraphSMS' | translate | replace("[mobile]", phoneNumber)}}</p>
+    {% elseif mfaMethodType === 'AUTH_APP' %}
+        <p class="govuk-body">{{'pages.changeSecurityCodesConfirmation.info.paragraphAuthApp' | translate}}</p>
+    {% endif %}
 {% endif %}
 
 {{ govukButton({

--- a/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
@@ -23,29 +23,53 @@ describe("change security codes confirmation controller", () => {
 
   afterEach(() => {
     sinon.restore();
+    delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
   });
 
   describe("changeSecurityCodesConfirmationGet", () => {
-    [MFA_METHOD_TYPE.SMS, MFA_METHOD_TYPE.AUTH_APP].forEach(
-      function (mfaMethodType) {
-        it(`should render the change security codes codes confirmation page for mfaMethodType ${mfaMethodType}`, async () => {
-          req.session.user.accountRecoveryVerifiedMfaType = mfaMethodType;
-          req.session.user.email =
-            "security.codes.changed@testtwofactorauth.org";
-          req.session.user.redactedPhoneNumber = "*******1234";
+    const redactedPhoneNumber = "*******1234";
+    const testData = [
+      {
+        methodType: MFA_METHOD_TYPE.SMS,
+        supportMfaResetWithIpv: false,
+      },
+      {
+        methodType: MFA_METHOD_TYPE.AUTH_APP,
+        supportMfaResetWithIpv: false,
+      },
+      {
+        methodType: MFA_METHOD_TYPE.SMS,
+        supportMfaResetWithIpv: true,
+      },
+      {
+        methodType: MFA_METHOD_TYPE.AUTH_APP,
+        supportMfaResetWithIpv: true,
+      },
+    ];
+    testData.forEach(function (testParams) {
+      it(`should render the change security codes codes confirmation page for mfaMethodType ${testParams.methodType}`, async () => {
+        req.session.user.accountRecoveryVerifiedMfaType = testParams.methodType;
+        req.session.user.email = "security.codes.changed@testtwofactorauth.org";
+        req.session.user.redactedPhoneNumber = redactedPhoneNumber;
+        if (testParams.supportMfaResetWithIpv) {
+          process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+        }
 
-          await changeSecurityCodesConfirmationGet()(
-            req as Request,
-            res as Response
-          );
+        await changeSecurityCodesConfirmationGet()(
+          req as Request,
+          res as Response
+        );
 
-          expect(res.render).to.have.been.calledWith(
-            "account-recovery/change-security-codes-confirmation/index.njk",
-            { mfaMethodType: mfaMethodType, phoneNumber: "*******1234" }
-          );
-        });
-      }
-    );
+        expect(res.render).to.have.been.calledWith(
+          "account-recovery/change-security-codes-confirmation/index.njk",
+          {
+            mfaMethodType: testParams.methodType,
+            phoneNumber: redactedPhoneNumber,
+            supportMfaResetWithIpv: testParams.supportMfaResetWithIpv,
+          }
+        );
+      });
+    });
   });
 
   describe("changeSecurityCodesConfirmationPost", () => {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -684,6 +684,11 @@
       "info": {
         "paragraphSMS": "Byddwn yn anfon codau diogelwch i’ch rhif ffôn sy’n gorffen gyda [mobile] pan fyddwch yn mewngofnodi.",
         "paragraphAuthApp": "Bydd angen i chi ddefnyddio’ch ap dilysydd i gael codau diogelwch pan rydych yn mewngofnodi."
+      },
+      "infoForJourneyWithIpvReset": {
+        "confirmationParagraph": "Gallwch nawr barhau i’r gwasanaeth roeddech yn ei ddefnyddio.",
+        "paragraphSMS": "Y tro nesaf y byddwch yn mewngofnodi, byddwn yn anfon codau diogelwch i’ch rhif ffôn sy’n gorffen gyda [mobile].",
+        "paragraphAuthApp": "Y tro nesaf y byddwch yn mewngofnodi, bydd angen i chi ddefnyddio’ch ap dilyswr i gael codau diogelwch."
       }
     },
     "checkYourEmailSecurityCodes": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -684,6 +684,11 @@
       "info": {
         "paragraphSMS": "We’ll send security codes to your phone number ending with [mobile] when you sign in.",
         "paragraphAuthApp": "You’ll need to use your authenticator app to get security codes when you sign in."
+      },
+      "infoForJourneyWithIpvReset": {
+        "confirmationParagraph": "You can now continue to the service you were using.",
+        "paragraphSMS": "Next time you sign in, we’ll send security codes to your phone number ending with [mobile].",
+        "paragraphAuthApp": "Next time you sign in, you’ll need to use your authenticator app to get security codes."
       }
     },
     "checkYourEmailSecurityCodes": {


### PR DESCRIPTION
## What

Minor content changes for the screen that confirms a user has changed their MFA method. These changes will be released alongside the updated mfa reset journey, so are behind a feature flag.

## How to review

1. Code Review

## Screenshots

**With IPV MFA reset journey on:**

| | English | Welsh |
|---|---|---|
|After changing to SMS |<img width="725" alt="Screenshot 2025-01-23 at 08 52 19" src="https://github.com/user-attachments/assets/60aacfc9-1914-4be7-9bba-115229fe6b71" />|<img width="755" alt="Screenshot 2025-01-23 at 08 52 26" src="https://github.com/user-attachments/assets/d19e588f-defc-4cf2-a3e2-29f839c549f6" />|
| After changing to Auth App |<img width="704" alt="Screenshot 2025-01-23 at 16 05 00" src="https://github.com/user-attachments/assets/1a957221-2dc6-4d19-848e-f2fd30c976e1" />|<img width="729" alt="Screenshot 2025-01-27 at 10 26 14" src="https://github.com/user-attachments/assets/bf35a76f-73ec-4163-8995-a9e4ca5dd132" />|



**With IPV MFA reset journey off (no change to existing):**

| | English | Welsh |
|---|---|---|
|After changing to SMS |<img width="590" alt="Screenshot 2025-01-23 at 09 10 03" src="https://github.com/user-attachments/assets/88985d96-815a-499d-a526-605149b07425" />|<img width="610" alt="Screenshot 2025-01-23 at 09 10 09" src="https://github.com/user-attachments/assets/61397e40-b7bc-4ac1-9d7c-b8890696c280" />|
| After changing to Auth App |<img width="546" alt="Screenshot 2025-01-23 at 09 07 29" src="https://github.com/user-attachments/assets/41dbedde-d7ff-42ca-a140-fb847c91c6c4" />|<img width="594" alt="Screenshot 2025-01-23 at 09 07 33" src="https://github.com/user-attachments/assets/bfc4d4c0-0e78-4267-8657-273f2b50448e" />|

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.
