### PR TITLE
AUT-3689: Maintain migrated zone records in BUILD

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -236,6 +236,9 @@ Conditions:
       - Fn::Equals:
           - !Ref Environment
           - "production"
+      - Fn::Equals:
+          - !Ref Environment
+          - "build"
 
   SwitchToMigratedZone:
     Fn::And:


### PR DESCRIPTION
## What

AUT-3689 :  Enable  MaintainMigratedZoneRecordsfeature switch in the Build  account, required for Build Zone Id migration and frontend 

## How to review

1. Code Review


