### PR TITLE
AUT-4052: Remove old allowlist variable

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -180,12 +180,6 @@ variable "incoming_traffic_cidr_blocks" {
   description = "The list of CIDR blocks allowed to send requests to the ALB"
 }
 
-variable "basic_auth_bypass_cidr_blocks" {
-  default     = []
-  type        = list(string)
-  description = "The list of CIDR blocks allowed to bypass basic auth (if enabled)"
-}
-
 variable "basic_auth_bypass_cidr_blocks_with_description" {
   default = []
   type = list(object({
@@ -196,7 +190,7 @@ variable "basic_auth_bypass_cidr_blocks_with_description" {
 }
 
 locals {
-  basic_auth_bypass_cidr_blocks = distinct(concat(var.basic_auth_bypass_cidr_blocks, [for item in var.basic_auth_bypass_cidr_blocks_with_description : item.cidr_block]))
+  basic_auth_bypass_cidr_blocks = distinct([for item in var.basic_auth_bypass_cidr_blocks_with_description : item.cidr_block])
 }
 
 variable "new_auth_account_id" {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -17,10 +17,6 @@ variable "redis_node_size" {
   default = "cache.t2.small"
 }
 
-variable "service_domain" {
-  default = null
-}
-
 variable "support_account_recovery" {
   type = string
 }


### PR DESCRIPTION
## What

Remove the old allowlist variable - this is no longer required since #2548.

I've kept the `distinct` call in, just in case a CIDR gets added twice. It won't hurt to have it twice, but why not clean it up.

## How to review

Code review
