### PR TITLE
AUT-4081: Check & persist allowed optional paths state for /enter-code

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -163,6 +163,24 @@ export function pathWithQueryParam(
   return path;
 }
 
+export async function saveSessionState(req: Request): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    req.session.save((error) => {
+      if (error) {
+        reject(new Error(error));
+        req.log.error(
+          "Session could not be saved after setting the user journey."
+        );
+      } else {
+        req.log.debug(
+          "Session was successfully saved after setting the user journey."
+        );
+        resolve();
+      }
+    });
+  });
+}
+
 export async function getNextPathAndUpdateJourney(
   req: Request,
   path: string,
@@ -180,21 +198,7 @@ export async function getNextPathAndUpdateJourney(
         : [],
   };
 
-  await new Promise<void>((resolve, reject) => {
-    req.session.save((error) => {
-      if (error) {
-        reject(new Error(error));
-        req.log.error(
-          "Session could not be saved after setting the user journey."
-        );
-      } else {
-        req.log.debug(
-          "Session was successfully saved after setting the user journey."
-        );
-        resolve();
-      }
-    });
-  });
+  await saveSessionState(req);
 
   req.log.info(
     `User journey transitioned from ${req.path} to ${nextState.value} with session id ${sessionId}`

--- a/src/components/enter-mfa/enter-mfa-routes.ts
+++ b/src/components/enter-mfa/enter-mfa-routes.ts
@@ -4,14 +4,17 @@ import express from "express";
 import { enterMfaGet, enterMfaPost } from "./enter-mfa-controller";
 import { asyncHandler } from "../../utils/async";
 import { validateEnterMfaRequest } from "./enter-mfa-validation";
-import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import {
+  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
+} from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
 
 router.get(
   PATH_NAMES.ENTER_MFA,
   validateSessionMiddleware,
-  allowUserJourneyMiddleware,
+  asyncHandler(allowAndPersistUserJourneyMiddleware),
   asyncHandler(enterMfaGet())
 );
 

--- a/src/middleware/allow-user-journey-middleware.ts
+++ b/src/middleware/allow-user-journey-middleware.ts
@@ -1,4 +1,6 @@
 import { NextFunction, Request, Response } from "express";
+import { authStateMachine } from "../components/common/state-machine/state-machine";
+import { saveSessionState } from "../components/common/constants";
 
 export function transitionForbidden(req: Request): boolean {
   const nextPath = req.session.user.journey.nextPath;
@@ -23,6 +25,33 @@ export function allowUserJourneyMiddleware(
       } and optionalPaths ${req.session.user.journey.optionalPaths.join()}`
     );
     return res.redirect(nextPath);
+  }
+
+  next();
+}
+
+export async function allowAndPersistUserJourneyMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  if (transitionForbidden(req)) {
+    const nextPath = req.session.user.journey.nextPath;
+    req.log.warn(
+      `User tried invalid journey to ${
+        req.path
+      }, but session indicates they should be on ${nextPath} for session ${
+        res.locals.sessionId
+      } and optionalPaths ${req.session.user.journey.optionalPaths.join()}`
+    );
+    return res.redirect(nextPath);
+  }
+
+  if (req.session.user.journey.optionalPaths.includes(req.path)) {
+    req.session.user.journey.nextPath = req.path;
+    req.session.user.journey.optionalPaths =
+      authStateMachine.states[req.path]?.meta?.optionalPaths || [];
+    await saveSessionState(req);
   }
 
   next();

--- a/test/unit/middleware/allow-user-journey-middleware.test.ts
+++ b/test/unit/middleware/allow-user-journey-middleware.test.ts
@@ -2,10 +2,14 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { NextFunction } from "express";
 import { sinon } from "../../utils/test-utils";
-import { allowUserJourneyMiddleware } from "../../../src/middleware/allow-user-journey-middleware";
+import {
+  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
+} from "../../../src/middleware/allow-user-journey-middleware";
 import { PATH_NAMES } from "../../../src/app.constants";
 import { createMockRequest } from "../../helpers/mock-request-helper";
 import { mockResponse } from "mock-req-res";
+import { authStateMachine } from "../../../src/components/common/state-machine/state-machine";
 
 describe("Allow user journey middleware", () => {
   it("Should call next when use journey is valid", () => {
@@ -52,5 +56,63 @@ describe("Allow user journey middleware", () => {
     expect(res.redirect).to.have.been.calledWith(PATH_NAMES.ENTER_MFA);
     expect(req.log.warn).to.have.been.called;
     expect(nextFunction).to.not.have.been.called;
+  });
+});
+
+describe("Allow and persist user journey middleware", () => {
+  it("Should call next when use journey is valid", async () => {
+    const req = createMockRequest(PATH_NAMES.ENTER_MFA);
+    req.session.user.journey = {
+      nextPath: PATH_NAMES.ENTER_MFA,
+      optionalPaths: [],
+    };
+    const res = mockResponse();
+    const nextFunction: NextFunction = sinon.fake() as unknown as NextFunction;
+
+    await allowAndPersistUserJourneyMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.not.have.been.called;
+    expect(nextFunction).to.have.been.called;
+  });
+
+  it("Should call next and update journey when allowed optional path", async () => {
+    const pathUserIsOn = PATH_NAMES.ENTER_MFA;
+    const nextPath = PATH_NAMES.ENTER_PASSWORD;
+    const req = createMockRequest(pathUserIsOn);
+    req.session.user = {
+      journey: { nextPath: nextPath, optionalPaths: [pathUserIsOn] },
+    };
+    req.session.save = sinon.spy((callback) => callback(null));
+    const res = mockResponse();
+    const nextFunction: NextFunction = sinon.fake() as unknown as NextFunction;
+
+    await allowAndPersistUserJourneyMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.not.have.been.called;
+    expect(nextFunction).to.have.been.called;
+    expect(req.session.user.journey.nextPath).to.eq(PATH_NAMES.ENTER_MFA);
+    expect(req.session.user.journey.optionalPaths).to.eq(
+      authStateMachine.states[PATH_NAMES.ENTER_MFA].meta.optionalPaths
+    );
+    expect(req.session.save).to.have.been.called;
+  });
+
+  it("Should redirect back to next path when invalid user journey without changing journey", async () => {
+    const req = createMockRequest(PATH_NAMES.ENTER_PASSWORD);
+    req.session.user = {
+      journey: { nextPath: PATH_NAMES.ENTER_MFA, optionalPaths: [] },
+    };
+    req.session.save = sinon.spy((callback) => callback(null));
+    const res = mockResponse();
+    const nextFunction: NextFunction = sinon.fake() as unknown as NextFunction;
+
+    await allowAndPersistUserJourneyMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.have.been.calledWith(PATH_NAMES.ENTER_MFA);
+    expect(req.log.warn).to.have.been.called;
+    expect(nextFunction).to.not.have.been.called;
+    expect(req.session.user.journey.nextPath).to.eq(PATH_NAMES.ENTER_MFA);
+    expect(req.session.user.journey.optionalPaths).to.deep.eq([]);
+    expect(req.session.save).to.have.not.been.called;
   });
 });


### PR DESCRIPTION
## What

When a user is on the `/enter-code` page, starts the MFA reset journey and hits back they go back to the `/enter-code` page. The user is then unable to resend the code as the state machine is not in the right state to do so.

`allowAndPersistUserJourneyMiddleware` is introduced to solve this problem. It asserts the user is allowed to be on the page. It also updates the user session `journey` to reflect the path they are on (if the path is an optionalPath from a previous page). This ensures that when the users loads the page they can do any of the intended actions of that page.

This new middleware is only applied to the `GET /enter-code` route and we can consider if we want to roll this out to more, or all, routes.

## How to review

1. Code Review
2. Deploy to an env
3. Start journey
4. On SMS MFA code entry, start reset journey
5. Back out to SMS MFA code entry page
6. See you can resend the code and continue your journey
