### PR TITLE
AUT-4103: Put numbered elements on setup auth app page in correct html

### DIFF
--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -30,58 +30,65 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.setupAuthenticatorApp.header' | translate }}</h1>
 
-    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step1' | translate }}</p>
-    {{ govukDetails({
-        summaryText: 'pages.setupAuthenticatorApp.noAuthAppDetails.summaryText' | translate,
-        html: noAuthAppInsetTextHtml
-    }) }}
-    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step2' | translate }}</p>
+    <ol class="govuk-list govuk-list--number">
+        <li>
+            <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step1' | translate }}</p>
+            {{ govukDetails({
+                summaryText: 'pages.setupAuthenticatorApp.noAuthAppDetails.summaryText' | translate,
+                html: noAuthAppInsetTextHtml
+            }) }}
+        </li>
+        <li>
+           <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step2' | translate }}</p>
 
-    <p class="govuk-body">
-        <img id="qr-code" src="{{ qrCode }}" alt="QR Code Image">
-    </p>
+           <p class="govuk-body">
+              <img id="qr-code" src="{{ qrCode }}" alt="QR Code Image">
+           </p>
 
-    {{ govukDetails({
-        summaryText: 'pages.setupAuthenticatorApp.cannotScanDetails.summaryText' | translate,
-        html: cannotScanInsetTextHtml
-    }) }}
+           {{ govukDetails({
+               summaryText: 'pages.setupAuthenticatorApp.cannotScanDetails.summaryText' | translate,
+               html: cannotScanInsetTextHtml
+           }) }}
+        </li>
+        <li>
+            <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step3' | translate }}</p>
+        </li>
+        <li>
+            <form id="form-tracking" method="post" novalidate="novalidate">
 
-    <p class="govuk-body">{{ 'pages.setupAuthenticatorApp.step3' | translate }}</p>
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            <input type="hidden" name="_secretKey" value="{{ secretKey }}" />
 
-    <form id="form-tracking" method="post" novalidate="novalidate">
+            {{ govukInput({
+                label: {
+                    text: 'pages.setupAuthenticatorApp.code.label' | translate
+                },
+                hint: {
+                    text: 'pages.setupAuthenticatorApp.code.hintText' | translate
+                },
+                classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+                id: "code",
+                name: "code",
+                inputmode: "numeric",
+                spellcheck: false,
+                autocomplete: "one-time-code",
+                errorMessage: {
+                    text: errors['code'].text
+                } if (errors['code'])}) }}
 
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-        <input type="hidden" name="_secretKey" value="{{ secretKey }}" />
+                {{ govukButton({
+                    "text": "general.continue.label" | translate,
+                    "type": "Submit",
+                    "preventDoubleClick": true
+                }) }}
 
-        {{ govukInput({
-            label: {
-                text: 'pages.setupAuthenticatorApp.code.label' | translate
-            },
-            hint: {
-                text: 'pages.setupAuthenticatorApp.code.hintText' | translate
-            },
-            classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-            id: "code",
-            name: "code",
-            inputmode: "numeric",
-            spellcheck: false,
-            autocomplete: "one-time-code",
-            errorMessage: {
-                text: errors['code'].text
-            } if (errors['code'])}) }}
-
-        {{ govukButton({
-            "text": "general.continue.label" | translate,
-            "type": "Submit",
-            "preventDoubleClick": true
-        }) }}
-
-        <p class="govuk-body">
-            <a href="/get-security-codes" class="govuk-link"
-               rel="noreferrer">{{ 'pages.setupAuthenticatorApp.changeMfaChoiceLinkText' | translate }}</a>
-        </p>
-
-    </form>
+            <p class="govuk-body">
+                <a href="/get-security-codes" class="govuk-link"
+                   rel="noreferrer">{{ 'pages.setupAuthenticatorApp.changeMfaChoiceLinkText' | translate }}</a>
+            </p>
+            </form>
+        </li>
+    </ol>
 
     {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: true } %}
     {%- include "ga4-opl/template.njk" -%}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2509,23 +2509,23 @@
     "setupAuthenticatorApp": {
       "title": "Sefydlu ap dilysydd",
       "header": "Sefydlu ap dilysydd",
-      "step1": "1. Agorwch eich ap dilysydd ar eich ffôn clyfar, llechen neu gyfrifiadur.",
+      "step1": "Agorwch eich ap dilysydd ar eich ffôn clyfar, llechen neu gyfrifiadur.",
       "noAuthAppDetails": {
         "summaryText": "Nid oes gennyf ap dilysydd",
         "paragraph1": "Gallwch lawrlwytho ap dilysydd ar gyfer eich ffôn clyfar neu lechen o’ch siop apiau.",
         "paragraph2": "Os nad oes gennych ffôn clyfar neu lechen, chwiliwch ar-lein am ap dilysydd ar gyfer eich cyfrifiadur.",
         "paragraph3": "Gallwch ddefnyddio unrhyw ap dilysydd."
       },
-      "step2": "2. Defnyddiwch eich ap dilysydd i sganio’r cod QR.",
+      "step2": "Defnyddiwch eich ap dilysydd i sganio’r cod QR.",
       "cannotScanDetails": {
         "summaryText": "Ni allaf sganio’r cod QR",
         "paragraph1": "Gallwch roi yr allwedd gyfrinachol i’ch ap dilysydd yn lle hynny.",
         "paragraph2": "Allwedd gyfrinachol: ",
         "paragraph3": "Mae rhai apiau dilysydd yn galw’r allwedd gyfrinachol yn ‘cod’."
       },
-      "step3": "3. Bydd yr ap dilysydd yn dangos cod diogelwch.",
+      "step3": "Bydd yr ap dilysydd yn dangos cod diogelwch.",
       "code": {
-        "label": "4. Rhowch y cod.",
+        "label": "Rhowch y cod.",
         "hintText": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
           "required": "Rhowch y cod a dangosir yn eich ap dilysydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2509,23 +2509,23 @@
     "setupAuthenticatorApp": {
       "title": "Set up an authenticator app",
       "header": "Set up an authenticator app",
-      "step1": "1. Open your authenticator app on your smartphone, tablet or computer.",
+      "step1": "Open your authenticator app on your smartphone, tablet or computer.",
       "noAuthAppDetails": {
         "summaryText": "I don’t have an authenticator app",
         "paragraph1": "You can download an authenticator app for your smartphone or tablet from your app store.",
         "paragraph2": "If you don’t have a smartphone or tablet, search online for an authenticator app for your computer.",
         "paragraph3": "You can use any authenticator app."
       },
-      "step2": "2. Use your authenticator app to scan the QR code.",
+      "step2": "Use your authenticator app to scan the QR code.",
       "cannotScanDetails": {
         "summaryText": "I cannot scan the QR code",
         "paragraph1": "You can enter the secret key into your authenticator app instead.",
         "paragraph2": "Secret key: ",
         "paragraph3": "Some authenticator apps call the secret key a ‘code’."
       },
-      "step3": "3. The authenticator app will show a security code.",
+      "step3": "The authenticator app will show a security code.",
       "code": {
-        "label": "4. Enter the code.",
+        "label": "Enter the code.",
         "hintText": "This is the 6-digit number shown in your authenticator app",
         "validationError": {
           "required": "Enter the code shown in your authenticator app",


### PR DESCRIPTION
By putting these items in an ordered list element in html, users accessing the service via assistive technologies (e.g. screen readers) should be able to better understand the structure of the page.

This necessitated removing the hard-coded numbers from the steps in the translation files, as these will be provided by the html elements.

This fixes a failure against this WCAG standard:
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships

## What

<!-- Describe what you have changed and why -->

## Screenshots

| | Current page | Page as rendered by this PR |
|---|----|-------|
| En |<img width="450" alt="Screenshot 2025-03-07 at 11 43 04" src="https://github.com/user-attachments/assets/94044ddc-7b53-4474-8a1a-d1f9ac3ee919" />|<img width="741" alt="Screenshot 2025-03-07 at 11 54 35" src="https://github.com/user-attachments/assets/c8af0ff8-8f99-4eb6-90f7-6b1ccbb8e844" />|
| Cy |<img width="741" alt="Screenshot 2025-03-07 at 11 43 16" src="https://github.com/user-attachments/assets/4e010ef9-6d14-4ed1-bb69-90474ca36081" />|<img width="741" alt="Screenshot 2025-03-07 at 11 54 44" src="https://github.com/user-attachments/assets/b9e0b9e1-ab1d-445a-926c-0f7f083542bb" />|

Note that there is a slight visual change here in that the elements between steps have been indented slightly as I've considered them part of that step. I don't think this is a big issue - I think instead this is probably clearer than before.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->
