### PR TITLE
AUT-4047: PR-Visible - Switch on MFA reset for end-users in integration and production

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -433,7 +433,7 @@ Mappings:
       transitionalDomain: signin-sp.integration.account.gov.uk
       migratedDomain: signin.integration.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "No"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
     production:
@@ -464,7 +464,7 @@ Mappings:
       transitionalDomain: signin-sp.account.gov.uk
       migratedDomain: signin.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "No"
+      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
 


### PR DESCRIPTION
## What

PR-Visible - Switch on MFA reset for end-users in integration and production

- Makes MFA reset available for live proving
- Switch on 'UseRouteUsersToNewIpvJourney' in the secure pipeline environments

See [implementation plan](https://govukverify.atlassian.net/wiki/spaces/LO/pages/5082808321/DCP-3200+Resetting+MFA+with+ID+re-verification+-+Implementation+Plan+27+Feb+2025)

To be merged after: https://github.com/govuk-one-login/authentication-frontend/pull/2615/

## How to review

1. Code Review

## Related PRs

#2615 