### PR TITLE
AUT-3991: switchever to ECS canary in production

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -420,6 +420,7 @@ Mappings:
       migratedDomain: signin.account.gov.uk
       UseMfaResetWithIpv: "Yes"
       UseRouteUsersToNewIpvJourney: "Yes"
+      ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
 


### PR DESCRIPTION
## What

This change triggers the first canary deployment via CodeDeploy in production

This is dependent on
1. https://github.com/govuk-one-login/authentication-frontend/pull/2681 released in the environment first
2. production frontend pipeline updated with changes in https://github.com/govuk-one-login/authentication-infrastructure/pull/59

[AUT-3991]

## How to review

Verify that the changes are as prescribed in the [step 8 of the deployment guide](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance#Step-8%3A-Trigger-first-Canary-deployment)

[AUT-3991]: https://govukverify.atlassian.net/browse/AUT-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ