### PR TITLE
BAU: Upgrade cheerio

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@typescript-eslint/parser": "^8.13.0",
     "chai": "^4.3.6",
     "chai-http": "^5.1.1",
-    "cheerio": "^1.0.0-rc.10",
+    "cheerio": "^1.0.0",
     "concurrently": "^9.0.1",
     "copyfiles": "^2.4.1",
     "debug": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,7 +2845,7 @@ cheerio-select@^2.1.0:
     domhandler "^5.0.3"
     domutils "^3.0.1"
 
-cheerio@^1.0.0-rc.10:
+cheerio@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0.tgz#1ede4895a82f26e8af71009f961a9b8cb60d6a81"
   integrity sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==
@@ -6649,9 +6649,9 @@ undici@^5.28.5:
     "@fastify/busboy" "^2.0.0"
 
 undici@^6.19.5:
-  version "6.20.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.20.1.tgz#fbb87b1e2b69d963ff2d5410a40ffb4c9e81b621"
-  integrity sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
 
 unicorn-magic@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## What

Upgrade cheerio from the release candidate to the main 1.0.0 version, which as a side-effect resolved CVE-2025-22150 which depends on undici versions being updated, and in this case to 6.21.1.

## How to review

1. Code Review
