### PR TITLE
AUT-3693 - Feature switch on to maintain zone records in integration

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -230,6 +230,9 @@ Conditions:
       - Fn::Equals:
           - !Ref Environment
           - "staging"
+      - Fn::Equals:
+          - !Ref Environment
+          - "integration"
 
   SwitchToMigratedZone:
     Fn::And:


### PR DESCRIPTION
## What

Deploy the frontend application with the MaintainMigratedZoneRecordsfeature switch enabled in the integration account. This will add the source (old) CloudFront and origin ALB alias records pointing to the old frontend to the newly created hosted zone in step 1.1

## How to review

Migration guide https://govukverify.atlassian.net/wiki/spaces/LO/pages/4773052525/Auth+New+Frontend+Go-live+Release+Plan step 1.2 