### PR TITLE
BAU: remove ECS canary deployment from Authdev2 Sp env

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -277,7 +277,6 @@ Mappings:
       basicAuthSidecarURI: "975050272416.dkr.ecr.eu-west-2.amazonaws.com/authdev2-basic-auth-sidecar-image-repository-containerrepository-zvcjtkip2sye"
       UseNginxSidecar: "Yes"
       cloudfrontDistributionStackName: "authdev2-cloudfront"
-      ECSServiceCanaryPhasedDeploy: "Yes"
       orchToAuthSigningPublicKey: |
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUm


### PR DESCRIPTION
## What

Remove ECS canary deployment from Authdev2 Sp env

## How to review

1. Code Review
