### PR TITLE
AUT-3693 - Enable SwitchToMigratedZone feature in integration

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -244,6 +244,9 @@ Conditions:
           - Fn::Equals:
               - !Ref Environment
               - "staging"
+          - Fn::Equals:
+              - !Ref Environment
+              - "integration"
 
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html


### PR DESCRIPTION
## What

Enable SwitchToMigratedZone feature in integration

This will switch the signin.integration.** and origin.signin.integration.** DNS records to the target CloudFront distribution and new frontend ALB respectively.

## How to review

Migration step https://govukverify.atlassian.net/wiki/spaces/LO/pages/4773052525/Auth+New+Frontend+Go-live+Release+Plan#Switch-traffic-to-the-new-frontend-ALB

