### PR TITLE
Aut 4088/update mfa feature switch for live testing

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -25,6 +25,7 @@ language_toggle_enabled                             = "1"
 no_photo_id_contact_forms                           = "1"
 support_new_ipv_spinner                             = "1"
 support_mfa_reset_with_ipv                          = "1"
+route_users_to_new_ipv_journey                      = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -24,6 +24,7 @@ language_toggle_enabled                             = "1"
 no_photo_id_contact_forms                           = "1"
 support_new_ipv_spinner                             = "1"
 support_mfa_reset_with_ipv                          = "1"
+route_users_to_new_ipv_journey                      = "1"
 
 frontend_task_definition_cpu     = 512
 frontend_task_definition_memory  = 1024

--- a/ci/terraform/dev.tfvars
+++ b/ci/terraform/dev.tfvars
@@ -29,6 +29,7 @@ url_for_support_links                               = "https://home.dev.account.
 language_toggle_enabled                             = "1"
 no_photo_id_contact_forms                           = "1"
 support_mfa_reset_with_ipv                          = "1"
+route_users_to_new_ipv_journey                      = "1"
 
 logging_endpoint_arns = []
 

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -194,6 +194,10 @@ locals {
       {
         name  = "SUPPORT_MFA_RESET_WITH_IPV"
         value = var.support_mfa_reset_with_ipv
+      },
+      {
+        name  = "ROUTE_USERS_TO_NEW_IPV_JOURNEY"
+        value = var.route_users_to_new_ipv_journey
       }
     ]
 

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -27,6 +27,7 @@ no_photo_id_contact_forms                           = "1"
 support_new_ipv_spinner                             = "1"
 support_http_keep_alive                             = "1"
 support_mfa_reset_with_ipv                          = "1"
+route_users_to_new_ipv_journey                      = "1"
 
 url_for_support_links = "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -416,6 +416,12 @@ variable "support_mfa_reset_with_ipv" {
   description = "Switch to support the IPV prove identity journey when resetting the mfa"
 }
 
+variable "route_users_to_new_ipv_journey" {
+  type        = string
+  default     = "0"
+  description = "Switch to enable testing of prod connectivity of new journey without affecting normal users"
+}
+
 variable "vpc_environment" {
   description = "The name of the environment this environment is sharing the VPC , this var is only for Authdevs env and must be overide using Authdevs.tfvars, default value should be null always."
   type        = string

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -140,6 +140,29 @@ Conditions:
                 ]
               - "Yes"
 
+  UseRouteUsersToNewIpvJourney:
+    Fn::Or:
+      - Fn::And:
+          - !Condition UseSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                EnvironmentConfiguration,
+                !Ref SubEnvironment,
+                UseRouteUsersToNewIpvJourney,
+                DefaultValue: "No",
+              ]
+              - "Yes"
+      - Fn::And:
+          - !Condition NotSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                UseRouteUsersToNewIpvJourney,
+                DefaultValue: "No",
+              ]
+              - "Yes"
+
   UseSubEnvironment:
     Fn::And:
       - Fn::Equals:
@@ -275,6 +298,7 @@ Mappings:
       transitionalDomain: signin.authdev1.dev.account.gov.uk
       migratedDomain: signin.authdev1.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
     authdev2:
       cloudfrontDistributionStackName: "authdev2-cloudfront"
@@ -291,6 +315,7 @@ Mappings:
       transitionalDomain: signin.authdev2.dev.account.gov.uk
       migratedDomain: signin.authdev2.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
     dev:
       DeployServiceDownPage: "No"
@@ -318,6 +343,7 @@ Mappings:
       transitionalDomain: signin-sp.dev.account.gov.uk
       migratedDomain: signin.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -345,6 +371,7 @@ Mappings:
       transitionalDomain: signin-sp.build.account.gov.uk
       migratedDomain: signin.build.account.gov.uk
       UseMfaResetWithIpv: "Yes"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -378,6 +405,7 @@ Mappings:
       transitionalDomain: signin-sp.staging.account.gov.uk
       migratedDomain: signin.staging.account.gov.uk
       UseMfaResetWithIpv: "Yes"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
     integration:
       DeployServiceDownPage: "Yes"
@@ -405,6 +433,7 @@ Mappings:
       transitionalDomain: signin-sp.integration.account.gov.uk
       migratedDomain: signin.integration.account.gov.uk
       UseMfaResetWithIpv: "No"
+      UseRouteUsersToNewIpvJourney: "No"
       Enableipvspinner: "No"
       orchStubToAuth: ""
     production:
@@ -435,6 +464,7 @@ Mappings:
       transitionalDomain: signin-sp.account.gov.uk
       migratedDomain: signin.account.gov.uk
       UseMfaResetWithIpv: "No"
+      UseRouteUsersToNewIpvJourney: "No"
       Enableipvspinner: "No"
       orchStubToAuth: ""
 
@@ -982,6 +1012,8 @@ Resources:
               Value: !If [SupportHTTPKeepAlive, "1", "0"]
             - Name: SUPPORT_MFA_RESET_WITH_IPV
               Value: !If [UseMfaResetWithIpv, "1", "0"]
+            - Name: ROUTE_USERS_TO_NEW_IPV_JOURNEY
+              Value: !If [UseRouteUsersToNewIpvJourney, "1", "0"]
           Secrets:
             - Name: API_KEY
               ValueFrom: !If

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -12,6 +12,7 @@ import {
 } from "../common/constants";
 import {
   getCodeEnteredWrongBlockDurationInMinutes,
+  routeUsersToNewIpvJourney,
   supportAccountRecovery,
   supportMfaResetWithIpv,
   supportReauthentication,
@@ -85,7 +86,10 @@ export function enterAuthenticatorAppCodeGet(
       (req.session.user.isAccountRecoveryPermitted =
         accountRecoveryResponse.data.accountRecoveryPermitted);
 
-    const mfaResetPath = supportMfaResetWithIpv()
+    const routeUserViaIpvReset =
+      supportMfaResetWithIpv() && routeUsersToNewIpvJourney();
+
+    const mfaResetPath = routeUserViaIpvReset
       ? PATH_NAMES.MFA_RESET_WITH_IPV
       : pathWithQueryParam(
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES,
@@ -95,7 +99,7 @@ export function enterAuthenticatorAppCodeGet(
 
     return res.render(templateName, {
       isAccountRecoveryPermitted: isAccountRecoveryPermittedForUser,
-      routeUserViaIpvReset: supportMfaResetWithIpv(),
+      routeUserViaIpvReset: routeUserViaIpvReset,
       mfaResetPath,
     });
   };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -95,7 +95,7 @@ export function enterAuthenticatorAppCodeGet(
 
     return res.render(templateName, {
       isAccountRecoveryPermitted: isAccountRecoveryPermittedForUser,
-      supportMfaResetWithIpv: supportMfaResetWithIpv(),
+      routeUserViaIpvReset: supportMfaResetWithIpv(),
       mfaResetPath,
     });
   };

--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -28,7 +28,7 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
         <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
         <input type="hidden" name="mfaResetPath" value="{{mfaResetPath}}"/>
-        <input type="hidden" name="supportMfaResetWithIpv" value="{{supportMfaResetWithIpv}}"/>
+        <input type="hidden" name="routeUserViaIpvReset" value="{{routeUserViaIpvReset}}"/>
 
         {{ govukInput({
             label: {
@@ -57,7 +57,7 @@
 
     {% if isAccountRecoveryPermitted === true or isAccountRecoveryPermitted === "true" %}
         {% set detailsHTML %}
-        {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+        {% if routeUserViaIpvReset === true or routeUserViaIpvReset === "true" %}
             <p class="govuk-body">
                 {{'pages.enterAuthenticatorAppCode.details.text1MfaResetWithIpv' | translate}}
                 <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2MfaResetWithIpv'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -14,7 +14,7 @@
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
     <input type="hidden" name="mfaResetPath" value="{{mfaResetPath}}"/>
-    <input type="hidden" name="supportMfaResetWithIpv" value="{{supportMfaResetWithIpv}}"/>
+    <input type="hidden" name="routeUserViaIpvReset" value="{{routeUserViaIpvReset}}"/>
 
     {{ govukInput({
       label: {
@@ -43,7 +43,7 @@
 
   {% if isAccountRecoveryPermitted === true or isAccountRecoveryPermitted === "true" %}
     {% set detailsHTML %}
-      {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+      {% if routeUserViaIpvReset === true or routeUserViaIpvReset === "true" %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1MfaResetWithIpv' | translate}}
         <a href="{{mfaResetPath}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2MfaResetWithIpv'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -22,7 +22,29 @@ Object {
 }
 `;
 
-exports[`Integration:: enter authenticator app code should display correct link to reset mfa when support mfa reset with ipv is on 1`] = `
+exports[`Integration:: enter authenticator app code should display correct link to reset mfa when support mfa reset with ipv is off regardless of route to new journey flag 1`] = `
+Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration:: enter authenticator app code should display correct link to reset mfa when support mfa reset with ipv is on and route users to new journey is on 1`] = `
+Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration:: enter authenticator app code should display correct link to reset mfa when support mfa reset with ipv is on but route to new journeys is off 1`] = `
 Object {
   "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
   "taxonomyLevel1": "authentication",

--- a/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
+++ b/src/components/enter-authenticator-app-code/tests/__snapshots__/enter-authenticator-app-code-integration.test.ts.snap
@@ -11,6 +11,28 @@ Object {
 }
 `;
 
+exports[`Integration:: enter authenticator app code should display correct link to reset mfa when support mfa reset with ipv is off 1`] = `
+Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration:: enter authenticator app code should display correct link to reset mfa when support mfa reset with ipv is on 1`] = `
+Object {
+  "contentId": "89461417-df3f-46a8-9c37-713b9dd78085",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
 exports[`Integration:: enter authenticator app code should return enter authenticator app security code with reauth analytics properties 1`] = `
 Object {
   "contentId": "6e5cc49f-4770-4089-8547-06149e0f59b1",

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -71,7 +71,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: true,
-          supportMfaResetWithIpv: false,
+          routeUserViaIpvReset: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -89,7 +89,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: false,
-          supportMfaResetWithIpv: false,
+          routeUserViaIpvReset: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -125,7 +125,7 @@ describe("enter authenticator app code controller", () => {
         UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME,
         {
           isAccountRecoveryPermitted: true,
-          supportMfaResetWithIpv: false,
+          routeUserViaIpvReset: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -145,7 +145,7 @@ describe("enter authenticator app code controller", () => {
         ENTER_AUTH_APP_CODE_DEFAULT_TEMPLATE_NAME,
         {
           isAccountRecoveryPermitted: true,
-          supportMfaResetWithIpv: false,
+          routeUserViaIpvReset: false,
           mfaResetPath:
             PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
             "?type=AUTH_APP",
@@ -165,7 +165,7 @@ describe("enter authenticator app code controller", () => {
         "enter-authenticator-app-code/index.njk",
         {
           isAccountRecoveryPermitted: true,
-          supportMfaResetWithIpv: true,
+          routeUserViaIpvReset: true,
           mfaResetPath: PATH_NAMES.MFA_RESET_WITH_IPV,
         }
       );

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -56,6 +56,7 @@ describe("enter authenticator app code controller", () => {
   afterEach(() => {
     sinon.restore();
     delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
+    delete process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY;
   });
 
   describe("enterAuthenticatorAppCodeGet", () => {
@@ -155,6 +156,7 @@ describe("enter authenticator app code controller", () => {
 
     it("should render enter authenticator app code view with mfaResetPath being IPV_DUMMY_URL when mfa reset with ipv is supported", async () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+      process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY = "1";
 
       await enterAuthenticatorAppCodeGet(fakeAccountRecoveryService(true))(
         req as Request,

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -99,6 +99,7 @@ describe("Integration:: enter authenticator app code", () => {
   after(() => {
     sinon.restore();
     delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
+    delete process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY;
     app = undefined;
   });
 
@@ -112,21 +113,44 @@ describe("Integration:: enter authenticator app code", () => {
     {
       description: "when support mfa reset with ipv is off",
       supportMfaResetWithIpv: "0",
+      routeUsersToNewIpvJourney: "0",
       expectedHref:
         PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=AUTH_APP",
       expectedLinkText: "change how you get security codes",
     },
     {
-      description: "when support mfa reset with ipv is on",
+      description:
+        "when support mfa reset with ipv is off regardless of route to new journey flag",
+      supportMfaResetWithIpv: "0",
+      routeUsersToNewIpvJourney: "1",
+      expectedHref:
+        PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=AUTH_APP",
+      expectedLinkText: "change how you get security codes",
+    },
+    {
+      description:
+        "when support mfa reset with ipv is on and route users to new journey is on",
       supportMfaResetWithIpv: "1",
+      routeUsersToNewIpvJourney: "1",
       expectedHref: PATH_NAMES.MFA_RESET_WITH_IPV,
       expectedLinkText: "check if you can change how you get security codes",
+    },
+    {
+      description:
+        "when support mfa reset with ipv is on but route to new journeys is off",
+      supportMfaResetWithIpv: "1",
+      routeUsersToNewIpvJourney: "0",
+      expectedHref:
+        PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=AUTH_APP",
+      expectedLinkText: "change how you get security codes",
     },
   ];
 
   TEST_DATA.forEach((testData) => {
     it(`should display correct link to reset mfa ${testData.description}`, async () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = testData.supportMfaResetWithIpv;
+      process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY =
+        testData.routeUsersToNewIpvJourney;
       await request(app, (test) =>
         test
           .get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -13,7 +13,11 @@ import {
   pathWithQueryParam,
   SecurityCodeErrorType,
 } from "../common/constants";
-import { supportAccountRecovery, supportMfaResetWithIpv } from "../../config";
+import {
+  routeUsersToNewIpvJourney,
+  supportAccountRecovery,
+  supportMfaResetWithIpv,
+} from "../../config";
 import { AccountRecoveryInterface } from "../common/account-recovery/types";
 import { accountRecoveryService } from "../common/account-recovery/account-recovery-service";
 import { BadRequestError } from "../../utils/error";
@@ -82,7 +86,10 @@ export function enterMfaGet(
     req.session.user.isAccountRecoveryPermitted =
       accountRecoveryResponse.data.accountRecoveryPermitted;
 
-    const mfaResetPath = supportMfaResetWithIpv()
+    const routeUserViaIpvReset =
+      supportMfaResetWithIpv() && routeUsersToNewIpvJourney();
+
+    const mfaResetPath = routeUserViaIpvReset
       ? PATH_NAMES.MFA_RESET_WITH_IPV
       : pathWithQueryParam(
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES,
@@ -94,7 +101,7 @@ export function enterMfaGet(
       phoneNumber: req.session.user.redactedPhoneNumber,
       supportAccountRecovery: req.session.user.isAccountRecoveryPermitted,
       mfaResetPath: mfaResetPath,
-      routeUserViaIpvReset: supportMfaResetWithIpv(),
+      routeUserViaIpvReset: routeUserViaIpvReset,
     });
   };
 }

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -94,7 +94,7 @@ export function enterMfaGet(
       phoneNumber: req.session.user.redactedPhoneNumber,
       supportAccountRecovery: req.session.user.isAccountRecoveryPermitted,
       mfaResetPath: mfaResetPath,
-      supportMfaResetWithIpv: supportMfaResetWithIpv(),
+      routeUserViaIpvReset: supportMfaResetWithIpv(),
     });
   };
 }

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -28,7 +28,7 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
         <input type="hidden" name="supportAccountRecovery" value="{{ supportAccountRecovery }}" />
         <input type="hidden" name="mfaResetPath" value="{{ mfaResetPath }}" />
-        <input type="hidden" name="supportMfaResetWithIpv" value="{{supportMfaResetWithIpv}}"/>
+        <input type="hidden" name="routeUserViaIpvReset" value="{{routeUserViaIpvReset}}"/>
 
         {{ govukInput({
             label: {
@@ -52,7 +52,7 @@
                 {{ 'pages.enterMfa.details.text 2' | translate }}
             </p>
                 {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
-                    {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+                    {% if routeUserViaIpvReset === true or routeUserViaIpvReset === "true" %}
                         <p class="govuk-body">
                             {{ 'pages.enterMfa.details.changeGetSecurityCodesTextWithIpv' | translate }}
                             <a href={{ mfaResetPath }} class="govuk-link"

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -27,7 +27,7 @@
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="supportAccountRecovery" value="{{supportAccountRecovery}}"/>
     <input type="hidden" name="mfaResetPath" value="{{mfaResetPath}}"/>
-    <input type="hidden" name="supportMfaResetWithIpv" value="{{supportMfaResetWithIpv}}"/>
+    <input type="hidden" name="routeUserViaIpvReset" value="{{routeUserViaIpvReset}}"/>
 
     {{ govukInput({
   label: {
@@ -52,7 +52,7 @@
     </p>
 
     {% if supportAccountRecovery === true or supportAccountRecovery === "true" %}
-      {% if supportMfaResetWithIpv === true or supportMfaResetWithIpv === "true" %}
+      {% if routeUserViaIpvReset === true or routeUserViaIpvReset === "true" %}
         <p class="govuk-body">
           {{ 'pages.enterMfa.details.changeGetSecurityCodesTextWithIpv' | translate }}
           <a href={{ mfaResetPath }} class="govuk-link"

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -22,7 +22,29 @@ Object {
 }
 `;
 
-exports[`Integration:: enter mfa should include the correct link to change mfa methods when support mfa reset with ipv is on 1`] = `
+exports[`Integration:: enter mfa should include the correct link to change mfa methods when support mfa reset with ipv is off regardless of route to new journey flag 1`] = `
+Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration:: enter mfa should include the correct link to change mfa methods when support mfa reset with ipv is on and route users to new journey is on 1`] = `
+Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration:: enter mfa should include the correct link to change mfa methods when support mfa reset with ipv is on but route to new journeys is off 1`] = `
 Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
   "taxonomyLevel1": "authentication",

--- a/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
+++ b/src/components/enter-mfa/tests/__snapshots__/enter-mfa-integration.test.ts.snap
@@ -11,6 +11,28 @@ Object {
 }
 `;
 
+exports[`Integration:: enter mfa should include the correct link to change mfa methods when support mfa reset with ipv is off 1`] = `
+Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration:: enter mfa should include the correct link to change mfa methods when support mfa reset with ipv is on 1`] = `
+Object {
+  "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "sign in",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
 exports[`Integration:: enter mfa should return check your phone page with sign in analytics properties 1`] = `
 Object {
   "contentId": "19601dd7-be55-4ab6-aa44-a6358c4239dc",

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -74,7 +74,7 @@ describe("enter mfa controller", () => {
         supportAccountRecovery: false,
         mfaResetPath:
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
-        supportMfaResetWithIpv: false,
+        routeUserViaIpvReset: false,
       });
     });
 
@@ -91,7 +91,7 @@ describe("enter mfa controller", () => {
         supportAccountRecovery: true,
         mfaResetPath:
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
-        supportMfaResetWithIpv: false,
+        routeUserViaIpvReset: false,
       });
     });
 
@@ -153,7 +153,7 @@ describe("enter mfa controller", () => {
         phoneNumber: TEST_PHONE_NUMBER,
         supportAccountRecovery: true,
         mfaResetPath: PATH_NAMES.MFA_RESET_WITH_IPV,
-        supportMfaResetWithIpv: true,
+        routeUserViaIpvReset: true,
       });
     });
   });

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -143,6 +143,7 @@ describe("enter mfa controller", () => {
 
     it("should render enter mfa code view with mfaResetPath being IPV_DUMMY_URL when mfa reset with ipv is supported", async () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
+      process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY = "1";
 
       await enterMfaGet(fakeAccountRecoveryPermissionCheckService(true))(
         req as Request,

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -86,6 +86,7 @@ describe("Integration:: enter mfa", () => {
   after(() => {
     process.env.SUPPORT_REAUTHENTICATION = "0";
     delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
+    delete process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY;
     sinon.restore();
     app = undefined;
   });
@@ -98,21 +99,44 @@ describe("Integration:: enter mfa", () => {
     {
       description: "when support mfa reset with ipv is off",
       supportMfaResetWithIpv: "0",
+      routeUsersToNewIpvJourney: "0",
       expectedHref:
         PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
       expectedLinkText: "change how you get security codes",
     },
     {
-      description: "when support mfa reset with ipv is on",
+      description:
+        "when support mfa reset with ipv is off regardless of route to new journey flag",
+      supportMfaResetWithIpv: "0",
+      routeUsersToNewIpvJourney: "1",
+      expectedHref:
+        PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
+      expectedLinkText: "change how you get security codes",
+    },
+    {
+      description:
+        "when support mfa reset with ipv is on and route users to new journey is on",
       supportMfaResetWithIpv: "1",
+      routeUsersToNewIpvJourney: "1",
       expectedHref: PATH_NAMES.MFA_RESET_WITH_IPV,
       expectedLinkText: "check if you can change how you get security codes",
+    },
+    {
+      description:
+        "when support mfa reset with ipv is on but route to new journeys is off",
+      supportMfaResetWithIpv: "1",
+      routeUsersToNewIpvJourney: "0",
+      expectedHref:
+        PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
+      expectedLinkText: "change how you get security codes",
     },
   ];
 
   TEST_DATA.forEach((testData) => {
     it(`should include the correct link to change mfa methods ${testData.description}`, async () => {
       process.env.SUPPORT_MFA_RESET_WITH_IPV = testData.supportMfaResetWithIpv;
+      process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY =
+        testData.routeUsersToNewIpvJourney;
       await request(app, (test) =>
         test
           .get(PATH_NAMES.ENTER_MFA)

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -85,12 +85,52 @@ describe("Integration:: enter mfa", () => {
 
   after(() => {
     process.env.SUPPORT_REAUTHENTICATION = "0";
+    delete process.env.SUPPORT_MFA_RESET_WITH_IPV;
     sinon.restore();
     app = undefined;
   });
 
   it("should return check your phone page with sign in analytics properties", async () => {
     await request(app, (test) => test.get(PATH_NAMES.ENTER_MFA).expect(200));
+  });
+
+  const TEST_DATA = [
+    {
+      description: "when support mfa reset with ipv is off",
+      supportMfaResetWithIpv: "0",
+      expectedHref:
+        PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",
+      expectedLinkText: "change how you get security codes",
+    },
+    {
+      description: "when support mfa reset with ipv is on",
+      supportMfaResetWithIpv: "1",
+      expectedHref: PATH_NAMES.MFA_RESET_WITH_IPV,
+      expectedLinkText: "check if you can change how you get security codes",
+    },
+  ];
+
+  TEST_DATA.forEach((testData) => {
+    it(`should include the correct link to change mfa methods ${testData.description}`, async () => {
+      process.env.SUPPORT_MFA_RESET_WITH_IPV = testData.supportMfaResetWithIpv;
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.ENTER_MFA)
+          .expect(200)
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect(
+              $("a")
+                .toArray()
+                .some(
+                  (link) =>
+                    $(link).attr("href") === testData.expectedHref &&
+                    $(link).text().trim() === testData.expectedLinkText
+                )
+            ).to.be.true;
+          })
+      );
+    });
   });
 
   it("following a validation error it should not include link to change security codes where account recovery is not permitted", async () => {

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -11,7 +11,10 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { BadRequestError } from "../../utils/error";
 import { EnterPasswordServiceInterface } from "../enter-password/types";
 import { enterPasswordService } from "../enter-password/enter-password-service";
-import { supportMfaResetWithIpv } from "../../config";
+import {
+  routeUsersToNewIpvJourney,
+  supportMfaResetWithIpv,
+} from "../../config";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -45,7 +48,8 @@ export function resetPasswordPost(
 
     // WARNING! Before removing this feature flag, you first need to ensure that this behaviour is the default on the backend
     // Purely removing this feature flag will mean that we start writing to account modifiers again
-    const allowMfaResetAfterPasswordReset = supportMfaResetWithIpv();
+    const allowMfaResetAfterPasswordReset =
+      supportMfaResetWithIpv() && routeUsersToNewIpvJourney();
 
     const updatePasswordResponse = await resetService.updatePassword(
       newPassword,

--- a/src/config.ts
+++ b/src/config.ts
@@ -188,6 +188,10 @@ export function supportMfaResetWithIpv(): boolean {
   return process.env.SUPPORT_MFA_RESET_WITH_IPV === "1";
 }
 
+export function routeUsersToNewIpvJourney(): boolean {
+  return process.env.ROUTE_USERS_TO_NEW_IPV_JOURNEY === "1";
+}
+
 export function showTestBanner(): boolean {
   return getAppEnv() !== "production" || process.env.SHOW_TEST_BANNER === "1";
 }


### PR DESCRIPTION
## What

Introduces a new feature flag (routeUsersViaIpv) that will support a temporary testing phase of the new journey in production before we fully route users via the new journey. This is largely so that we can test prod connectivity.

During this testing phase, we will switch:
* the existing feature flag (supportMfaResetViaIpv) to on
* the new feature flag to off

The effect of this will be that users clicking through an mfa reset journey will still be routed via the existing mfa reset journey. But since the new routes for the new journey are deployed via the existing feature flag, they will be available to manually navigate to the new journey at the relevant point, meaning we can check the production journey without affecting users clicking through the normal journey.

Once we're happy, we will flick the new switch and users will be routed via the new journey.

## How to review

1. Code Review
1. If you like, you can test the various combinations of feature flags - chat to me if you'd like some help. I've already tested these: locally, deployed via terraform and deployed via cloudformation

