### PR TITLE
AUT-4131: Skip commitsha when deploying to dev envs via CLI scripts

### DIFF
--- a/scripts/dev_sam_deploy.sh
+++ b/scripts/dev_sam_deploy.sh
@@ -151,7 +151,7 @@ if [[ $DEPLOY == "1" ]]; then
         --config-env "$DEPLOY_ENV" \
         --config-file "$SAMCONFIG_FILE" \
         $CONFIRM_CHANGESET_OPTION \
-        --tags $TAGS Product="GOV.UK Sign In" commitsha=${GITHUB_SHA}
+        --tags $TAGS Product="GOV.UK Sign In"
 
     # cleanup
     rm cf-template.yaml*


### PR DESCRIPTION
## What

Skip commitsha when deploying to dev envs via CLI scripts
This reduces the size of the changeset every deployment and thus speeds up the deployment

Issue: [AUT-4131]

## How to review

Use `deploy-authdevs.sh`. Several test runs from the branch logged in the jira ticket

[AUT-4131]: https://govukverify.atlassian.net/browse/AUT-4131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ