### PR TITLE
BAU: refactor to remove sandpit.Dockerfile build warning messages

### DIFF
--- a/sandpit.Dockerfile
+++ b/sandpit.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.17.0-alpine@sha256:2d07db07a2df6830718ae2a47db6fedce6745f5bcd174c398f2acdda90a11c03 as builder
+FROM node:20.17.0-alpine@sha256:2d07db07a2df6830718ae2a47db6fedce6745f5bcd174c398f2acdda90a11c03 AS builder
 WORKDIR /app
 COPY package.json ./
 COPY yarn.lock ./
@@ -7,15 +7,15 @@ COPY ./src ./src
 COPY ./@types ./@types
 RUN yarn install && yarn build && yarn clean-modules && yarn install --production=true
 
-FROM node:20.17.0-alpine@sha256:2d07db07a2df6830718ae2a47db6fedce6745f5bcd174c398f2acdda90a11c03 as final
+FROM node:20.17.0-alpine@sha256:2d07db07a2df6830718ae2a47db6fedce6745f5bcd174c398f2acdda90a11c03 AS final
 
 WORKDIR /app
 COPY --chown=node:node --from=builder /app/package*.json ./
 COPY --chown=node:node --from=builder /app/node_modules/ node_modules
 COPY --chown=node:node --from=builder /app/dist/ dist
 
-ENV NODE_ENV "production"
-ENV PORT 3000
+ENV NODE_ENV="production"
+ENV PORT=3000
 
 EXPOSE $PORT
 USER node


### PR DESCRIPTION
## What

BAU: refactor to remove sandpit.Dockerfile build warning messages

Removes following warnings:
FromAsCasing - FROM and as casing do not match
LegacyKeyValueFormat - ENV key=value format should be used instead of legacy ENV key value

## How to review

Compare the docker build output by running `./deploy-authdevs.sh -b` between main and this branch