### PR TITLE
Aut 4051/prevent mfa reset for app journeys

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -78,6 +78,7 @@ export const PATH_NAMES = {
   RESET_PASSWORD_2FA_AUTH_APP: "/reset-password-2fa-auth-app",
   MFA_RESET_WITH_IPV: "/mfa-reset-with-ipv",
   IPV_CALLBACK: "/ipv/callback/authorize",
+  OPEN_IN_WEB_BROWSER: "/open-one-login-in-web-browser",
 };
 
 export const CONTENT_IDS: {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -63,6 +63,7 @@ const USER_JOURNEY_EVENTS = {
     "IPV_REVERIFICATION_INCOMPLETE_OR_UNAVAILABLE",
   IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH:
     "IPV_REVERIFICATION_FAILED_OR_DID_NOT_MATCH",
+  MFA_RESET_ATTEMPTED_VIA_AUTH_APP: "MFA_RESET_ATTEMPTED_VIA_AUTH_APP",
 };
 
 const authStateMachine = createMachine(
@@ -743,7 +744,13 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT]: [
             { target: [PATH_NAMES.IPV_CALLBACK] },
           ],
+          [USER_JOURNEY_EVENTS.MFA_RESET_ATTEMPTED_VIA_AUTH_APP]: [
+            { target: [PATH_NAMES.OPEN_IN_WEB_BROWSER] },
+          ],
         },
+      },
+      [PATH_NAMES.OPEN_IN_WEB_BROWSER]: {
+        type: "final",
       },
       [PATH_NAMES.IPV_CALLBACK]: {
         on: {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -751,6 +751,12 @@ const authStateMachine = createMachine(
       },
       [PATH_NAMES.OPEN_IN_WEB_BROWSER]: {
         type: "final",
+        meta: {
+          optionalPaths: [
+            PATH_NAMES.ENTER_MFA,
+            PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+          ],
+        },
       },
       [PATH_NAMES.IPV_CALLBACK]: {
         on: {

--- a/src/components/mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk
+++ b/src/components/mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk
@@ -1,5 +1,7 @@
 {% extends "common/layout/base.njk" %}
 {% set pageTitleName = 'pages.openOneLoginInWebBrowser.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = backLink %}
 
 {% block content %}
 

--- a/src/components/mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk
+++ b/src/components/mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk
@@ -1,8 +1,24 @@
 {% extends "common/layout/base.njk" %}
-{% set pageTitleName = "Hello world" %}
+{% set pageTitleName = 'pages.openOneLoginInWebBrowser.title' | translate %}
 
 {% block content %}
 
-    <p>Hello world</p>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+        {{ 'pages.openOneLoginInWebBrowser.heading' | translate }}
+    </h1>
+
+    <p class="govuk-body">{{ 'pages.openOneLoginInWebBrowser.section1.paragraph1' | translate }}</p>
+
+    <h2 class="govuk-heading-m">
+        {{ 'pages.openOneLoginInWebBrowser.section2.heading' | translate }}
+    </h2>
+
+    <ol class="govuk-list govuk-list--number">
+        <li>{{ 'pages.openOneLoginInWebBrowser.section2.bulletPointSection.bullet1' | translate }}</li>
+        <li>{{ 'pages.openOneLoginInWebBrowser.section2.bulletPointSection.bullet2' | translate }}</li>
+        <li>{{ 'pages.openOneLoginInWebBrowser.section2.bulletPointSection.bullet3' | translate }}</li>
+    </ol>
+
+    <p class="govuk-body">{{ 'pages.openOneLoginInWebBrowser.section2.paragraph1' | translate }}</p>
 
 {% endblock %}

--- a/src/components/mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk
+++ b/src/components/mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk
@@ -1,0 +1,8 @@
+{% extends "common/layout/base.njk" %}
+{% set pageTitleName = "Hello world" %}
+
+{% block content %}
+
+    <p>Hello world</p>
+
+{% endblock %}

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -19,6 +19,17 @@ export function mfaResetWithIpvGet(
       );
     }
 
+    if (res.locals.strategicAppChannel === true) {
+      const redirectPath = await getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.MFA_RESET_ATTEMPTED_VIA_AUTH_APP,
+        {},
+        res.locals.sessionId
+      );
+      return res.redirect(redirectPath);
+    }
+
     req.session.user.isAccountRecoveryJourney = true;
 
     const orchestrationRedirectUrl = req.session.client.redirectUri.concat(

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -51,3 +51,10 @@ export function mfaResetWithIpvGet(
     res.redirect(ipvCoreURL);
   };
 }
+
+export function mfaResetOpenInBrowserGet(): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const template = "mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk";
+    return res.render(template);
+  };
+}

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -5,6 +5,7 @@ import { Request, Response } from "express";
 import { BadRequestError } from "../../utils/error";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
 
 export function mfaResetWithIpvGet(
   service: MfaResetAuthorizeInterface = mfaResetAuthorizeService()
@@ -65,7 +66,11 @@ export function mfaResetWithIpvGet(
 
 export function mfaResetOpenInBrowserGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
+    const backLink =
+      req.session.user.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP
+        ? PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
+        : PATH_NAMES.ENTER_MFA;
     const template = "mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk";
-    return res.render(template);
+    return res.render(template, { backLink });
   };
 }

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes.ts
@@ -3,7 +3,10 @@ import { PATH_NAMES } from "../../app.constants";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { asyncHandler } from "../../utils/async";
-import { mfaResetWithIpvGet } from "./mfa-reset-with-ipv-controller";
+import {
+  mfaResetOpenInBrowserGet,
+  mfaResetWithIpvGet,
+} from "./mfa-reset-with-ipv-controller";
 
 const router = express.Router();
 
@@ -12,6 +15,13 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   asyncHandler(mfaResetWithIpvGet())
+);
+
+router.get(
+  PATH_NAMES.OPEN_IN_WEB_BROWSER,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(mfaResetOpenInBrowserGet())
 );
 
 export { router as mfaResetWithIpvRouter };

--- a/src/components/mfa-reset-with-ipv/tests/__snapshots__/mfa-reset-with-ipv-integration.test.ts.snap
+++ b/src/components/mfa-reset-with-ipv/tests/__snapshots__/mfa-reset-with-ipv-integration.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Mfa reset with ipv should render the guidance page for when someone is trying to access via an app journey 1`] = `
+Object {
+  "contentId": undefined,
+  "taxonomyLevel1": undefined,
+  "taxonomyLevel2": undefined,
+  "taxonomyLevel3": undefined,
+  "taxonomyLevel4": undefined,
+  "taxonomyLevel5": undefined,
+}
+`;

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
@@ -1,7 +1,11 @@
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import sinon from "sinon";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
-import { HTTP_STATUS_CODES, PATH_NAMES } from "../../../app.constants";
+import {
+  HTTP_STATUS_CODES,
+  MFA_METHOD_TYPE,
+  PATH_NAMES,
+} from "../../../app.constants";
 import {
   mfaResetOpenInBrowserGet,
   mfaResetWithIpvGet,
@@ -94,8 +98,10 @@ describe("mfa reset with ipv controller", () => {
   describe("mfaResetOpenInBrowserGet", async () => {
     it("should render the correct template", async () => {
       await mfaResetOpenInBrowserGet()(req as Request, res as Response);
+      req.session.user.mfaMethodType = MFA_METHOD_TYPE.SMS;
       expect(res.render).to.have.been.calledWith(
-        "mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk"
+        "mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk",
+        { backLink: PATH_NAMES.ENTER_MFA }
       );
     });
   });

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
@@ -2,7 +2,10 @@ import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import sinon from "sinon";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
 import { HTTP_STATUS_CODES, PATH_NAMES } from "../../../app.constants";
-import { mfaResetWithIpvGet } from "../mfa-reset-with-ipv-controller";
+import {
+  mfaResetOpenInBrowserGet,
+  mfaResetWithIpvGet,
+} from "../mfa-reset-with-ipv-controller";
 import { expect } from "chai";
 import { MfaResetAuthorizeInterface } from "../types";
 import { Request, Response } from "express";
@@ -70,6 +73,15 @@ describe("mfa reset with ipv controller", () => {
           ),
         BadRequestError,
         "500:Test error message"
+      );
+    });
+  });
+
+  describe("mfaResetOpenInBrowserGet", async () => {
+    it("should render the correct template", async () => {
+      await mfaResetOpenInBrowserGet()(req as Request, res as Response);
+      expect(res.render).to.have.been.calledWith(
+        "mfa-reset-with-ipv/index-open-in-browser-mfa-reset.njk"
       );
     });
   });

--- a/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
+++ b/src/components/mfa-reset-with-ipv/tests/mfa-reset-with-ipv-controller.test.ts
@@ -64,6 +64,20 @@ describe("mfa reset with ipv controller", () => {
       expect(req.session.user.journey.nextPath).to.eq(PATH_NAMES.IPV_CALLBACK);
     });
 
+    it("should allow redirect to new guidance page when user has come from a strategic app journey", async () => {
+      res.locals.strategicAppChannel = true;
+      await mfaResetWithIpvGet(fakeMfaResetAuthorizeService(true))(
+        req as Request,
+        res as Response
+      );
+      expect(res.redirect).to.have.been.calledWith(
+        PATH_NAMES.OPEN_IN_WEB_BROWSER
+      );
+      expect(req.session.user.journey.nextPath).to.eq(
+        PATH_NAMES.OPEN_IN_WEB_BROWSER
+      );
+    });
+
     it("should throw a BadRequestError when the request made to the MFA Reset Authorize endpoint is not successful", async () => {
       await assert.rejects(
         async () =>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2632,6 +2632,22 @@
         "paragraph1": "Dewch yn ôl yn nes ymlaen. Dylai eich GOV.UK One Login fod ar gael eto mewn 3 diwrnod gwaith.",
         "paragraph2": "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o’r hafan GOV.UK."
       }
+    },
+    "openOneLoginInWebBrowser": {
+      "title": "Agorwch GOV.UK One Login mewn porwr gwe i barhau",
+      "heading": "Agorwch GOV.UK One Login mewn porwr gwe i barhau",
+      "section1": {
+        "paragraph1": "Bydd angen i chi ddefnyddio porwr gwe i fewngofnodi i GOV.UK One Login. Yna gallwch wirio a allwch chi newid sut rydych chi’n cael codau diogelwch."
+      },
+      "section2": {
+        "heading": "Mewngofnodwch gan ddefnyddio porwr gwe",
+        "bulletPointSection": {
+          "bullet1": "Agor porwr gwe fel Chrome neu Safari.",
+          "bullet2": "Copiwch y cyfeiriad gwe hwn i’r porwr: gov.uk/account",
+          "bullet3": "Rhowch eich cyfeiriad e-bost a’ch cyfrinair, yna dewiswch ’Gwiriwch a allwch newid sut rydych yn cael codau diogelwch’."
+        },
+        "paragraph1": "I barhau ar ôl i chi newid sut rydych chi’n cael codau diogelwch, bydd angen i chi fewngofnodi yn ôl i’r ap rydych chi’n ei ddefnyddio nawr."
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2632,6 +2632,22 @@
         "paragraph1": "Come back later. Your GOV.UK  One Login should be available again in 3 working days.",
         "paragraph2": "You can also go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage."
       }
+    },
+    "openOneLoginInWebBrowser": {
+      "title": "Open GOV.UK One Login in a web browser to continue",
+      "heading": "Open GOV.UK One Login in a web browser to continue",
+      "section1": {
+        "paragraph1": "You’ll need to use a web browser to sign in to GOV.UK One Login. Then you can check if you can change how you get security codes."
+      },
+      "section2": {
+        "heading": "Sign in using a web browser",
+        "bulletPointSection": {
+          "bullet1": "Open a web browser like Chrome or Safari.",
+          "bullet2": "Copy this web address into the browser: gov.uk/account",
+          "bullet3": "Enter your email address and password, then select ‘Check if you can change how you get security codes’."
+        },
+        "paragraph1": "To continue after you’ve changed how you get security codes, you’ll need to sign back in to the app you’re using now."
+      }
     }
   }
 }


### PR DESCRIPTION
Introduces a new guidance page to be shown to app users who attempt to reset their mfa via the new journey.

There is an issue whereby if the user starts their journey in an app (for example the v2 one login app or the HMRC app), the user will not be able to complete an MFA reset journey in app. This is due to linking issues in the app portions of the journey. 

We therefore need to detect if a user is signing in via an app and, if so, show them a guidance page that instructs them to sign in via a web browser to complete an MFA reset.

## Not in this PR

Adding analytics data for the new page (awaiting from data analytics)

## Screenshots

New guidance page:

| English | Welsh |
|----|----|
|<img width="1004" alt="Screenshot 2025-02-10 at 15 29 38" src="https://github.com/user-attachments/assets/465e399e-8f43-470e-ba54-6a1437c7d2e9" />|<img width="994" alt="Screenshot 2025-02-10 at 15 29 45" src="https://github.com/user-attachments/assets/36d9de93-4bd4-4bde-9432-e4a0178ebe80" />|

UCD review done
