### PR TITLE
AUT-4166: add device intelligence cookie to cookies list

### DIFF
--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -216,6 +216,16 @@
                     text: 'pages.cookiePolicy.essential.info.table.rows.row14.col2' | translate,
                     classes: 'govuk-body-s'
                 }
+            ],
+            [
+                {
+                    text: "di-device-intelligence",
+                    classes: 'govuk-body-s'
+                },
+                {
+                    text: 'pages.cookiePolicy.essential.info.table.rows.row15.col2' | translate,
+                    classes: 'govuk-body-s'
+                }
             ]
         ]
     }) }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -830,6 +830,9 @@
               },
               "row14": {
                 "col2": "Pan fyddwch yn cau eich porwr gwe"
+              },
+              "row15": {
+                "col2": "Pan fyddwch yn cau eich porwr gwe"
               }
             }
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -830,6 +830,9 @@
               },
               "row14": {
                 "col2": "When you close your web browser"
+              },
+              "row15": {
+                "col2": "When you close your web browser"
               }
             }
           }


### PR DESCRIPTION
## What

Added di-device-intelligence to list of cookies.

## How to review

1. Code Review
2. Go to /cookies and see 'di-device-intelligence - When you close your web browser' added to cookies list

**English**
<img width="730" alt="Screenshot 2025-03-21 at 14 19 57" src="https://github.com/user-attachments/assets/e58f1629-d28e-4deb-8550-e988ed9bf165" />

**Welsh**
<img width="704" alt="Screenshot 2025-03-21 at 14 20 12" src="https://github.com/user-attachments/assets/960f012f-f433-4f11-8e99-5376c770d06e" />
 





## Checklist

- [ ] A UCD review has been performed.




