### PR TITLE
BAU: disable deploy-service-down-page for dev environments

### DIFF
--- a/.github/workflows/deploy-frontend-sp-dev.yml
+++ b/.github/workflows/deploy-frontend-sp-dev.yml
@@ -10,27 +10,31 @@ on:
         required: true
 
 jobs:
-  deploy-service-down-page:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    environment: ${{ inputs.environment }}
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Build and push service down page image
-        uses: govuk-one-login/devplatform-upload-action-ecr@5f4cd8b195ad7ae810d60881fa6dbaff1764b5da # v1.3.0
-        with:
-          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
-          build-and-push-image-only: true
-          working-directory: service-down-page-config
-          artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
-          ecr-repo-name: ${{ secrets.SERVICE_DOWN_PAGE_ECR_REPOSITORY }}
+  # NOTE:
+  # IF you are testing service down page deployment in dev envs
+  # THEN while uncommenting this job, also enable feature flag DeployServiceDownPage: "Yes" in template.yaml
+  # AND override ServiceDownPageRegistry param to env specific settings
+  # deploy-service-down-page:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 60
+  #   environment: ${{ inputs.environment }}
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Build and push service down page image
+  #       uses: govuk-one-login/devplatform-upload-action-ecr@5f4cd8b195ad7ae810d60881fa6dbaff1764b5da # v1.3.0
+  #       with:
+  #         role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+  #         container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
+  #         build-and-push-image-only: true
+  #         working-directory: service-down-page-config
+  #         artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+  #         ecr-repo-name: ${{ secrets.SERVICE_DOWN_PAGE_ECR_REPOSITORY }}
 
   deploy-frontend:
-    needs:
-      - deploy-service-down-page
+    # needs:
+    #   - deploy-service-down-page
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ inputs.environment }}


### PR DESCRIPTION
## What

BAU: disable deploy-service-down-page for dev environments
To help speedup deployments to dev, authdev1 and authdev2