### PR TITLE
AUT-3993: Tell backend not to block user for mfa reset when mfa reset via ipv is on

### DIFF
--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -11,6 +11,7 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { BadRequestError } from "../../utils/error";
 import { EnterPasswordServiceInterface } from "../enter-password/types";
 import { enterPasswordService } from "../enter-password/enter-password-service";
+import { supportMfaResetWithIpv } from "../../config";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -42,12 +43,17 @@ export function resetPasswordPost(
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const newPassword = req.body.password;
 
+    // WARNING! Before removing this feature flag, you first need to ensure that this behaviour is the default on the backend
+    // Purely removing this feature flag will mean that we start writing to account modifiers again
+    const allowMfaResetAfterPasswordReset = supportMfaResetWithIpv();
+
     const updatePasswordResponse = await resetService.updatePassword(
       newPassword,
       sessionId,
       clientSessionId,
       persistentSessionId,
       withinForcedPasswordResetJourney,
+      allowMfaResetAfterPasswordReset,
       req
     );
 

--- a/src/components/reset-password/reset-password-service.ts
+++ b/src/components/reset-password/reset-password-service.ts
@@ -18,6 +18,7 @@ export function resetPasswordService(
     clientSessionId: string,
     persistentSessionId: string,
     isForcedPasswordReset: boolean,
+    allowMfaResetAfterPasswordReset: boolean,
     req: Request
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
@@ -25,6 +26,7 @@ export function resetPasswordService(
       {
         password: newPassword,
         isForcedPasswordReset: isForcedPasswordReset,
+        allowMfaResetAfterPasswordReset: allowMfaResetAfterPasswordReset,
       },
       getInternalRequestConfigWithSecurityHeaders(
         {

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -85,159 +85,151 @@ describe("reset password controller (in 6 digit code flow)", () => {
     });
   });
 
-  TEST_SCENARIO_PARAMETERS.forEach(function (params) {
-    describe(
-      "resetPasswordPost supportPasswordResetRequired: " +
-        params.supportPasswordResetRequired +
-        " passwordChangeRequired: " +
-        params.passwordChangeRequired,
-      () => {
-        it("should redirect to /auth-code if request is success", async () => {
-          const fakeResetService: ResetPasswordServiceInterface = {
-            updatePassword: sinon.fake.returns({ success: true }),
-          } as unknown as ResetPasswordServiceInterface;
-          const fakeLoginService: EnterPasswordServiceInterface = {
-            loginUser: sinon.fake.returns({
-              success: true,
-              data: {
-                redactedPhoneNumber: "1234",
-                latestTermsAndConditionsAccepted: true,
-                mfaMethodVerified: true,
-                mfaMethodType: MFA_METHOD_TYPE.SMS,
-                mfaRequired: true,
-                passwordChangeRequired: params.passwordChangeRequired,
-              },
-            }),
-          } as unknown as EnterPasswordServiceInterface;
-
-          await resetPasswordPost(fakeResetService, fakeLoginService)(
-            req as Request,
-            res as Response
-          );
-
-          expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
-        });
-
-        it("should redirect to /get-security-codes when password updated and mfa method not verified", async () => {
-          const fakeResetService: ResetPasswordServiceInterface = {
-            updatePassword: sinon.fake.returns({ success: true }),
-          } as unknown as ResetPasswordServiceInterface;
-          const fakeLoginService: EnterPasswordServiceInterface = {
-            loginUser: sinon.fake.returns({
-              success: true,
-              data: {
-                redactedPhoneNumber: "1234",
-                latestTermsAndConditionsAccepted: true,
-                mfaMethodVerified: false,
-                mfaRequired: true,
-                passwordChangeRequired: params.passwordChangeRequired,
-              },
-            }),
-          } as unknown as EnterPasswordServiceInterface;
-
-          req.session.user = {
-            email: "joe.bloggs@test.com",
-          };
-          req.body.password = "Password1";
-
-          await resetPasswordPost(fakeResetService, fakeLoginService)(
-            req as Request,
-            res as Response
-          );
-
-          expect(fakeResetService.updatePassword).to.have.been.calledOnce;
-          expect(fakeLoginService.loginUser).to.have.been.calledOnce;
-
-          expect(res.redirect).to.have.calledWith(
-            PATH_NAMES.GET_SECURITY_CODES
-          );
-        });
-      }
-    );
-
-    it("should not set the passwordResetTime flag on the session if update password is not a success", async () => {
-      const fakeResetService: ResetPasswordServiceInterface = {
-        updatePassword: sinon.fake.returns({
-          success: false,
-          data: { code: ERROR_CODES.NEW_PASSWORD_SAME_AS_EXISTING },
-        }),
+  describe("resetPasswordPost", () => {
+    const newPassword = "Password1";
+    function fakeResetServiceReturningSuccess(success: boolean, data?: object) {
+      return {
+        updatePassword: sinon.fake.returns({ success, data }),
       } as unknown as ResetPasswordServiceInterface;
-      const fakeLoginService: EnterPasswordServiceInterface = {
-        loginUser: sinon.fake.returns({
-          success: true,
-          data: {
-            redactedPhoneNumber: "1234",
-            latestTermsAndConditionsAccepted: true,
-            mfaMethodVerified: true,
-            mfaRequired: false,
-            mfaMethodType: MFA_METHOD_TYPE.SMS,
-            passwordChangeRequired: params.passwordChangeRequired,
-          },
-        }),
-      } as unknown as EnterPasswordServiceInterface;
+    }
 
+    beforeEach(() => {
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
-      req.body.password = "Password1";
-
-      await resetPasswordPost(fakeResetService, fakeLoginService)(
-        req as Request,
-        res as Response
-      );
-
-      expect(fakeResetService.updatePassword).to.have.been.calledOnce;
-      expect(fakeLoginService.loginUser).not.to.have.been.called;
-
-      expect(req.session.user.passwordResetTime).to.be.undefined;
+      req.body.password = newPassword;
     });
-  });
 
-  [true, false].forEach(function (supportMfaResetWithIpv) {
-    it(`should call the update password service with the value of allowMfaResetAfterPasswordReset set ${supportMfaResetWithIpv} when this is the value of the mfa reset feature flag`, async () => {
-      if (supportMfaResetWithIpv) {
-        process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
-      } else {
-        process.env.SUPPORT_MFA_RESET_WITH_IPV = "0";
-      }
-      const fakeResetService: ResetPasswordServiceInterface = {
-        updatePassword: sinon.fake.returns({ success: true }),
-      } as unknown as ResetPasswordServiceInterface;
-      const fakeLoginService: EnterPasswordServiceInterface = {
-        loginUser: sinon.fake.returns({
-          success: true,
-          data: {
-            redactedPhoneNumber: "1234",
-            latestTermsAndConditionsAccepted: true,
-            mfaMethodVerified: false,
-            mfaRequired: true,
-            passwordChangeRequired: false,
-          },
-        }),
-      } as unknown as EnterPasswordServiceInterface;
+    TEST_SCENARIO_PARAMETERS.forEach(function (params) {
+      describe(
+        "resetPasswordPost supportPasswordResetRequired: " +
+          params.supportPasswordResetRequired +
+          " passwordChangeRequired: " +
+          params.passwordChangeRequired,
+        () => {
+          it("should redirect to /auth-code if request is success", async () => {
+            const fakeResetService = fakeResetServiceReturningSuccess(true);
+            const fakeLoginService: EnterPasswordServiceInterface = {
+              loginUser: sinon.fake.returns({
+                success: true,
+                data: {
+                  redactedPhoneNumber: "1234",
+                  latestTermsAndConditionsAccepted: true,
+                  mfaMethodVerified: true,
+                  mfaMethodType: MFA_METHOD_TYPE.SMS,
+                  mfaRequired: true,
+                  passwordChangeRequired: params.passwordChangeRequired,
+                },
+              }),
+            } as unknown as EnterPasswordServiceInterface;
 
-      req.session.user = {
-        email: "joe.bloggs@test.com",
-      };
-      req.body.password = "Password1";
+            await resetPasswordPost(fakeResetService, fakeLoginService)(
+              req as Request,
+              res as Response
+            );
 
-      await resetPasswordPost(fakeResetService, fakeLoginService)(
-        req as Request,
-        res as Response
+            expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+          });
+
+          it("should redirect to /get-security-codes when password updated and mfa method not verified", async () => {
+            const fakeResetService = fakeResetServiceReturningSuccess(true);
+            const fakeLoginService: EnterPasswordServiceInterface = {
+              loginUser: sinon.fake.returns({
+                success: true,
+                data: {
+                  redactedPhoneNumber: "1234",
+                  latestTermsAndConditionsAccepted: true,
+                  mfaMethodVerified: false,
+                  mfaRequired: true,
+                  passwordChangeRequired: params.passwordChangeRequired,
+                },
+              }),
+            } as unknown as EnterPasswordServiceInterface;
+
+            await resetPasswordPost(fakeResetService, fakeLoginService)(
+              req as Request,
+              res as Response
+            );
+
+            expect(fakeResetService.updatePassword).to.have.been.calledOnce;
+            expect(fakeLoginService.loginUser).to.have.been.calledOnce;
+
+            expect(res.redirect).to.have.calledWith(
+              PATH_NAMES.GET_SECURITY_CODES
+            );
+          });
+        }
       );
 
-      expect(fakeResetService.updatePassword).to.have.been.calledOnceWith(
-        "Password1",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        supportMfaResetWithIpv,
-        req
-      );
-      expect(fakeLoginService.loginUser).to.have.been.calledOnce;
+      it("should not set the passwordResetTime flag on the session if update password is not a success", async () => {
+        const fakeResetService = fakeResetServiceReturningSuccess(false, {
+          code: ERROR_CODES.NEW_PASSWORD_SAME_AS_EXISTING,
+        });
+        const fakeLoginService: EnterPasswordServiceInterface = {
+          loginUser: sinon.fake.returns({
+            success: true,
+            data: {
+              redactedPhoneNumber: "1234",
+              latestTermsAndConditionsAccepted: true,
+              mfaMethodVerified: true,
+              mfaRequired: false,
+              mfaMethodType: MFA_METHOD_TYPE.SMS,
+              passwordChangeRequired: params.passwordChangeRequired,
+            },
+          }),
+        } as unknown as EnterPasswordServiceInterface;
 
-      expect(res.redirect).to.have.calledWith(PATH_NAMES.GET_SECURITY_CODES);
+        await resetPasswordPost(fakeResetService, fakeLoginService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(fakeResetService.updatePassword).to.have.been.calledOnce;
+        expect(fakeLoginService.loginUser).not.to.have.been.called;
+
+        expect(req.session.user.passwordResetTime).to.be.undefined;
+      });
+    });
+
+    [true, false].forEach(function (supportMfaResetWithIpv) {
+      it(`should call the update password service with the value of allowMfaResetAfterPasswordReset set ${supportMfaResetWithIpv} when this is the value of the mfa reset feature flag`, async () => {
+        if (supportMfaResetWithIpv) {
+          process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+        } else {
+          process.env.SUPPORT_MFA_RESET_WITH_IPV = "0";
+        }
+        const fakeResetService = fakeResetServiceReturningSuccess(true);
+        const fakeLoginService: EnterPasswordServiceInterface = {
+          loginUser: sinon.fake.returns({
+            success: true,
+            data: {
+              redactedPhoneNumber: "1234",
+              latestTermsAndConditionsAccepted: true,
+              mfaMethodVerified: false,
+              mfaRequired: true,
+              passwordChangeRequired: false,
+            },
+          }),
+        } as unknown as EnterPasswordServiceInterface;
+
+        await resetPasswordPost(fakeResetService, fakeLoginService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(fakeResetService.updatePassword).to.have.been.calledOnceWith(
+          newPassword,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          supportMfaResetWithIpv,
+          req
+        );
+        expect(fakeLoginService.loginUser).to.have.been.calledOnce;
+
+        expect(res.redirect).to.have.calledWith(PATH_NAMES.GET_SECURITY_CODES);
+      });
     });
   });
 });

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -109,7 +109,6 @@ describe("reset password controller (in 6 digit code flow)", () => {
               },
             }),
           } as unknown as EnterPasswordServiceInterface;
-          fakeLoginService.loginUser;
 
           await resetPasswordPost(fakeResetService, fakeLoginService)(
             req as Request,
@@ -135,7 +134,6 @@ describe("reset password controller (in 6 digit code flow)", () => {
               },
             }),
           } as unknown as EnterPasswordServiceInterface;
-          fakeLoginService.loginUser;
 
           req.session.user = {
             email: "joe.bloggs@test.com",
@@ -177,7 +175,6 @@ describe("reset password controller (in 6 digit code flow)", () => {
           },
         }),
       } as unknown as EnterPasswordServiceInterface;
-      fakeLoginService.loginUser;
 
       req.session.user = {
         email: "joe.bloggs@test.com",

--- a/src/components/reset-password/tests/reset-password-service.test.ts
+++ b/src/components/reset-password/tests/reset-password-service.test.ts
@@ -45,6 +45,7 @@ describe("reset password service", () => {
       commonVariables;
     const newPassword = "abcdef";
     const isForcedPasswordReset = false;
+    const allowMfaResetAfterPasswordReset = true;
     const req = createMockRequest(PATH_NAMES.RESET_PASSWORD, {
       headers: requestHeadersWithIpAndAuditEncoded,
     });
@@ -55,6 +56,7 @@ describe("reset password service", () => {
       clientSessionId,
       diPersistentSessionId,
       isForcedPasswordReset,
+      allowMfaResetAfterPasswordReset,
       req
     );
 
@@ -64,6 +66,7 @@ describe("reset password service", () => {
       expectedBody: {
         password: newPassword,
         isForcedPasswordReset: isForcedPasswordReset,
+        allowMfaResetAfterPasswordReset: allowMfaResetAfterPasswordReset,
       },
     };
 

--- a/src/components/reset-password/types.ts
+++ b/src/components/reset-password/types.ts
@@ -8,6 +8,7 @@ export interface ResetPasswordServiceInterface {
     clientSessionId: string,
     persistentSessionId: string,
     isForcedPasswordReset: boolean,
+    allowMfaResetAfterPasswordReset: boolean,
     req: Request
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }


### PR DESCRIPTION
## What

This makes use of the new optional flag ("allowMfaResetAfterPasswordReset") on the request to the reset password handler when the mfa reset via ipv journey is on.

This will mean that a user who has successfully reset their password does not have any account modifiers put on them, and can immediately reset their mfa on a subsequent journey after resetting their password (previously they would have had to complete one successful subsequent login journey before resetting mfa.

This behaviour was somewhat legacy anyway since we put the MFA challenge as part of password reset, but will be especially now that they have to go through a higher security journey as part of resetting their MFA.

We've made a decision here not to introduce a separate feature flag on the backend that reflects whether the new support mfa journey is on or not. Instead the behaviour is controlled via the frontend feature flags, meaning this new behaviour will all be switched on at once.

A consequence of this is that if, once we're happy with the behaviour in production, we want to remove the feature flag and have the 'on' behaviour as default, we'll need to first default the behaviour in the backend (or always set this value to true, and then default the backend behaviour). This should be obvious when changing the code, but I've added in a rare comment to be on the safe side.

Also contains some test tidies.

## How to review

* Code review commit by commit - might be best to turn off whitespace comparison as I've added some nesting to tests which looks nasty without this
* QA will cover off testing but if you wanted to test you would deploy this and the frontend change to an env with the new journey flagged on or off, and see that either you could reset your MFA in the journey following a password reset (when the new journey is switched on), or you could not if the new journey is switched off.

## Related PRs

Requires [backend changes](https://github.com/govuk-one-login/authentication-api/pull/5798) to be merged first
