### PR TITLE
AUT-3957: Simplify including ga4 script

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -38,5 +38,6 @@
 {% endif %}
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "6857e410-75b8-4807-b475-3f24fc96c9de", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "6857e410-75b8-4807-b475-3f24fc96c9de", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-creation/resend-mfa-code/index.njk
+++ b/src/components/account-creation/resend-mfa-code/index.njk
@@ -36,5 +36,6 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "8247477c-3e33-4dae-9528-22e7ed44efb3", loggedInStatus: false, dynamic:false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "8247477c-3e33-4dae-9528-22e7ed44efb3", loggedInStatus: false, dynamic:false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-intervention/password-reset-required/index.njk
+++ b/src/components/account-intervention/password-reset-required/index.njk
@@ -20,6 +20,7 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/account-intervention/permanently-blocked/index.njk
+++ b/src/components/account-intervention/permanently-blocked/index.njk
@@ -15,6 +15,7 @@
 
     <p class="govuk-body">{{'pages.permanentlyLockedScreen.section2.paragraph2' | translate }}</p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/account-intervention/temporarily-blocked/index.njk
+++ b/src/components/account-intervention/temporarily-blocked/index.njk
@@ -16,6 +16,7 @@
 
     <p class="govuk-body">{{'pages.suspendedPageScreen.section2.paragraph2' | translate }}</p>
 
-    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "895deac9-e21d-4991-b1f7-9509c2d8c10e", loggedInStatus: false, dynamic: false })}}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "895deac9-e21d-4991-b1f7-9509c2d8c10e", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/account-not-found/index-mandatory.njk
+++ b/src/components/account-not-found/index-mandatory.njk
@@ -42,5 +42,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "10e1b70b-e208-4db8-8863-3679a675b51d", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "10e1b70b-e208-4db8-8863-3679a675b51d", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-not-found/index-mobile.njk
+++ b/src/components/account-not-found/index-mobile.njk
@@ -28,5 +28,6 @@
            rel="noreferrer noopener">{{ 'mobileAppPages.accountNotFound.findOutMoreLinkText' | translate }}</a>
     </p>
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", contentId: "10e1b70b-e208-4db8-8863-3679a675b51d", loggedInStatus: false, dynamic: false }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", contentId: "10e1b70b-e208-4db8-8863-3679a675b51d", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-not-found/index-one-login.njk
+++ b/src/components/account-not-found/index-one-login.njk
@@ -45,5 +45,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "a70b71e7-b444-46e5-895c-cd2e27bbe6ba", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "a70b71e7-b444-46e5-895c-cd2e27bbe6ba", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-not-found/index-optional.njk
+++ b/src/components/account-not-found/index-optional.njk
@@ -40,5 +40,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "a70b71e7-b444-46e5-895c-cd2e27bbe6ba", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "a70b71e7-b444-46e5-895c-cd2e27bbe6ba", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-recovery/change-security-codes-confirmation/index.njk
+++ b/src/components/account-recovery/change-security-codes-confirmation/index.njk
@@ -34,5 +34,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "1abedb1b-7d09-4e81-9f88-a8b4297635b3", loggedInStatus: false, dynamic: false }) }}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "1abedb1b-7d09-4e81-9f88-a8b4297635b3", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/account-recovery/check-your-email-security-codes/index.njk
+++ b/src/components/account-recovery/check-your-email-security-codes/index.njk
@@ -63,5 +63,6 @@
 
   </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: "false", dynamic:"false" })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: "false", dynamic:"false" } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -62,5 +62,6 @@
 
   </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "054e1ea8-97a8-461a-a964-07345c80098e", loggedInStatus: "false", dynamic: true }) }}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "054e1ea8-97a8-461a-a964-07345c80098e", loggedInStatus: "false", dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -76,5 +76,6 @@
 
   </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "1fef9388-34cd-4ea2-b899-a66b7327d2f7", loggedInStatus: false, dynamic: false}) }}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "1fef9388-34cd-4ea2-b899-a66b7327d2f7", loggedInStatus: false, dynamic: false} %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -515,6 +515,7 @@
 
     </form>
 
-    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -16,6 +16,7 @@
         "href": "error.error404.content.govUKHomepageButtonHref" | translate
     }) }}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "404", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "" , loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "404", englishPageTitle: pageTitleName, contentId: "" , loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/errors/500.njk
+++ b/src/components/common/errors/500.njk
@@ -10,5 +10,6 @@
   </div>
 </div>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "500", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "500", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/common/errors/mid-journey-direct-navigation-without-session.njk
+++ b/src/components/common/errors/mid-journey-direct-navigation-without-session.njk
@@ -12,6 +12,7 @@
     <a href="{{'error.sessionRequiredMidJourneyError.content.govUKHomepageButtonHref' | translate}}" class="govuk-link govuk-body" id="govUkHomeLink">{{ 'error.sessionRequiredMidJourneyError.content.paragraph1.text3' | translate }}</a>.
 </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/errors/session-expired.njk
+++ b/src/components/common/errors/session-expired.njk
@@ -21,6 +21,7 @@
         }) }}
     {% endif %}
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -195,6 +195,7 @@
     <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph2' | translate }}</p>
     <p class="govuk-body">{{ 'pages.accessibilityStatement.preparation.paragraph3' | translate }}</p>
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -925,6 +925,7 @@
         {{ 'pages.privacy.sections.changes_to_this_notice.paragraph_three' | translate }}
     </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/footer/support.njk
+++ b/src/components/common/footer/support.njk
@@ -55,5 +55,6 @@
 <p class="govuk-body">{{'pages.support.section2.paragraph1' | translate}}</p>
 <p class="govuk-body">{{'pages.support.section2.paragraph2' | translate}}</p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/common/footer/terms-conditions.njk
+++ b/src/components/common/footer/terms-conditions.njk
@@ -172,6 +172,7 @@
     <a href="https://www.gov.uk/government/organisations/government-digital-service/about" class="govuk-link">{{'pages.termsAndConditions.section11.paragraph2.linkText' | translate}}</a>.
   </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -1,5 +1,4 @@
 {% extends "govuk/template.njk" %}
-{% from "ga4-opl/macro.njk" import ga4OnPageLoad %}
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}

--- a/src/components/contact-us/further-information/index.njk
+++ b/src/components/contact-us/further-information/index.njk
@@ -50,5 +50,6 @@
         {% include 'contact-us/further-information/_proving-identity-further-information.njk' %}
     {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "a06d6387-d411-47db-8f7d-88871286330b", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "a06d6387-d411-47db-8f7d-88871286330b", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/contact-us/index-gov-service-contact-us.njk
+++ b/src/components/contact-us/index-gov-service-contact-us.njk
@@ -34,6 +34,7 @@
     </a>
 </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -97,5 +97,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "e08d04e6-b24f-4bad-9955-1eb860771747", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "e08d04e6-b24f-4bad-9955-1eb860771747", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/contact-us/index-submit-success.njk
+++ b/src/components/contact-us/index-submit-success.njk
@@ -26,5 +26,6 @@
     </a>
 </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "0e020971-d828-4679-97fe-23af6e96ab14", loggedInStatus: false, dynamic:false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "0e020971-d828-4679-97fe-23af6e96ab14", loggedInStatus: false, dynamic:false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -147,6 +147,7 @@
         {% include 'contact-us/questions/_proving-identity-problem-entering-address.njk' %}
     {% endif %}
 
-    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -57,7 +57,8 @@
 
     </form>
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "8c0cc624-2e97-471d-ad36-6b695f9a038d", loggedInStatus: false, dynamic: false }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "8c0cc624-2e97-471d-ad36-6b695f9a038d", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 {% endblock %}
 
 {% block scripts %}

--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -74,6 +74,7 @@
         }) }}
     {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -61,5 +61,6 @@
     }) }}
   {% endif %}
 
-  {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+  {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+  {%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -48,5 +48,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -40,5 +40,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -49,6 +49,7 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/enter-email/index-sign-in-details-entered-too-many-times.njk
+++ b/src/components/enter-email/index-sign-in-details-entered-too-many-times.njk
@@ -25,6 +25,7 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -80,6 +80,7 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -80,5 +80,6 @@
 
   </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -51,7 +51,8 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "a36232c7-2649-42f8-bf1e-e66ba151aa1c", loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "a36232c7-2649-42f8-bf1e-e66ba151aa1c", loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}
 
 {% block scripts %}

--- a/src/components/enter-password/index-account-locked.njk
+++ b/src/components/enter-password/index-account-locked.njk
@@ -24,6 +24,7 @@
     {% endif %}
 </ul>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/enter-password/index-sign-in-retry-blocked.njk
+++ b/src/components/enter-password/index-sign-in-retry-blocked.njk
@@ -30,5 +30,6 @@
 </ul>
 {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "e020dd02-2f97-46f9-9b26-c98730c89d73", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "e020dd02-2f97-46f9-9b26-c98730c89d73", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -45,7 +45,8 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}
 
 {% block scripts %}

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -83,5 +83,6 @@
 
   </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/ga4-opl/macro.njk
+++ b/src/components/ga4-opl/macro.njk
@@ -1,3 +1,0 @@
-{% macro ga4OnPageLoad(params) %}
-    {%- include "./template.njk" -%}
-{% endmacro %}

--- a/src/components/ga4-opl/template.njk
+++ b/src/components/ga4-opl/template.njk
@@ -1,16 +1,16 @@
-<script {% if params.nonce%} nonce='{{ params.nonce }}'{%  endif %}>
+<script {% if ga4Params.nonce%} nonce='{{ ga4Params.nonce }}'{%  endif %}>
     window.addEventListener('load', function () {
         window
             .DI.analyticsGa4
             .pageViewTracker
             .trackOnPageLoad({
-                statusCode: '{{params.statusCode}}',
-                englishPageTitle: '{{params.englishPageTitle}}',
-                taxonomy_level1: '{{params.taxonomyLevel1}}',
-                taxonomy_level2: '{{params.taxonomyLevel2}}',
-                content_id: '{{params.contentId}}',
-                logged_in_status: {{params.loggedInStatus}},
-                dynamic: {{params.dynamic}}
+                statusCode: '{{ga4Params.statusCode}}',
+                englishPageTitle: '{{ga4Params.englishPageTitle}}',
+                taxonomy_level1: '{{ ga4Params.taxonomyLevel1 | default(taxonomyLevel1, false) }}',
+                taxonomy_level2: '{{ ga4Params.taxonomyLevel2 | default(taxonomyLevel2, false) }}',
+                content_id: '{{ ga4Params.contentId | default(contentId, false) }}',
+                logged_in_status: {{ga4Params.loggedInStatus}},
+                dynamic: {{ga4Params.dynamic}}
             });
     });
 </script>

--- a/src/components/prove-identity-callback/index-new-spinner.njk
+++ b/src/components/prove-identity-callback/index-new-spinner.njk
@@ -32,7 +32,8 @@
         </div>
     </form>
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}
 

--- a/src/components/prove-identity-callback/index.njk
+++ b/src/components/prove-identity-callback/index.njk
@@ -10,6 +10,7 @@
     <div class="ccms-loader centre"></div>
     <p class="govuk-body text-centre">{{'pages.proveIdentityCheck.paragraph1' | translate}}</p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/prove-identity-callback/session-expiry-error.njk
+++ b/src/components/prove-identity-callback/session-expiry-error.njk
@@ -11,6 +11,7 @@
     <p class="govuk-body">{{ 'error.proveIdentityCallbackSessionExpiryError.content.section1.paragraph1' | translate }}</p>
     <p class="govuk-body">{{ 'error.proveIdentityCallbackSessionExpiryError.content.section1.paragraph2' | translate }}</p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -41,6 +41,7 @@
         }) }}
 
     </form>
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -44,6 +44,7 @@
         }) }}
 
     </form>
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -34,5 +34,6 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "3104ec55-1a4e-4811-b927-0531fb315480", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "3104ec55-1a4e-4811-b927-0531fb315480", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -39,5 +39,6 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200",englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200",englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/reset-password-2fa-auth-app/index.njk
+++ b/src/components/reset-password-2fa-auth-app/index.njk
@@ -64,5 +64,6 @@
     }) }}
   {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "943b41f4-8262-417f-8866-c0639319ccf0", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "943b41f4-8262-417f-8866-c0639319ccf0", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/reset-password-2fa-sms/index.njk
+++ b/src/components/reset-password-2fa-sms/index.njk
@@ -63,6 +63,7 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/reset-password-check-email/index-exceeded-request-count.njk
+++ b/src/components/reset-password-check-email/index-exceeded-request-count.njk
@@ -14,6 +14,7 @@
     {{'pages.resetPasswordCountExceeded.paragraph3' | translate}}
 </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/reset-password-check-email/index-request-attempt-blocked.njk
+++ b/src/components/reset-password-check-email/index-request-attempt-blocked.njk
@@ -14,6 +14,7 @@
     {{'pages.resetPasswordAttemptBlocked.paragraph3' | translate}}
 </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}

--- a/src/components/reset-password-check-email/index-reset-password-resend-code.njk
+++ b/src/components/reset-password-check-email/index-reset-password-resend-code.njk
@@ -26,5 +26,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -74,5 +74,6 @@
 
     </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/reset-password/index.njk
+++ b/src/components/reset-password/index.njk
@@ -64,7 +64,8 @@
 
     </form>
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "c8520c6c-9f09-4edf-8c99-7123a3991cfc", loggedInStatus: false, dynamic: false }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "c8520c6c-9f09-4edf-8c99-7123a3991cfc", loggedInStatus: false, dynamic: false } %}
+    {%- include "ga4-opl/template.njk" -%}
 {% endblock %}
 
 {% block scripts %}

--- a/src/components/security-code-error/index-security-code-entered-exceeded.njk
+++ b/src/components/security-code-error/index-security-code-entered-exceeded.njk
@@ -51,5 +51,6 @@
         {% endif %}
     {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -20,5 +20,6 @@
         <p class="govuk-body">{{ 'pages.securityRequestsExceededExpired.info.paragraph3' | translate }}</p>
     {% endif %}
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+    {%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/security-code-error/index-wait.njk
+++ b/src/components/security-code-error/index-wait.njk
@@ -24,5 +24,6 @@
         <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph3' | translate}}</p>
     {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/security-code-error/index.njk
+++ b/src/components/security-code-error/index.njk
@@ -40,5 +40,6 @@
     </p>
 {% endif %}
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -76,5 +76,6 @@
 
 </form>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -83,5 +83,6 @@
 
     </form>
 
-    {{ ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: contentId, loggedInStatus: false, dynamic: true }) }}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+    {%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/sign-in-or-create/index-mobile.njk
+++ b/src/components/sign-in-or-create/index-mobile.njk
@@ -24,5 +24,6 @@
 
     </form>
 
-    {{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true })}}
+    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true } %}
+    {%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -74,5 +74,6 @@
         </a>
     </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "Home", contentId: "9cd55996-3f12-4e79-adf3-0ec3c4faf7ce", loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/signed-out/index.njk
+++ b/src/components/signed-out/index.njk
@@ -14,5 +14,6 @@
   <a href="{{signinLink}}" class="govuk-link">{{'pages.signedOut.signInLinkText' | translate}}</a> {{'pages.signedOut.paragraph2' | translate}}
 </p>
 
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign out", contentId: contentId, loggedInStatus: false, dynamic: true })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign out", loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/components/updated-terms-conditions/index.njk
+++ b/src/components/updated-terms-conditions/index.njk
@@ -32,6 +32,7 @@
     <br >
 
 </form>
-{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, contentId: "", loggedInStatus: false, dynamic: false })}}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, contentId: "", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}


### PR DESCRIPTION
## What

In a future commit, `@govuk-one-login/frontend-analytics` will be updated and support for 5 taxonomy levels will be added. At the moment we only support 2. Taxonomies are defined in `src/utils/taxonomy.ts` and included as variables to nunjucks by `src/middleware/get-analytics-properties-middleware.ts`. This was after a refactor where taxonomies were previously embedded in templates (which lead to other problems).

What was left over in the refactor was on each template, the `ga4OnPageLoad()` macro call required a reference to each variable as an argument of the macro. Nunjucks macros do not support referencing a variable that is not passed into the macro as an argument.

Without any changes to this, adding the 3 new taxonomy levels will add lots of duplicate new params to `ga4OnPageLoad()` calls, which is fragile and prone to being forgotten.

Instead, the macro for `ga4OnPageLoad()` is replaced with directly including the GA4 script template, preceded by setting the same `ga4Params` values as previously used when calling the macro.

This allows the removal of the unnecessary `taxonomyLevel1: taxonomyLevel1`, `taxonomyLevel2: taxonomyLevel2`, `contentId: contentId` etc references and still allows for taxonomy values to be set/overridden per template.

Here's a future example of what supporting 5 taxonomy levels would look like in each template we load ga4.

Before:
```
{{ga4OnPageLoad({ nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: taxonomyLevel1, taxonomyLevel2: taxonomyLevel2, taxonomyLevel3: taxonomyLevel3, taxonomyLevel4: taxonomyLevel4, taxonomyLevel5: taxonomyLevel5, contentId: contentId, loggedInStatus: "false", dynamic:"false" })}}
```

After:
```
{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: "false", dynamic:"false" } %}
{%- include "ga4-opl/template.njk" -%}
```

## How to review

1. Code Review
1. Search the codebase for `ga4OnPageLoad` to prove all references to the macro have been removed.
1. See no changes to the `.snap` snapshot files that assert analytics properties tested.
