### PR TITLE
Aut 3998/add analytics for new mfa pages

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -105,6 +105,12 @@ export const CONTENT_IDS: {
     default: "f463a280-31f1-43c0-a2f5-6b46b1e2bb15",
     reauth: "a2776ef7-9ef3-4d8d-bdbc-3f798b15e5d4",
   },
+  [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES]: {
+    default: "d9290539-0b0c-468f-8f87-22d0400b6431",
+  },
+  [PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL]: {
+    default: "d1b7cd24-f508-49ce-bf0d-ac1fe980c09c",
+  },
 };
 
 export const HREF_BACK = {

--- a/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
+++ b/src/components/ipv-callback/index-cannot-change-how-get-security-codes.njk
@@ -56,4 +56,7 @@
   }) }}
   </form>
 
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
+{%- include "ga4-opl/template.njk" -%}
+
 {% endblock %}

--- a/src/utils/taxonomy.test.ts
+++ b/src/utils/taxonomy.test.ts
@@ -78,6 +78,10 @@ const accountInterventionRequests: Request[] = [
   { path: PATH_NAMES.UNAVAILABLE_PERMANENT },
   { path: PATH_NAMES.UNAVAILABLE_TEMPORARY },
 ] as Request[];
+const mfaResetRequests: Request[] = [
+  { path: PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES },
+  { path: PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL },
+] as Request[];
 
 const expectations: RequestTaxonomyExpectation[] = [
   {
@@ -156,6 +160,16 @@ const expectations: RequestTaxonomyExpectation[] = [
       taxonomyLevel1: TaxonomyLevel1.ACCOUNTS,
       taxonomyLevel2: TaxonomyLevel2.ACCOUNT_INTERVENTION,
       taxonomyLevel3: TaxonomyLevel3.BLANK,
+      taxonomyLevel4: TaxonomyLevel4.BLANK,
+      taxonomyLevel5: TaxonomyLevel5.BLANK,
+    },
+  })),
+  ...mfaResetRequests.map((request) => ({
+    request,
+    taxonomy: {
+      taxonomyLevel1: TaxonomyLevel1.AUTHENTICATION,
+      taxonomyLevel2: TaxonomyLevel2.ACCOUNT_RECOVERY,
+      taxonomyLevel3: TaxonomyLevel3.MFA_RESET,
       taxonomyLevel4: TaxonomyLevel4.BLANK,
       taxonomyLevel5: TaxonomyLevel5.BLANK,
     },

--- a/src/utils/taxonomy.ts
+++ b/src/utils/taxonomy.ts
@@ -21,6 +21,7 @@ export enum TaxonomyLevel2 {
 
 export enum TaxonomyLevel3 {
   BLANK = "",
+  MFA_RESET = "mfa reset",
 }
 
 export enum TaxonomyLevel4 {
@@ -41,6 +42,7 @@ export type Taxonomy = {
 
 export function getRequestTaxonomy(req: Request): Taxonomy {
   const taxonomyLevel2 = getTaxonomyLevel2(req);
+  const taxonomyLevel3 = getTaxonomyLevel3(req);
 
   let taxonomyLevel1 = TaxonomyLevel1.BLANK;
   if (isAuthenticationTaxonomy(taxonomyLevel2))
@@ -51,7 +53,7 @@ export function getRequestTaxonomy(req: Request): Taxonomy {
   return {
     taxonomyLevel1,
     taxonomyLevel2,
-    taxonomyLevel3: TaxonomyLevel3.BLANK,
+    taxonomyLevel3,
     taxonomyLevel4: TaxonomyLevel4.BLANK,
     taxonomyLevel5: TaxonomyLevel5.BLANK,
   };
@@ -77,6 +79,22 @@ function getTaxonomyLevel2(req: Request) {
 
   return taxonomyLevel2;
 }
+
+function getTaxonomyLevel3(req: Request) {
+  let taxonomyLevel3 = TaxonomyLevel3.BLANK;
+
+  if (isMfaResetTaxonomy(req)) {
+    taxonomyLevel3 = TaxonomyLevel3.MFA_RESET;
+  }
+
+  return taxonomyLevel3;
+}
+
+const isMfaResetTaxonomy = (req: Request): boolean =>
+  [
+    PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL,
+    PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES,
+  ].includes(req.path);
 
 const isSignInTaxonomy = (req: Request): boolean =>
   req?.session?.user?.isSignInJourney ||
@@ -119,6 +137,8 @@ const isAccountRecoveryTaxonomy = (req: Request): boolean => {
       PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL,
       PATH_NAMES.RESET_PASSWORD_REQUIRED,
       PATH_NAMES.RESET_PASSWORD_RESEND_CODE,
+      PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES,
+      PATH_NAMES.CANNOT_CHANGE_SECURITY_CODES_IDENTITY_FAIL,
     ].includes(req.path)
   );
 };


### PR DESCRIPTION
## What

Add ga4 data for new cannot change security code pages (applicable to the new mfa reset journey).

## How to review

1. Code review
1. Turn on ga4 for an environment where the ipv stub is working - either dev, or non strategic pipelines authdev1 or authdev2 (e.g. if in a tf environment `ga4_enabled = "true"`
1. Deploy this branch to that environment
1. Run through an mfa reset journey, and select one of the failure cases. Ensure you have accepted cookies
1. Verify the taxonomy data and content ids for that pages matches what is expected here, either via google tag assistant or the network tab