### PR TITLE
AUT-3693: Frontend ECS rolling update speedup

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -521,7 +521,7 @@ Resources:
       DeploymentConfiguration: !If
         - UseECSCanaryDeploymentStack
         - !Ref AWS::NoValue
-        - MaximumPercent: 150
+        - MaximumPercent: 200
           MinimumHealthyPercent: 50
       DeploymentController:
         Type: !If
@@ -1748,7 +1748,7 @@ Resources:
       LaunchType: FARGATE
       DesiredCount: 2
       DeploymentConfiguration:
-        MaximumPercent: 100
+        MaximumPercent: 200
         MinimumHealthyPercent: 50
       LoadBalancers:
         - ContainerName: "service-down-page"


### PR DESCRIPTION
## What

Frontend ECS rolling update speedup
MaximumPercent set to 200% for both frontend and service-down page. The scheduler may now start desiredCount number of new tasks before stopping the older tasks

## How to review

Recommended setup in https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeploymentConfiguration.html
