### PR TITLE
AUT-4110: Replicate auth code logic in prove-identity-callback

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -674,9 +674,7 @@ const authStateMachine = createMachine(
         },
       },
       [PATH_NAMES.PROVE_IDENTITY_CALLBACK]: {
-        on: {
-          [USER_JOURNEY_EVENTS.PROVE_IDENTITY_CALLBACK]: [PATH_NAMES.AUTH_CODE],
-        },
+        type: "final",
         meta: {
           optionalPaths: [
             PATH_NAMES.PROVE_IDENTITY,

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -1,6 +1,4 @@
 import { NextFunction, Request, Response } from "express";
-import { getNextPathAndUpdateJourney } from "../common/constants";
-import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { ExpressRouteFunc } from "../../types";
 import {
   IdentityProcessingStatus,
@@ -50,14 +48,11 @@ export function proveIdentityCallbackGetOrPost(
     let redirectPath;
 
     if (response.data.status === IdentityProcessingStatus.COMPLETED) {
-      req.session.user.authCodeReturnToRP = true;
-
-      redirectPath = await getNextPathAndUpdateJourney(
-        req,
-        req.path,
-        USER_JOURNEY_EVENTS.PROVE_IDENTITY_CALLBACK,
-        null,
-        sessionId
+      redirectPath = await service.generateSuccessfulRpReturnUrl(
+        sessionId,
+        clientSessionId,
+        persistentSessionId,
+        req
       );
     } else {
       redirectPath = createServiceRedirectErrorUrl(

--- a/src/components/prove-identity-callback/prove-identity-callback-service.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-service.ts
@@ -4,16 +4,23 @@ import {
   Http,
   http,
 } from "../../utils/http";
-import { API_ENDPOINTS } from "../../app.constants";
+import { API_ENDPOINTS, COOKIE_CONSENT } from "../../app.constants";
 import { ApiResponseResult } from "../../types";
 import {
   ProcessIdentityResponse,
   ProveIdentityCallbackServiceInterface,
 } from "./types";
 import { Request } from "express";
+import { getApiBaseUrl } from "../../config";
+import { AuthCodeResponse } from "../auth-code/types";
+import { ApiError } from "../../utils/error";
+import { sanitize } from "../../utils/strings";
+import { CookieConsentServiceInterface } from "../common/cookie-consent/types";
+import { cookieConsentService } from "../common/cookie-consent/cookie-consent-service";
 
 export function proveIdentityCallbackService(
-  axios: Http = http
+  axios: Http = http,
+  cookieService: CookieConsentServiceInterface = cookieConsentService()
 ): ProveIdentityCallbackServiceInterface {
   const identityProcessed = async function (
     email: string,
@@ -38,8 +45,52 @@ export function proveIdentityCallbackService(
 
     return createApiResponse<ProcessIdentityResponse>(response);
   };
+  const generateSuccessfulRpReturnUrl = async function (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request
+  ): Promise<string> {
+    const config = getInternalRequestConfigWithSecurityHeaders(
+      {
+        baseURL: getApiBaseUrl(),
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        persistentSessionId: persistentSessionId,
+      },
+      req,
+      API_ENDPOINTS.AUTH_CODE
+    );
+    const response = await axios.client.get(API_ENDPOINTS.AUTH_CODE, config);
+    const result = createApiResponse<AuthCodeResponse>(response);
+
+    if (!result.success) {
+      throw new ApiError(result.data.message, result.data.code);
+    }
+
+    let authCodeLocation = result.data.location;
+
+    if (req.session.client.cookieConsentEnabled) {
+      const consentValue = cookieService.getCookieConsent(
+        sanitize(req.cookies.cookies_preferences_set)
+      );
+
+      const queryParams = new URLSearchParams({
+        cookie_consent: consentValue.cookie_consent,
+      });
+
+      const gaId = req.session.client.crossDomainGaTrackingId;
+      if (gaId && consentValue.cookie_consent === COOKIE_CONSENT.ACCEPT) {
+        queryParams.append("_ga", gaId);
+      }
+
+      authCodeLocation = authCodeLocation + "&" + queryParams.toString();
+    }
+    return authCodeLocation;
+  };
 
   return {
     processIdentity: identityProcessed,
+    generateSuccessfulRpReturnUrl,
   };
 }

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -43,21 +43,30 @@ describe("prove identity callback controller", () => {
   });
 
   describe("proveIdentityCallbackGet", () => {
-    it("should redirect to auth code when identity processing complete", async () => {
+    it("should redirect to the RP when identity processing complete", async () => {
+      const rpRedirectUrl =
+        "https://rp.example.com?authcode=1234&state=teststate";
       const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
-        processIdentity: sinon.fake.returns({
-          success: true,
-          data: {
-            status: IdentityProcessingStatus.COMPLETED,
-          },
-        }),
-      } as unknown as ProveIdentityCallbackServiceInterface;
+        processIdentity: sinon.fake.returns(
+          Promise.resolve({
+            success: true,
+            data: {
+              status: IdentityProcessingStatus.COMPLETED,
+              code: 200,
+              message: "",
+            },
+          })
+        ),
+        generateSuccessfulRpReturnUrl: sinon.fake.returns(
+          Promise.resolve(rpRedirectUrl)
+        ),
+      };
       await proveIdentityCallbackGetOrPost(fakeProveIdentityService)(
         req as Request,
         res as Response
       );
 
-      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
+      expect(res.redirect).to.have.been.calledWith(rpRedirectUrl);
     });
 
     it("should render index when identity is being processed", async () => {

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-service.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-service.test.ts
@@ -12,60 +12,278 @@ import { ProveIdentityCallbackServiceInterface } from "../types";
 import { proveIdentityCallbackService } from "../prove-identity-callback-service";
 import {
   API_ENDPOINTS,
+  COOKIE_CONSENT,
   HTTP_STATUS_CODES,
   PATH_NAMES,
 } from "../../../app.constants";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
+import { expect } from "chai";
+import { CookieConsentServiceInterface } from "../../common/cookie-consent/types";
+import { Request } from "express";
 
 describe("prove identity callback service", () => {
   const httpInstance = new Http();
   const service: ProveIdentityCallbackServiceInterface =
     proveIdentityCallbackService(httpInstance);
-  let postStub: SinonStub;
 
-  beforeEach(() => {
-    setupApiKeyAndBaseUrlEnvVars();
-    postStub = sinon.stub(httpInstance.client, "post");
-  });
+  describe("processIdentity", () => {
+    let postStub: SinonStub;
 
-  afterEach(() => {
-    postStub.reset();
-    resetApiKeyAndBaseUrlEnvVars();
-  });
-
-  it("successfully calls the API to make a request to process an identity", async () => {
-    const axiosResponse = Promise.resolve({
-      data: {},
-      status: HTTP_STATUS_CODES.OK,
-      statusText: "OK",
-    });
-    postStub.resolves(axiosResponse);
-    const { email, sessionId, clientSessionId, diPersistentSessionId } =
-      commonVariables;
-    const req = createMockRequest(PATH_NAMES.PROVE_IDENTITY, {
-      headers: requestHeadersWithIpAndAuditEncoded,
+    beforeEach(() => {
+      setupApiKeyAndBaseUrlEnvVars();
+      postStub = sinon.stub(httpInstance.client, "post");
     });
 
-    const expectedApiCallDetails = {
-      expectedPath: API_ENDPOINTS.IPV_PROCESSING_IDENTITY,
-      expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
-      expectedBody: { email },
+    afterEach(() => {
+      postStub.reset();
+      resetApiKeyAndBaseUrlEnvVars();
+    });
+
+    it("successfully calls the API to make a request to process an identity", async () => {
+      const axiosResponse = Promise.resolve({
+        data: {},
+        status: HTTP_STATUS_CODES.OK,
+        statusText: "OK",
+      });
+      postStub.resolves(axiosResponse);
+      const { email, sessionId, clientSessionId, diPersistentSessionId } =
+        commonVariables;
+      const req = createMockRequest(PATH_NAMES.PROVE_IDENTITY, {
+        headers: requestHeadersWithIpAndAuditEncoded,
+      });
+
+      const expectedApiCallDetails = {
+        expectedPath: API_ENDPOINTS.IPV_PROCESSING_IDENTITY,
+        expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+        expectedBody: { email },
+      };
+
+      const result = await service.processIdentity(
+        email,
+        sessionId,
+        clientSessionId,
+        diPersistentSessionId,
+        req
+      );
+
+      checkApiCallMadeWithExpectedBodyAndHeaders(
+        result,
+        postStub,
+        true,
+        expectedApiCallDetails
+      );
+    });
+  });
+
+  describe("generateSuccessfulRpReturnUrl", () => {
+    const redirectUriReturnedFromResponse =
+      "/redirect-here?with-some-params=added-by-the-endpoint";
+    const apiBaseUrl = "https://base-url";
+    const sessionId = "sessionId";
+    const apiKey = "apiKey";
+    const clientSessionId = "clientSessionId";
+    const sourceIp = "sourceIp";
+    const persistentSessionId = "persistentSessionId";
+    const auditEncodedString =
+      "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc";
+    const crossDomainGaTrackingId =
+      "2.172053219.3232.1636392870-444224.1635165988";
+    const expectedHeaders = {
+      "X-API-Key": apiKey,
+      "Session-Id": sessionId,
+      "Client-Session-Id": clientSessionId,
+      "x-forwarded-for": sourceIp,
+      "txma-audit-encoded": auditEncodedString,
+      "di-persistent-session-id": persistentSessionId,
     };
+    const axiosResponse = Promise.resolve({
+      data: {
+        location: redirectUriReturnedFromResponse,
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: {},
+    });
+    let getStub: SinonStub;
+    let req = {} as any as Request;
 
-    const result = await service.processIdentity(
-      email,
-      sessionId,
-      clientSessionId,
-      diPersistentSessionId,
-      req
-    );
+    beforeEach(() => {
+      process.env.API_BASE_URL = apiBaseUrl;
+      getStub = sinon.stub(httpInstance.client, "get");
+      getStub.resolves(axiosResponse);
+      req = createMockRequest(PATH_NAMES.PROVE_IDENTITY_CALLBACK);
+      req.ip = sourceIp;
+      req.headers = {
+        "txma-audit-encoded": auditEncodedString,
+        "x-forwarded-for": sourceIp,
+      };
+    });
 
-    checkApiCallMadeWithExpectedBodyAndHeaders(
-      result,
-      postStub,
-      true,
-      expectedApiCallDetails
-    );
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should make a request for an RP auth code", async () => {
+      const result = await service.generateSuccessfulRpReturnUrl(
+        sessionId,
+        clientSessionId,
+        persistentSessionId,
+        req
+      );
+
+      expect(
+        getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
+          headers: expectedHeaders,
+          baseURL: apiBaseUrl,
+          proxy: sinon.match.bool,
+        })
+      ).to.be.true;
+      expect(result).to.eq(redirectUriReturnedFromResponse);
+    });
+
+    describe("cookieConsentEnabled true", () => {
+      beforeEach(() => {
+        req.session.client.cookieConsentEnabled = true;
+      });
+
+      it("should redirect to the auth code url with cookie consent param set as not-engaged", async () => {
+        const fakeCookieConsentService =
+          createFakeCookieConsentService("NOT_ENGAGED");
+
+        const result = await proveIdentityCallbackService(
+          httpInstance,
+          fakeCookieConsentService
+        ).generateSuccessfulRpReturnUrl(
+          sessionId,
+          clientSessionId,
+          persistentSessionId,
+          req
+        );
+
+        expect(result).to.eq(
+          `${redirectUriReturnedFromResponse}&cookie_consent=not-engaged`
+        );
+      });
+
+      it("should redirect to the auth code url with cookie consent param set as accept", async () => {
+        const fakeCookieConsentService =
+          createFakeCookieConsentService("ACCEPT");
+
+        const result = await proveIdentityCallbackService(
+          httpInstance,
+          fakeCookieConsentService
+        ).generateSuccessfulRpReturnUrl(
+          sessionId,
+          clientSessionId,
+          persistentSessionId,
+          req
+        );
+
+        expect(result).to.eq(
+          `${redirectUriReturnedFromResponse}&cookie_consent=accept`
+        );
+      });
+
+      it("should redirect to the auth code url with cookie consent param set as reject", async () => {
+        const fakeCookieConsentService =
+          createFakeCookieConsentService("REJECT");
+        req.session.client.crossDomainGaTrackingId = crossDomainGaTrackingId;
+
+        const result = await proveIdentityCallbackService(
+          httpInstance,
+          fakeCookieConsentService
+        ).generateSuccessfulRpReturnUrl(
+          sessionId,
+          clientSessionId,
+          persistentSessionId,
+          req
+        );
+
+        expect(
+          getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
+            headers: expectedHeaders,
+            baseURL: apiBaseUrl,
+            proxy: sinon.match.bool,
+          })
+        ).to.be.true;
+        expect(result).to.eq(
+          `${redirectUriReturnedFromResponse}&cookie_consent=reject`
+        );
+      });
+
+      it("should redirect to auth code url with cookie consent param set as accept and with the _ga param set", async () => {
+        req.session.client.cookieConsentEnabled = true;
+        req.session.client.crossDomainGaTrackingId = crossDomainGaTrackingId;
+
+        const fakeCookieConsentService =
+          createFakeCookieConsentService("ACCEPT");
+
+        const result = await proveIdentityCallbackService(
+          httpInstance,
+          fakeCookieConsentService
+        ).generateSuccessfulRpReturnUrl(
+          sessionId,
+          clientSessionId,
+          persistentSessionId,
+          req
+        );
+
+        expect(
+          getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
+            headers: expectedHeaders,
+            baseURL: apiBaseUrl,
+            proxy: sinon.match.bool,
+          })
+        ).to.be.true;
+        expect(result).to.eq(
+          `${redirectUriReturnedFromResponse}&cookie_consent=accept&_ga=${crossDomainGaTrackingId}`
+        );
+      });
+    });
+
+    describe("cookieConsentEnabled false", () => {
+      beforeEach(() => {
+        req.session.client.cookieConsentEnabled = false;
+      });
+
+      it("should redirect to auth code url with cookie consent param set as reject and no _ga param", async () => {
+        req.session.client.crossDomainGaTrackingId = crossDomainGaTrackingId;
+
+        const fakeCookieConsentService =
+          createFakeCookieConsentService("REJECT");
+
+        const result = await proveIdentityCallbackService(
+          httpInstance,
+          fakeCookieConsentService
+        ).generateSuccessfulRpReturnUrl(
+          sessionId,
+          clientSessionId,
+          persistentSessionId,
+          req
+        );
+
+        expect(
+          getStub.calledOnceWithExactly(API_ENDPOINTS.AUTH_CODE, {
+            headers: expectedHeaders,
+            baseURL: apiBaseUrl,
+            proxy: sinon.match.bool,
+          })
+        ).to.be.true;
+        expect(result).to.eq(`${redirectUriReturnedFromResponse}`);
+      });
+    });
   });
 });
+
+function createFakeCookieConsentService(
+  consent: keyof typeof COOKIE_CONSENT
+): CookieConsentServiceInterface {
+  return {
+    getCookieConsent: sinon.fake.returns({
+      cookie_consent: COOKIE_CONSENT[consent],
+    }),
+    createConsentCookieValue: sinon.fake(),
+  };
+}

--- a/src/components/prove-identity-callback/types.ts
+++ b/src/components/prove-identity-callback/types.ts
@@ -9,6 +9,12 @@ export interface ProveIdentityCallbackServiceInterface {
     persistentSessionId: string,
     req: Request
   ) => Promise<ApiResponseResult<ProcessIdentityResponse>>;
+  generateSuccessfulRpReturnUrl: (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request
+  ) => Promise<string>;
 }
 
 export type ProcessIdentityResponse =


### PR DESCRIPTION
## What

As part of a refactor to remove the RP auth code logic from /auth-code, reproduce this functionality here and no longer redirect to auth-code.
I've tested this in sandpit and dropped screenshots on the ticket

## How to review
Code review. I've deliberately left auth-code alone as that needs cleaning up later. If you want to test this it will need deploying to sandpit as you'll need real orchestration for identity.


