### PR TITLE
AUT-3991: bump and lockdown ecs canary nested stack to v2.1.2

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -1674,7 +1674,7 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
     Properties:
-      TemplateURL: https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=5RRU1nfKQD_d08FKttr8W7pzrAsqQiUM # v2.1.1
+      TemplateURL: https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=gVRaSSPqy7XFvDtOB3PL0XPh4GUfrlTi # v2.1.2
       Parameters:
         VpcId: !Sub ${VpcStackName}-VpcId
         Subnets: !Join


### PR DESCRIPTION
## What

Bump and lockdown ecs canary nested stack to v2.1.2
**Phase 1 dependency**: pipelines are updated with the changes https://github.com/govuk-one-login/authentication-infrastructure/pull/59/files

[AUT-3991]

## How to review

Verify that the changes are as prescribed in the [step 6 of the deployment guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance#Step-6%3A-Deploy-newly-added-resources)


[AUT-3991]: https://govukverify.atlassian.net/browse/AUT-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ