### PR TITLE
AUT-4050: Set analytics cookie preferences to off for strategic app journeys

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -5,6 +5,7 @@ import {
   PATH_NAMES,
   ERROR_LOG_LEVEL,
   COOKIES_CHANNEL,
+  CHANNEL,
 } from "../../app.constants";
 import { getNextPathAndUpdateJourney, ERROR_CODES } from "../common/constants";
 import { BadRequestError, QueryParamsError } from "../../utils/error";
@@ -138,7 +139,17 @@ export function authorizeGet(
 
     const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);
 
-    if (req.session.client.cookieConsentEnabled && cookieConsent) {
+    if (req.session.user.channel === CHANNEL.STRATEGIC_APP) {
+      const consentCookieValue = cookiesConsentService.createConsentCookieValue(
+        COOKIE_CONSENT.REJECT
+      );
+
+      res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
+        secure: true,
+        httpOnly: false,
+        domain: res.locals.analyticsCookieDomain,
+      });
+    } else if (req.session.client.cookieConsentEnabled && cookieConsent) {
       const consentCookieValue =
         cookiesConsentService.createConsentCookieValue(cookieConsent);
 


### PR DESCRIPTION
For strategic app journeys:
* We don't want to display the cookie banner
* We want to disable analytics cookies, regardless of the user's preferences (without affecting what happens if they go through a web journey)

This achieves this by setting analytics cookie preferences to false in the authorize controller (which is the start of a user's journey). This will mean that the banner will not appear for a user within this journey (as we only display when this cookie is not set) and also that no analytics data will be sent during this journey.

## How to review

1. Code Review
1. Run locally
1. Clear cookies and go through a normal journey and make sure you can see the banner
1. Start a strategic app journey locally (I hack this by setting the res.locals.strategicAppChannel to true in channel middleware) and clear cookies
1. See that you don't get a banner
