### PR TITLE
AUT-3910: Send state to /reverification-result API

### DIFF
--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -41,12 +41,18 @@ export function ipvCallbackGet(
     const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
-    const code = req.query.code;
+    const { code, state } = req.query;
 
     if (code === undefined) {
       throw new BadRequestError("Request query missing auth code param", 400);
     } else if (typeof code !== "string") {
       throw new BadRequestError("Invalid auth code param type", 400);
+    }
+
+    if (state === undefined) {
+      throw new BadRequestError("Request query missing state param", 400);
+    } else if (typeof state !== "string") {
+      throw new BadRequestError("Invalid state param type", 400);
     }
 
     const result = await service.getReverificationResult(
@@ -55,7 +61,8 @@ export function ipvCallbackGet(
       persistentSessionId,
       req,
       email,
-      code
+      code,
+      state
     );
 
     logger.info(

--- a/src/components/ipv-callback/reverification-result-service.ts
+++ b/src/components/ipv-callback/reverification-result-service.ts
@@ -21,7 +21,8 @@ export function reverificationResultService(
     persistentSessionId: string,
     req: Request,
     email: string,
-    code: string
+    code: string,
+    state: string
   ): Promise<ApiResponseResult<ReverificationResultResponse>> {
     const config = getInternalRequestConfigWithSecurityHeaders(
       {
@@ -35,7 +36,7 @@ export function reverificationResultService(
 
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.REVERIFICATION_RESULT,
-      { email, code },
+      { email, code, state },
       config
     );
 

--- a/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-controller.test.ts
@@ -62,10 +62,11 @@ describe("ipv callback controller", () => {
     commonVariables;
 
   const AUTH_CODE = "5678";
+  const STATE = "efghijk";
 
   beforeEach(() => {
     req = createMockRequest(PATH_NAMES.IPV_CALLBACK);
-    req.query = { code: AUTH_CODE };
+    req.query = { code: AUTH_CODE, state: STATE };
     req.session.user.email = email;
     req.session.id = sessionId;
     req.cookies.gs = sessionId + clientSessionId;
@@ -105,7 +106,8 @@ describe("ipv callback controller", () => {
         diPersistentSessionId,
         req,
         email,
-        AUTH_CODE
+        AUTH_CODE,
+        STATE
       );
       expect(res.redirect).to.have.been.calledWith(
         PATH_NAMES.GET_SECURITY_CODES

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -43,7 +43,7 @@ describe("Integration:: ipv callback", () => {
         .once()
         .reply(200, { success: true });
 
-      const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+      const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=12345&state=abcde";
 
       await request(
         app,
@@ -64,7 +64,7 @@ describe("Integration:: ipv callback", () => {
         .once()
         .reply(200, { success: false, failure_code: "no_identity_available" });
 
-      const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=" + "12345";
+      const requestPath = PATH_NAMES.IPV_CALLBACK + "?code=12345&state=abcde";
 
       await request(
         app,

--- a/src/components/ipv-callback/tests/reverification-result-service.test.ts
+++ b/src/components/ipv-callback/tests/reverification-result-service.test.ts
@@ -48,13 +48,14 @@ describe("reverification result service", () => {
       diPersistentSessionId,
       req,
       email,
-      "12345"
+      "12345",
+      "abcdef"
     );
 
     const expectedApiCallDetails = {
       expectedPath: API_ENDPOINTS.REVERIFICATION_RESULT,
       expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
-      expectedBody: { email, code: "12345" },
+      expectedBody: { email, code: "12345", state: "abcdef" },
     };
 
     checkApiCallMadeWithExpectedBodyAndHeaders(

--- a/src/components/ipv-callback/types.ts
+++ b/src/components/ipv-callback/types.ts
@@ -39,7 +39,8 @@ export interface ReverificationResultInterface {
     persistentSessionId: string,
     req: Request,
     email: string,
-    code: string
+    code: string,
+    state: string
   ) => Promise<ApiResponseResult<ReverificationResultResponse>>;
 }
 


### PR DESCRIPTION
## What

We need to forward the state received when a user returns from IPV during an MFA reset journey to our backend. This is so the backend can check the state received matches the state created by the backend for the session as a CSRF mitigation.

## How to review

1. Code Review

