### PR TITLE
AUT-4007: Release international address support

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -14,7 +14,6 @@ import { logger } from "../../utils/logger";
 import {
   getServiceDomain,
   getSupportLinkUrl,
-  supportContactFormProblemWithAddress,
   supportNoPhotoIdContactForms,
 } from "../../config";
 import { contactUsServiceSmartAgent } from "./contact-us-service-smart-agent";
@@ -383,8 +382,6 @@ export function furtherInformationGet(req: Request, res: Response): void {
       validateReferer(req.query.referer as string, serviceDomain)
     ),
     supportNoPhotoIdContactForms: supportNoPhotoIdContactForms(),
-    supportContactFormProblemWithAddress:
-      supportContactFormProblemWithAddress(),
   });
 }
 
@@ -450,9 +447,6 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
       req.query.subtheme === CONTACT_US_THEMES.SUGGESTIONS_FEEDBACK
         ? "94ff0276-9791-4a74-95c4-8210ec4028f7"
         : "",
-    supportContactFormProblemWithAddress:
-      supportContactFormProblemWithAddress() ||
-      req.query.supportContactFormProblemWithAddress === "true",
   });
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -208,7 +208,6 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       if (
         req.body.subtheme ===
           CONTACT_US_THEMES.PROVING_IDENTITY_SOMETHING_ELSE &&
-        req.body.supportContactFormProblemWithAddress === "true" &&
         value === undefined
       ) {
         throw new Error(
@@ -299,10 +298,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
     body("name").customSanitizer(sanitizeFreeTextValue),
     body("country").customSanitizer(sanitizeFreeTextValue),
     body("countryPhoneNumberFrom").customSanitizer(sanitizeFreeTextValue),
-    validateBodyMiddleware("contact-us/questions/index.njk", (req) => ({
-      supportContactFormProblemWithAddress:
-        req.body.supportContactFormProblemWithAddress === "true",
-    })),
+    validateBodyMiddleware("contact-us/questions/index.njk"),
   ];
 }
 

--- a/src/components/contact-us/further-information/_proving-identity-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-further-information.njk
@@ -25,6 +25,10 @@
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemUpdatingPersonalInformation' | translate
             },
             {
+                value: "proving_identity_problem_with_address",
+                text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemEnteringAddress' | translate
+            },
+            {
                 value: "proving_identity_technical_problem",
                 text: 'pages.contactUsFurtherInformation.provingIdentity.section1.technicalProblem' | translate
             },
@@ -34,17 +38,6 @@
             }
         ]
     %}
-
-
-    {% if supportContactFormProblemWithAddress %}
-    {% set problem_with_address_item = {
-            value: "proving_identity_problem_with_address",
-            text: 'pages.contactUsFurtherInformation.provingIdentity.section1.problemEnteringAddress' | translate
-        }
-    %}
-
-    {% set items = (items.splice(3, 0, problem_with_address_item), items) %}
-    {% endif %}
 
     {% if supportNoPhotoIdContactForms %}
     {% set no_photo_id_bank_item = {

--- a/src/components/contact-us/questions/_proving-identity-something-else.njk
+++ b/src/components/contact-us/questions/_proving-identity-something-else.njk
@@ -68,10 +68,7 @@
 
     {% set show_location_hint = true %}
 
-    {% if supportContactFormProblemWithAddress %}
     {% include 'contact-us/questions/_user-location-question.njk' %}
-    <input type="hidden" name="supportContactFormProblemWithAddress" value="true"/>
-    {% endif %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -363,7 +363,6 @@ describe("Integration:: contact us - public user", () => {
         theme: "proving_identity",
         subtheme: "proving_identity_something_else",
         contact: "false",
-        supportContactFormProblemWithAddress: true,
       };
       await expectValidationErrorOnPost(
         "/contact-us-questions",
@@ -379,7 +378,6 @@ describe("Integration:: contact us - public user", () => {
         theme: "proving_identity",
         subtheme: "proving_identity_problem_with_address",
         contact: "false",
-        supportContactFormProblemWithAddress: true,
       };
       await expectValidationErrorOnPost(
         "/contact-us-questions",

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -10,10 +10,7 @@ import {
 import { PATH_NAMES, CONTACT_US_THEMES } from "../../../app.constants";
 import { RequestGet, ResponseRedirect } from "../../../types";
 
-import {
-  supportContactFormProblemWithAddress,
-  supportNoPhotoIdContactForms,
-} from "../../../config";
+import { supportNoPhotoIdContactForms } from "../../../config";
 
 describe("contact us further information controller", () => {
   let sandbox: sinon.SinonSandbox;
@@ -50,8 +47,6 @@ describe("contact us further information controller", () => {
           referer: encodeURIComponent(REFERER),
           hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${CONTACT_US_THEMES.SIGNING_IN}`,
           supportNoPhotoIdContactForms: false,
-          supportContactFormProblemWithAddress:
-            supportContactFormProblemWithAddress(),
         }
       );
     });
@@ -69,8 +64,6 @@ describe("contact us further information controller", () => {
           referer: encodeURIComponent(REFERER),
           hrefBack: `${PATH_NAMES.CONTACT_US}?theme=${CONTACT_US_THEMES.ACCOUNT_CREATION}`,
           supportNoPhotoIdContactForms: false,
-          supportContactFormProblemWithAddress:
-            supportContactFormProblemWithAddress(),
         }
       );
     });

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -63,7 +63,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -85,7 +84,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -107,7 +105,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
 
@@ -130,7 +127,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
 
@@ -163,7 +159,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -186,7 +181,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -209,7 +203,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -232,7 +225,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -255,7 +247,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -278,7 +269,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -301,7 +291,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
   });
@@ -327,7 +316,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -350,7 +338,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'You have another problem with a phone number' radio option was chosen", () => {
@@ -374,7 +361,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -397,7 +383,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -420,7 +405,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -443,7 +427,6 @@ describe("contact us questions controller", () => {
         appErrorCode: "",
         appSessionId: "",
         contentId: "",
-        supportContactFormProblemWithAddress: false,
       });
     });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -198,9 +198,3 @@ export function isValidChannel(channel: string): boolean {
 export function supportMfaResetWithIpv(): boolean {
   return process.env.SUPPORT_MFA_RESET_WITH_IPV === "1";
 }
-
-export function supportContactFormProblemWithAddress(): boolean {
-  return ["local", "dev", "sandpit", "authdev1", "authdev2", "build"].includes(
-    getAppEnv()
-  );
-}


### PR DESCRIPTION
## What

Enable contact form changes to support international address questions.

## How to review

1. Code Review
1. Run locally
1. See "You had a problem entering your address" option at http://localhost:3000/contact-us-further-information?theme=proving_identity&referer=
1. Select it and continue
1. Submit the form, see validation errors
1. Fill in form, submit and see expected error (SmartAgent won't be set up locally, but this is a success for release)
1. Go back to http://localhost:3000/contact-us-further-information?theme=proving_identity&referer=
1. Select option "Something else" and continue
1. See the "Do you live in the UK, Channel Islands or the Isle of Man?" question.
1. Submit the form, see validation errors
1. Fill in form, submit and see expected error (SmartAgent won't be set up locally, but this is a success for release)


## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.

## Related PRs

- https://github.com/govuk-one-login/authentication-frontend/pull/2425