### PR TITLE
AUT-3941 - authdevs disable ECS canary and use shared vpc

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -281,7 +281,6 @@ Mappings:
       basicAuthSidecarURI: "975050272416.dkr.ecr.eu-west-2.amazonaws.com/authdev2-basic-auth-sidecar-image-repository-containerrepository-zvcjtkip2sye"
       UseNginxSidecar: "No"
       cloudfrontDistributionStackName: "authdev2-cloudfront"
-      ECSServiceCanaryPhasedDeploy: "Yes"
       orchToAuthSigningPublicKey: |
         -----BEGIN PUBLIC KEY-----
         MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/Yz722IDLN1mPqkPTihkwAkp/rUm

--- a/scripts/dev_deploy_samconfig.toml
+++ b/scripts/dev_deploy_samconfig.toml
@@ -6,7 +6,7 @@ s3_bucket = "authdev1-frontend-pipeline-pipelinebucket-kit9bfu7ko2m"
 region = "eu-west-2"
 confirm_changeset = true
 capabilities = "CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND"
-parameter_overrides = "Environment=\"dev\" SubEnvironment=\"authdev1\" VpcStackName=\"authdev1-vpc\" CodeSigningConfigArn=\"arn:aws:lambda:eu-west-2:975050272416:code-signing-config:csc-08363373ee41af407\" DeploymentStrategy=\"CodeDeployDefault.ECSAllAtOnce\" PermissionsBoundary=\"arn:aws:iam::975050272416:policy/authdev1-frontend-pipeline-AppProgrammaticPermissionsBoundary-0208ecb7797f\""
+parameter_overrides = "Environment=\"dev\" SubEnvironment=\"authdev1\" VpcStackName=\"vpc\" CodeSigningConfigArn=\"arn:aws:lambda:eu-west-2:975050272416:code-signing-config:csc-08363373ee41af407\" DeploymentStrategy=\"None\" PermissionsBoundary=\"arn:aws:iam::975050272416:policy/authdev1-frontend-pipeline-AppProgrammaticPermissionsBoundary-0208ecb7797f\""
 image_repositories = []
 
 [authdev2.deploy.parameters]


### PR DESCRIPTION
## What

Applied to authdev(s)-sp only
- disable ECS canary
- use shared vpc

## How to review

Successfully deploy to authdev1-sp or authdev2-sp with `./deploy-authdevs.sh`