### PR TITLE
ATO-1435: Pass new claims to auth backend.

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -74,6 +74,13 @@ export function authorizeGet(
         previous_govuk_signin_journey_id:
           claims.previous_govuk_signin_journey_id,
         reauthenticate: claims.reauthenticate,
+        cookie_consent: claims.cookie_consent,
+        _ga: claims._ga,
+        vtr_list: claims.vtr_list,
+        client_id: claims.client_id,
+        scope: claims.scope,
+        redirect_uri: claims.redirect_uri,
+        state: claims.state,
       }
     );
 

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -72,5 +72,13 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   )
     body["previous-govuk-signin-journey-id"] =
       startRequestParameters.previous_govuk_signin_journey_id;
+  body["cookie_consent"] = startRequestParameters.cookie_consent;
+  if (startRequestParameters._ga !== undefined)
+    body["_ga"] = startRequestParameters._ga;
+  body["vtr_list"] = startRequestParameters.vtr_list;
+  body["client_id"] = startRequestParameters.client_id;
+  body["scope"] = startRequestParameters.scope;
+  body["redirect_uri"] = startRequestParameters.redirect_uri;
+  body["state"] = startRequestParameters.state;
   return body;
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -49,6 +49,10 @@ export type Claims = {
   channel?: string;
   authenticated: boolean;
   current_credential_strength?: string;
+  cookie_consent: string;
+  _ga?: string;
+  vtr_list: string;
+  scope: string;
 };
 
 export const requiredClaimsKeys = [
@@ -69,4 +73,7 @@ export const requiredClaimsKeys = [
   "redirect_uri",
   "rp_sector_host",
   "authenticated",
+  "cookie_consent",
+  "vtr_list",
+  "scope",
 ];

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -47,6 +47,12 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
+      cookie_consent: "accept",
+      vtr_list: "[Cl.Cm]",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -55,6 +61,12 @@ describe("authorize service", () => {
         {
           "rp-pairwise-id-for-reauth": "123456",
           authenticated: isAuthenticated,
+          cookie_consent: "accept",
+          vtr_list: "[Cl.Cm]",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -72,12 +84,26 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
+      cookie_consent: "accept",
+      vtr_list: "[Cl.Cm]",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { authenticated: isAuthenticated },
+        {
+          authenticated: isAuthenticated,
+          cookie_consent: "accept",
+          vtr_list: "[Cl.Cm]",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+        },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
@@ -90,12 +116,26 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
+      cookie_consent: "accept",
+      vtr_list: "[Cl.Cm]",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { authenticated: isAuthenticated },
+        {
+          authenticated: isAuthenticated,
+          cookie_consent: "accept",
+          vtr_list: "[Cl.Cm]",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+        },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
@@ -111,6 +151,12 @@ describe("authorize service", () => {
       current_credential_strength: undefined,
       reauthenticate: undefined,
       previous_session_id: previousSessionId,
+      cookie_consent: "accept",
+      vtr_list: "[Cl.Cm]",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -119,6 +165,12 @@ describe("authorize service", () => {
         {
           "previous-session-id": previousSessionId,
           authenticated: isAuthenticated,
+          cookie_consent: "accept",
+          vtr_list: "[Cl.Cm]",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -138,6 +190,12 @@ describe("authorize service", () => {
       reauthenticate: "123456",
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
+      cookie_consent: "accept",
+      vtr_list: "[Cl.Cm]",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -147,6 +205,12 @@ describe("authorize service", () => {
           "rp-pairwise-id-for-reauth": "123456",
           "previous-govuk-signin-journey-id": "previous-journey-id",
           authenticated: isAuthenticated,
+          cookie_consent: "accept",
+          vtr_list: "[Cl.Cm]",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -167,6 +231,13 @@ describe("authorize service", () => {
       reauthenticate: undefined,
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
+      cookie_consent: "accept",
+      vtr_list: "[Cl.Cm]",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
+      _ga: "987654321",
     });
 
     expect(
@@ -176,6 +247,13 @@ describe("authorize service", () => {
           "current-credential-strength": currentCredentialStrength,
           "previous-govuk-signin-journey-id": "previous-journey-id",
           authenticated: isAuthenticated,
+          cookie_consent: "accept",
+          vtr_list: "[Cl.Cm]",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+          _ga: "987654321",
         },
         {
           headers: {

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -31,6 +31,9 @@ export function createMockClaims(): Claims {
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
     authenticated: false,
     current_credential_strength: "MEDIUM_LEVEL",
+    cookie_consent: "accept",
+    vtr_list: "[Cl.Cm]",
+    scope: "openid",
   };
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -9,6 +9,13 @@ export interface StartRequestParameters {
   rp_pairwise_id_for_reauth?: string;
   previous_govuk_signin_journey_id?: string;
   reauthenticate?: string;
+  cookie_consent: string;
+  _ga?: string;
+  vtr_list: string;
+  client_id: string;
+  scope: string;
+  redirect_uri: string;
+  state: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

Now we are passing new fields from orch to the auth frontend, we would like to pass these fields to the auth backend, to avoid having to use the client session authRequestParams field. 
## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change. n/a
- [x] A UCD review has been performed. n/a
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. n/a 
- [x] Documentation has been updated to reflect these changes. n/a