### PR TITLE
BAU: pin golang to 1.23.6 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 default_language_version:
   node: 20.17.0
+  golang: 1.23.6
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
## What

1.24 breaks compat

```
❯ go version
go version go1.24.0 darwin/arm64
❯ git commit
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for local.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/rhysd/actionlint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
mixed line ending........................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check that scripts with shebangs are executable..........................Passed
AWS CloudFormation Linter............................(no files to check)Skipped
Terraform fmt........................................(no files to check)Skipped
Run tflint (terraform linter)........................(no files to check)Skipped
Run ESLint...........................................(no files to check)Skipped
Run prettier.............................................................Passed
Update terraform provider locks......................(no files to check)Skipped
GitHub Actions Pinning...............................(no files to check)Skipped
Lint GitHub Actions workflow files...................(no files to check)Skipped
ruff.................................................(no files to check)Skipped
ruff-format..........................................(no files to check)Skipped
[whi-tw/bau/pin-go-version eb867fd5] BAU: pin golang to 1.23.6 in pre-commit
 1 file changed, 1 insertion(+)
```
