### PR TITLE
AUT-3957: Upgrade analytics to support 5 taxonomy levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@aws-sdk/client-ssm": "^3.366.0",
     "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.14.0",
-    "@govuk-one-login/frontend-analytics": "3.0.1",
+    "@govuk-one-login/frontend-analytics": "3.1.0",
     "@govuk-one-login/frontend-language-toggle": "^2.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "^1.1.1",
     "@govuk-one-login/frontend-vital-signs": "0.1.2",

--- a/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/account-creation/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -21,5 +27,8 @@ Object {
   "contentId": "8247477c-3e33-4dae-9528-22e7ed44efb3",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/account-recovery/check-your-email-security-codes/tests/__snapshots__/check-your-email-security-codes-integration.test.ts.snap
+++ b/src/components/account-recovery/check-your-email-security-codes/tests/__snapshots__/check-your-email-security-codes-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,5 +71,8 @@ Object {
   "contentId": "e768e27b-1c4d-48ba-8bcf-4c40274a6441",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
+++ b/src/components/check-your-email/tests/__snapshots__/check-your-email-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,5 +82,8 @@ Object {
   "contentId": "054e1ea8-97a8-461a-a964-07345c80098e",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
+++ b/src/components/check-your-phone/tests/__snapshots__/check-your-phone-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,5 +93,8 @@ Object {
   "contentId": "1fef9388-34cd-4ea2-b899-a66b7327d2f7",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
+++ b/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,6 +93,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -77,6 +104,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -85,6 +115,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -93,6 +126,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -101,6 +137,9 @@ Object {
   "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -109,6 +148,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -117,6 +159,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -125,6 +170,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -133,6 +181,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -141,6 +192,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -149,6 +203,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -157,6 +214,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -165,6 +225,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -173,6 +236,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -181,6 +247,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -189,6 +258,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -197,6 +269,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -205,6 +280,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -213,6 +291,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -221,6 +302,9 @@ Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -229,6 +313,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -237,6 +324,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -245,6 +335,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -253,6 +346,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -261,6 +357,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -269,6 +368,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -277,6 +379,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -285,6 +390,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -293,6 +401,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -301,6 +412,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -309,6 +423,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -317,6 +434,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -325,5 +445,8 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "feedback",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
+++ b/src/components/create-password/tests/__snapshots__/create-password-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,5 +82,8 @@ Object {
   "contentId": "8c0cc624-2e97-471d-ad36-6b695f9a038d",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "6e5cc49f-4770-4089-8547-06149e0f59b1",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,5 +93,8 @@ Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-email/tests/__snapshots__/enter-email-create-account-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-create-account-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,5 +82,8 @@ Object {
   "contentId": "390f46f9-1f6b-44f2-8fd7-21a5385a7d3a",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
+++ b/src/components/enter-email/tests/__snapshots__/enter-email-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "aff1628e-177d-4afc-825b-56e926b2fc1f",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,5 +82,8 @@ Object {
   "contentId": "d8767bcf-ffb8-4b43-8bda-24c6291590bb",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,5 +82,8 @@ Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-reauth-integration.test.ts.snap
@@ -5,5 +5,8 @@ Object {
   "contentId": "c9f09429-b29d-421e-a33a-41149489a0a2",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,5 +38,8 @@ Object {
   "contentId": "6b9f2243-d217-4c55-8ef3-7ac24b1f77e2",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
+++ b/src/components/enter-password/tests/__snapshots__/enter-password-reauth-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,5 +38,8 @@ Object {
   "contentId": "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
+++ b/src/components/enter-phone-number/tests/__snapshots__/enter-phone-number-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "0f519eb6-5cd4-476f-968f-d847b3c4c034",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,6 +93,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -77,6 +104,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -85,6 +115,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -93,6 +126,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -101,5 +137,8 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/ga4-opl/template.njk
+++ b/src/components/ga4-opl/template.njk
@@ -8,6 +8,9 @@
                 englishPageTitle: '{{ga4Params.englishPageTitle}}',
                 taxonomy_level1: '{{ ga4Params.taxonomyLevel1 | default(taxonomyLevel1, false) }}',
                 taxonomy_level2: '{{ ga4Params.taxonomyLevel2 | default(taxonomyLevel2, false) }}',
+                taxonomy_level3: '{{ ga4Params.taxonomyLevel3 | default(taxonomyLevel3, false) }}',
+                taxonomy_level4: '{{ ga4Params.taxonomyLevel4 | default(taxonomyLevel4, false) }}',
+                taxonomy_level5: '{{ ga4Params.taxonomyLevel5 | default(taxonomyLevel5, false) }}',
                 content_id: '{{ ga4Params.contentId | default(contentId, false) }}',
                 logged_in_status: {{ga4Params.loggedInStatus}},
                 dynamic: {{ga4Params.dynamic}}

--- a/src/components/healthcheck/tests/__snapshots__/healthcheck-integration.test.ts.snap
+++ b/src/components/healthcheck/tests/__snapshots__/healthcheck-integration.test.ts.snap
@@ -5,5 +5,8 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;

--- a/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
+++ b/src/components/prove-identity/tests/__snapshots__/prove-identity-integration.test.ts.snap
@@ -5,5 +5,8 @@ Object {
   "contentId": "3104ec55-1a4e-4811-b927-0531fb315480",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
+++ b/src/components/resend-email-code/tests/__snapshots__/resend-email-code-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "3104ec55-1a4e-4811-b927-0531fb315480",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -37,5 +49,8 @@ Object {
   "contentId": "3104ec55-1a4e-4811-b927-0531fb315480",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
+++ b/src/components/resend-mfa-code/tests/__snapshots__/resend-mfa-code-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "a2776ef7-9ef3-4d8d-bdbc-3f798b15e5d4",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "a2776ef7-9ef3-4d8d-bdbc-3f798b15e5d4",
   "taxonomyLevel1": "accounts",
   "taxonomyLevel2": "re auth",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,5 +93,8 @@ Object {
   "contentId": "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
@@ -5,5 +5,8 @@ Object {
   "contentId": "943b41f4-8262-417f-8866-c0639319ccf0",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,5 +16,8 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-auth-app-2fa-integration.test.ts.snap
@@ -5,5 +5,8 @@ Object {
   "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,5 +60,8 @@ Object {
   "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,6 +93,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -77,5 +104,8 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
+++ b/src/components/reset-password/tests/__snapshots__/reset-password-required-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": "95e26313-bc2f-49bc-bc62-fd715476c1d9",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,6 +49,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -45,6 +60,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -53,6 +71,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -61,6 +82,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -69,6 +93,9 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -77,5 +104,8 @@ Object {
   "contentId": "c8520c6c-9f09-4edf-8c99-7123a3991cfc",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
+++ b/src/components/select-mfa-options/tests/__snapshots__/select-mfa-options-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "95e26313-bc2f-49bc-bc62-fd715476c1d9",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,5 +27,8 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
+++ b/src/components/setup-authenticator-app/tests/__snapshots__/setup-authenticator-app-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -13,6 +16,9 @@ Object {
   "contentId": "5bc82db9-2012-44bf-9a7d-34d1d22fb035",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "create account",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -21,6 +27,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -29,6 +38,9 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;
 
@@ -37,5 +49,8 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/components/updated-terms-conditions/tests/__snapshots__/updated-terms-conditions-integration.test.ts.snap
+++ b/src/components/updated-terms-conditions/tests/__snapshots__/updated-terms-conditions-integration.test.ts.snap
@@ -5,6 +5,9 @@ Object {
   "contentId": undefined,
   "taxonomyLevel1": undefined,
   "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
 }
 `;
 
@@ -13,5 +16,8 @@ Object {
   "contentId": "",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
 }
 `;

--- a/src/utils/taxonomy.test.ts
+++ b/src/utils/taxonomy.test.ts
@@ -11,30 +11,27 @@ import {
 import { describe } from "mocha";
 import { Request } from "express";
 import { expect } from "chai";
-import { UserSession } from "../types";
 import { CONTACT_US_THEMES, PATH_NAMES } from "../app.constants";
+import { ParsedQs } from "qs";
 
-type Variant = {
-  user?: Partial<UserSession>;
-  path?: string;
-  query?: { [key: string]: string };
+type RequestTaxonomyExpectation = {
+  request: Request;
+  taxonomy: Taxonomy;
 };
 
-type VariantExpectation = Variant & {
-  expectedTaxonomy: Taxonomy;
-};
-
-const signInVariants: Variant[] = [
-  { user: { isSignInJourney: true } },
+const signInRequests: Request[] = [
+  { session: { user: { isSignInJourney: true } } },
   { path: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE },
   { path: PATH_NAMES.ENTER_EMAIL_SIGN_IN },
   { path: PATH_NAMES.ENTER_MFA },
   { path: PATH_NAMES.ENTER_PASSWORD },
   { path: PATH_NAMES.RESEND_MFA_CODE },
-];
-const reauthVariants: Variant[] = [{ user: { reauthenticate: "samplevalue" } }];
-const createAccountVariants: Variant[] = [
-  { user: { isAccountCreationJourney: true } },
+] as Request[];
+const reauthRequests: Request[] = [
+  { session: { user: { reauthenticate: "samplevalue" } } },
+] as Request[];
+const createAccountRequests: Request[] = [
+  { session: { user: { isAccountCreationJourney: true } } },
   { path: PATH_NAMES.CHECK_YOUR_EMAIL },
   { path: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER },
   { path: PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD },
@@ -42,12 +39,14 @@ const createAccountVariants: Variant[] = [
   { path: PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT },
   { path: PATH_NAMES.RESEND_EMAIL_CODE },
   { path: PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION },
-];
-const accountRecoveryVariants: Variant[] = [
+] as Request[];
+const accountRecoveryRequests: Request[] = [
   {
-    user: {
-      isAccountRecoveryJourney: true,
-      isAccountRecoveryPermitted: true,
+    session: {
+      user: {
+        isAccountRecoveryJourney: true,
+        isAccountRecoveryPermitted: true,
+      },
     },
   },
   { path: PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION },
@@ -58,31 +57,32 @@ const accountRecoveryVariants: Variant[] = [
   { path: PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL },
   { path: PATH_NAMES.RESET_PASSWORD_REQUIRED },
   { path: PATH_NAMES.RESET_PASSWORD_RESEND_CODE },
-];
-const feedbackVariants: Variant[] = [
+] as Request[];
+const feedbackRequests: Request[] = [
   { path: PATH_NAMES.CONTACT_US },
   { path: PATH_NAMES.CONTACT_US_FROM_TRIAGE_PAGE },
   { path: PATH_NAMES.CONTACT_US_FURTHER_INFORMATION },
   { path: PATH_NAMES.CONTACT_US_QUESTIONS },
   { path: PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS },
-];
-const guidanceVariants: Variant[] = [
+] as Request[];
+const guidanceRequests: Request[] = [
   {
     path: PATH_NAMES.CONTACT_US_QUESTIONS,
     query: {
       theme: CONTACT_US_THEMES.SUGGESTIONS_FEEDBACK,
-    },
+    } as ParsedQs,
   },
-];
-const accountInterventionVariants: Variant[] = [
+] as Request[];
+const accountInterventionRequests: Request[] = [
   { path: PATH_NAMES.PASSWORD_RESET_REQUIRED },
   { path: PATH_NAMES.UNAVAILABLE_PERMANENT },
   { path: PATH_NAMES.UNAVAILABLE_TEMPORARY },
-];
+] as Request[];
 
-const mappingsToTest: VariantExpectation[] = [
+const expectations: RequestTaxonomyExpectation[] = [
   {
-    expectedTaxonomy: {
+    request: {} as Request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.BLANK,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -90,9 +90,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   },
-  ...signInVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...signInRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.SIGN_IN,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -100,9 +100,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
-  ...reauthVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...reauthRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.ACCOUNTS,
       taxonomyLevel2: TaxonomyLevel2.REAUTH,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -110,9 +110,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
-  ...createAccountVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...createAccountRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.CREATE_ACCOUNT,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -120,9 +120,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
-  ...feedbackVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...feedbackRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.FEEDBACK,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -130,9 +130,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
-  ...guidanceVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...guidanceRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.GUIDANCE,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -140,9 +140,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
-  ...accountRecoveryVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...accountRecoveryRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.ACCOUNT_RECOVERY,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -150,9 +150,9 @@ const mappingsToTest: VariantExpectation[] = [
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
-  ...accountInterventionVariants.map((t) => ({
-    ...t,
-    expectedTaxonomy: {
+  ...accountInterventionRequests.map((request) => ({
+    request,
+    taxonomy: {
       taxonomyLevel1: TaxonomyLevel1.ACCOUNTS,
       taxonomyLevel2: TaxonomyLevel2.ACCOUNT_INTERVENTION,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
@@ -168,14 +168,10 @@ describe("getRequestTaxonomy", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
   });
 
-  mappingsToTest.forEach((mapping) => {
-    it(`user (${JSON.stringify(mapping.user)}) on path (${mapping.path}) should map to taxonomy ${JSON.stringify(mapping.expectedTaxonomy)}`, async () => {
-      const taxonomy = getRequestTaxonomy({
-        session: { user: mapping.user },
-        path: mapping.path,
-        query: mapping.query,
-      } as Request);
-      expect(taxonomy).to.deep.equal(mapping.expectedTaxonomy);
+  expectations.forEach((expectation) => {
+    it(`user (${JSON.stringify(expectation.request.session?.user)}) on path (${expectation.request.path}) should map to taxonomy ${JSON.stringify(expectation.taxonomy)}`, async () => {
+      const taxonomy = getRequestTaxonomy(expectation.request);
+      expect(taxonomy).to.deep.equal(expectation.taxonomy);
     });
   });
 });

--- a/src/utils/taxonomy.test.ts
+++ b/src/utils/taxonomy.test.ts
@@ -3,6 +3,9 @@ import {
   Taxonomy,
   TaxonomyLevel1,
   TaxonomyLevel2,
+  TaxonomyLevel3,
+  TaxonomyLevel4,
+  TaxonomyLevel5,
 } from "./taxonomy";
 
 import { describe } from "mocha";
@@ -82,6 +85,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.BLANK,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   },
   ...signInVariants.map((t) => ({
@@ -89,6 +95,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.SIGN_IN,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
   ...reauthVariants.map((t) => ({
@@ -96,6 +105,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.ACCOUNTS,
       taxonomyLevel2: TaxonomyLevel2.REAUTH,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
   ...createAccountVariants.map((t) => ({
@@ -103,6 +115,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.CREATE_ACCOUNT,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
   ...feedbackVariants.map((t) => ({
@@ -110,6 +125,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.FEEDBACK,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
   ...guidanceVariants.map((t) => ({
@@ -117,6 +135,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.GUIDANCE,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
   ...accountRecoveryVariants.map((t) => ({
@@ -124,6 +145,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
       taxonomyLevel2: TaxonomyLevel2.ACCOUNT_RECOVERY,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
   ...accountInterventionVariants.map((t) => ({
@@ -131,6 +155,9 @@ const mappingsToTest: VariantExpectation[] = [
     expectedTaxonomy: {
       taxonomyLevel1: TaxonomyLevel1.ACCOUNTS,
       taxonomyLevel2: TaxonomyLevel2.ACCOUNT_INTERVENTION,
+      taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
     },
   })),
 ];

--- a/src/utils/taxonomy.ts
+++ b/src/utils/taxonomy.ts
@@ -19,9 +19,24 @@ export enum TaxonomyLevel2 {
   REAUTH = "re auth",
 }
 
+export enum TaxonomyLevel3 {
+  BLANK = "",
+}
+
+export enum TaxonomyLevel4 {
+  BLANK = "",
+}
+
+export enum TaxonomyLevel5 {
+  BLANK = "",
+}
+
 export type Taxonomy = {
   taxonomyLevel1: TaxonomyLevel1;
   taxonomyLevel2: TaxonomyLevel2;
+  taxonomyLevel3: TaxonomyLevel3;
+  taxonomyLevel4: TaxonomyLevel4;
+  taxonomyLevel5: TaxonomyLevel5;
 };
 
 export function getRequestTaxonomy(req: Request): Taxonomy {
@@ -36,6 +51,9 @@ export function getRequestTaxonomy(req: Request): Taxonomy {
   return {
     taxonomyLevel1,
     taxonomyLevel2,
+    taxonomyLevel3: TaxonomyLevel3.BLANK,
+    taxonomyLevel4: TaxonomyLevel4.BLANK,
+    taxonomyLevel5: TaxonomyLevel5.BLANK,
   };
 }
 

--- a/test/helpers/expect-response-helpers.ts
+++ b/test/helpers/expect-response-helpers.ts
@@ -8,6 +8,9 @@ export function expectAnalyticsPropertiesMatchSnapshot(
     expect({
       taxonomyLevel1: res.text.match(/taxonomy_level1: '([\w\d\s]*)'/)?.[1],
       taxonomyLevel2: res.text.match(/taxonomy_level2: '([\w\d\s]*)'/)?.[1],
+      taxonomyLevel3: res.text.match(/taxonomy_level3: '([\w\d\s]*)'/)?.[1],
+      taxonomyLevel4: res.text.match(/taxonomy_level4: '([\w\d\s]*)'/)?.[1],
+      taxonomyLevel5: res.text.match(/taxonomy_level5: '([\w\d\s]*)'/)?.[1],
       contentId: res.text.match(/content_id: '([\w\d-]*)'/)?.[1],
     }).toMatchSnapshot();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
   integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
-"@govuk-one-login/frontend-analytics@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.0.1.tgz#3dcf4a117abca0823a11e7190f37c335c464d41d"
-  integrity sha512-Si1ZHG+RV4JBdDBH2bAAJFHRxnukExeix/JOL12prMThUkLsnZbamgPUAcVoByZRydYYXzilJgRw7PNiO1g1Kg==
+"@govuk-one-login/frontend-analytics@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.1.0.tgz#7b8ad99ede1f5a0dbf81a62f375f26036d8b1e02"
+  integrity sha512-cHjuTWo7fLRwxjIcJCDG8cLheH/te77TZ03gDPvwvMRxI3xmCZ0HDQ2fVAHn6PMzOzPxODn5EUQIUQKxWhJskw==
   dependencies:
     copy-webpack-plugin "^12.0.2"
     loglevel "^1.9.1"


### PR DESCRIPTION
## What

`@govuk-one-login/frontend-analytics` is updated to 3.1.0 and support added for the 3 new taxonomy levels

`taxonomy.ts` is updated to support empty strings as default for each new level, with future work expanding on these possible values.

Note that it is intended that there are a lot of empty strings sent to the GA4 library, which matches the implementation at https://github.com/govuk-one-login/govuk-one-login-frontend/blob/60326ab8f4d5c77e7f7ede8c0030431ab4b614f3/packages/frontend-analytics/src/components/ga4-opl/template.njk#L12. The GA4 library itself strips empty string values from the network requests to Google Analytics.


## How to review

1. Code Review

## Related PRs

Builds off the back of https://github.com/govuk-one-login/authentication-frontend/pull/2520
