### PR TITLE
AUT-3991: switchover to ECS Canary CodeDeploy

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -307,6 +307,7 @@ Mappings:
       migratedDomain: signin.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
       UseRouteUsersToNewIpvJourney: "Yes"
+      ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -388,6 +389,7 @@ Mappings:
       migratedDomain: signin.integration.account.gov.uk
       UseMfaResetWithIpv: "Yes"
       UseRouteUsersToNewIpvJourney: "Yes"
+      ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
     production:


### PR DESCRIPTION
## What

This change triggers the first canary deployment via CodeDeploy

This is dependent on https://github.com/govuk-one-login/authentication-frontend/pull/2681 released in the environment first

[AUT-3991]

## How to review

Verify that the changes are as prescribed in the [step 8 of the deployment guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance#Step-8%3A-Trigger-first-Canary-deployment)

[AUT-3991]: https://govukverify.atlassian.net/browse/AUT-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ