### PR TITLE
ATO-1435: Pass new claims to auth backend.

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -62,6 +62,7 @@ export function authorizeGet(
       throw new BadRequestError(error.message);
     }
 
+    logger.info("VTR list  is: %s", claims.vtr);
     const startAuthResponse = await authService.start(
       sessionId,
       clientSessionId,
@@ -74,6 +75,13 @@ export function authorizeGet(
         previous_govuk_signin_journey_id:
           claims.previous_govuk_signin_journey_id,
         reauthenticate: claims.reauthenticate,
+        cookie_consent: claims.cookie_consent,
+        _ga: claims._ga,
+        vtr: claims.vtr,
+        scope: claims.scope,
+        client_id: claims.rp_client_id,
+        redirect_uri: claims.rp_redirect_uri,
+        state: claims.rp_state,
       }
     );
 

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -72,5 +72,14 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   )
     body["previous-govuk-signin-journey-id"] =
       startRequestParameters.previous_govuk_signin_journey_id;
+  if (startRequestParameters.cookie_consent !== undefined)
+    body["cookie_consent"] = startRequestParameters.cookie_consent;
+  if (startRequestParameters._ga !== undefined)
+    body["_ga"] = startRequestParameters._ga;
+  body["vtr"] = startRequestParameters.vtr;
+  body["client_id"] = startRequestParameters.client_id;
+  body["scope"] = startRequestParameters.scope;
+  body["redirect_uri"] = startRequestParameters.redirect_uri;
+  body["state"] = startRequestParameters.state;
   return body;
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -42,6 +42,7 @@ export type Claims = {
   rp_sector_host: string;
   rp_redirect_uri: string;
   rp_state: string;
+  rp_client_id: string;
   reauthenticate?: string;
   claim?: string;
   previous_session_id?: string;
@@ -49,6 +50,10 @@ export type Claims = {
   channel?: string;
   authenticated: boolean;
   current_credential_strength?: string;
+  cookie_consent?: string;
+  _ga?: string;
+  vtr: string[];
+  scope: string;
 };
 
 export const requiredClaimsKeys = [
@@ -69,4 +74,6 @@ export const requiredClaimsKeys = [
   "redirect_uri",
   "rp_sector_host",
   "authenticated",
+  "vtr",
+  "scope",
 ];

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -47,6 +47,11 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -55,6 +60,11 @@ describe("authorize service", () => {
         {
           "rp-pairwise-id-for-reauth": "123456",
           authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -72,12 +82,24 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { authenticated: isAuthenticated },
+        {
+          authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+        },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
@@ -90,12 +112,24 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { authenticated: isAuthenticated },
+        {
+          authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+        },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
@@ -111,6 +145,11 @@ describe("authorize service", () => {
       current_credential_strength: undefined,
       reauthenticate: undefined,
       previous_session_id: previousSessionId,
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -119,6 +158,11 @@ describe("authorize service", () => {
         {
           "previous-session-id": previousSessionId,
           authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -138,6 +182,11 @@ describe("authorize service", () => {
       reauthenticate: "123456",
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -147,6 +196,11 @@ describe("authorize service", () => {
           "rp-pairwise-id-for-reauth": "123456",
           "previous-govuk-signin-journey-id": "previous-journey-id",
           authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -167,6 +221,11 @@ describe("authorize service", () => {
       reauthenticate: undefined,
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -176,11 +235,85 @@ describe("authorize service", () => {
           "current-credential-strength": currentCredentialStrength,
           "previous-govuk-signin-journey-id": "previous-journey-id",
           authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,
           },
+          proxy: false,
+        }
+      )
+    ).to.be.true;
+  });
+
+  it("sends a request with optional parameters when present in start request", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "0";
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: "123456",
+      vtr: ["Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
+      cookie_consent: "accept",
+      _ga: "987654321",
+    });
+
+    expect(
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {
+          authenticated: isAuthenticated,
+          vtr: ["Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+          cookie_consent: "accept",
+          _ga: "987654321",
+        },
+        {
+          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
+          proxy: false,
+        }
+      )
+    ).to.be.true;
+  });
+  it("sends a request with multiple vtrs in list in start request", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "0";
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: "123456",
+      vtr: ["Cl.Cm", "P0.Cl.Cm"],
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
+      cookie_consent: "accept",
+      _ga: "987654321",
+    });
+
+    expect(
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {
+          authenticated: isAuthenticated,
+          vtr: ["Cl.Cm", "P0.Cl.Cm"],
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+          cookie_consent: "accept",
+          _ga: "987654321",
+        },
+        {
+          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
         }
       )

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -11,6 +11,7 @@ export function createMockClaims(): Claims {
     confidence: "Cl.Cm",
     iss: "UNKNOWN",
     client_id: getOrchToAuthExpectedClientId(),
+    rp_client_id: "test-rp-client-id",
     govuk_signin_journey_id: "QOFzoB3o-9gGplMgdT1dJfH4vaI",
     aud: getOrchToAuthExpectedAudience(),
     service_type: "MANDATORY",
@@ -31,6 +32,8 @@ export function createMockClaims(): Claims {
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
     authenticated: false,
     current_credential_strength: "MEDIUM_LEVEL",
+    vtr: ["Cl.Cm"],
+    scope: "openid",
   };
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -9,6 +9,13 @@ export interface StartRequestParameters {
   rp_pairwise_id_for_reauth?: string;
   previous_govuk_signin_journey_id?: string;
   reauthenticate?: string;
+  cookie_consent?: string;
+  _ga?: string;
+  vtr: string[];
+  client_id: string;
+  scope: string;
+  redirect_uri: string;
+  state: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
Reopening this PR as it had to be reverted - I forgot that `cookie_consent` was an optional field in orch, but was set in the requiredClaims in auth frontend.

## What

Now we are passing new fields from orch to the auth frontend, we would like to pass these fields to the auth backend, to avoid having to use the client session authRequestParams field. 

Also added tests to ensure we only pass optional parameters to the backend when they are sent to frontend by orch
## How to review

1. Code Review

Deployed to sandpit with all other PRs, verified that the claims that are passed from orch to auth backend were in sync with the client session auth request

## Checklist

- [x] Performance analyst has been notified of the change. n/a
- [x] A UCD review has been performed. n/a
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. n/a 
- [x] Documentation has been updated to reflect these changes. n/a