### PR TITLE
AUT-3694 - maintain migrated zone records in prod

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -233,6 +233,9 @@ Conditions:
       - Fn::Equals:
           - !Ref Environment
           - "integration"
+      - Fn::Equals:
+          - !Ref Environment
+          - "production"
 
   SwitchToMigratedZone:
     Fn::And:


### PR DESCRIPTION
## What

Deploy the frontend application with the MaintainMigratedZoneRecordsfeature switch enabled in the production account. This will add the source (old) CloudFront and origin ALB alias records pointing to the old frontend to the newly created hosted zone in step 3.1 

## How to review

Migration guide https://govukverify.atlassian.net/wiki/spaces/LO/pages/4773052525/Auth+New+Frontend+Go-live+Release+Plan step 3.2