### PR TITLE
AUT-3689: switch build env to migrated domain

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -269,6 +269,9 @@ Conditions:
       - Fn::Or:
           - Fn::Equals:
               - !Ref Environment
+              - "build"
+          - Fn::Equals:
+              - !Ref Environment
               - "staging"
           - Fn::Equals:
               - !Ref Environment


### PR DESCRIPTION
## What

Deploy the frontend application with the `SwitchToMigratedZone` feature switch enabled in the build account.

## How to review

This is step 1.11 equivalent for build env in the [release plan](https://govukverify.atlassian.net/wiki/spaces/LO/pages/4773052525/Auth+New+Frontend+Go-live+Release+Plan)

