### PR TITLE
AUT-4047: PR-Align - Align build and staging with production for mfa reset

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -370,8 +370,8 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       transitionalDomain: signin-sp.build.account.gov.uk
       migratedDomain: signin.build.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
+      UseMfaResetWithIpv: "No"
+      UseRouteUsersToNewIpvJourney: "No"
       Enableipvspinner: "No"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -404,8 +404,8 @@ Mappings:
       SupportHTTPKeepAlive: "Yes"
       transitionalDomain: signin-sp.staging.account.gov.uk
       migratedDomain: signin.staging.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
+      UseMfaResetWithIpv: "No"
+      UseRouteUsersToNewIpvJourney: "No"
       Enableipvspinner: "No"
     integration:
       DeployServiceDownPage: "Yes"


### PR DESCRIPTION
## What

Align build and staging with production for mfa reset

- All environments in the pipeline should reflect prod before go-live
- Switches are already off in the backend/legacy pipeline for build which is not currently migrated to SP

See [implementation plan](https://govukverify.atlassian.net/wiki/spaces/LO/pages/5082808321/DCP-3200+Resetting+MFA+with+ID+re-verification+-+Implementation+Plan+27+Feb+2025)

## How to review

1. Code Review

## Related PRs


