### PR TITLE
BAU: update es-lint to 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@aws-sdk/client-kms": "^3.366.0",
     "@aws-sdk/client-ssm": "^3.366.0",
-    "@eslint/eslintrc": "^3.1.0",
+    "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.14.0",
     "@govuk-one-login/frontend-analytics": "3.1.0",
     "@govuk-one-login/frontend-language-toggle": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,10 +832,25 @@
   dependencies:
     "@types/json-schema" "^7.0.15"
 
-"@eslint/eslintrc@^3.1.0", "@eslint/eslintrc@^3.3.0":
+"@eslint/eslintrc@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.0.tgz#96a558f45842989cca7ea1ecd785ad5491193846"
   integrity sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^10.0.1"
+    globals "^14.0.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@eslint/eslintrc@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.1.tgz#e55f7f1dd400600dd066dbba349c4c0bac916964"
+  integrity sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"


### PR DESCRIPTION
## What

BAU: update es-lint to 3.3.1

This is really just to trigger a deployment for canary rollout.

## How to review

1. Code Review
1. Test locally

