### PR TITLE
AUT-4047: PR-Silent-Enable - Enable MFA reset in integration and production

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -432,7 +432,7 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       transitionalDomain: signin-sp.integration.account.gov.uk
       migratedDomain: signin.integration.account.gov.uk
-      UseMfaResetWithIpv: "No"
+      UseMfaResetWithIpv: "Yes"
       UseRouteUsersToNewIpvJourney: "No"
       Enableipvspinner: "No"
       orchStubToAuth: ""
@@ -463,7 +463,7 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       transitionalDomain: signin-sp.account.gov.uk
       migratedDomain: signin.account.gov.uk
-      UseMfaResetWithIpv: "No"
+      UseMfaResetWithIpv: "Yes"
       UseRouteUsersToNewIpvJourney: "No"
       Enableipvspinner: "No"
       orchStubToAuth: ""


### PR DESCRIPTION
## What

Enable MFA reset in integration and production

- Makes MFA reset available for live proving
- Switch on 'UseMfaResetWithIpv' in the secure pipeline environments

See [implementation plan](https://govukverify.atlassian.net/wiki/spaces/LO/pages/5082808321/DCP-3200+Resetting+MFA+with+ID+re-verification+-+Implementation+Plan+27+Feb+2025)

## How to review

1. Code Review

## Related PRs

