### PR TITLE
AUT-4178: PART II - Detect when session not restored from the database

### DIFF
--- a/src/components/ipv-callback/tests/cross-browser-middleware.test.ts
+++ b/src/components/ipv-callback/tests/cross-browser-middleware.test.ts
@@ -57,6 +57,7 @@ describe("CrossBrowserMiddleware", () => {
     req.session.id = sessionId;
     req.cookies.gs = sessionId + clientSessionId;
     req.cookies.aps = sessionId;
+    req.session.sessionRestored = true;
 
     await crossBrowserMiddleware(mockCrossBrowserService(true))(req, res, next);
 

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -56,7 +56,12 @@ export function getSessionIdMiddleware(
 }
 
 export function sessionIsValid(req: Request): boolean {
-  return !!(req.cookies?.gs && req.cookies?.aps && req.session?.id);
+  return !!(
+    req.cookies?.gs &&
+    req.cookies?.aps &&
+    req.session?.id &&
+    req.session?.sessionRestored
+  );
 }
 
 export function validateSessionMiddleware(

--- a/src/middleware/tests/session-middleware.test.ts
+++ b/src/middleware/tests/session-middleware.test.ts
@@ -71,6 +71,7 @@ describe("session-middleware", () => {
       req = {
         session: {
           id: "session-id",
+          sessionRestored: true,
         },
         cookies: {
           gs: "gs-cookie",
@@ -157,6 +158,7 @@ describe("session-middleware", () => {
     it("should call next if all required session properties are present", () => {
       req.cookies.gs = "gs-cookie";
       req.cookies.aps = "aps-cookie";
+      req.session.sessionRestored = true;
 
       validateSessionMiddleware(req, res, next);
 
@@ -178,6 +180,18 @@ describe("session-middleware", () => {
 
     it("should destroy session and call next with error if aps cookie is missing", () => {
       req.cookies.gs = "gs-cookie";
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(req.session.destroy).to.have.been.calledOnce;
+      expect(res.status).to.have.been.calledOnceWith(401);
+      expect(next).to.have.been.calledOnce;
+      expect(next.args[0][0]).to.be.an("error");
+    });
+
+    it("should destroy session and call next with error if sessionRestored is missing", () => {
+      req.cookies.gs = "gs-cookie";
+      req.cookies.aps = "aps-cookie";
 
       validateSessionMiddleware(req, res, next);
 


### PR DESCRIPTION
## What

Use the new 'sessionRestored' flag in the session and set this to 'true when the session is first initialised. Check that this field exists for the session to be vaild in 'sessionIsValid' If the database ttl expires (despite the aps cookie still being available) then this field will be undefined, indicating that the session has not been restored from the database.  In this case the session expired page is displayed to users as the session has actually expired.

Temporary fix for an issue where the aps cookie expiry time is extended in a rolling manner, whereas the corresponding ttl for the Redis session item is not, which results in errors.

The reason this works (given that in theory every journey that goes through /authenticate will have the flag set to true) is because on any subsequent page if there is actually no backing session item in the database then none of the fields in the session object are restored, so the session validity check will fail.  This is demonstrated by the logs for the issue we are seeing, for [example](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?q=search%20index%3D%22gds_di_production%22%20(source%3D%22GOV.UK_PaaS%3A*%3Agds-digital-identity-authentication*%22%20OR%20source%3D%22*%3A%2Fecs%2F*%22)%20source%3D%22*production*%22%20(source%3D%22*authentication-frontend%22%20OR%20source%3D%22*frontend-application*%22)%20msg%3D%22Error*%22%20msg!%3D%22Error%20code%20undefined%20was%20falsy%22%20%20msg%3D%22Error%3ACannot%20read%20properties%20of%20undefined%20(reading%20%27toLowerCase%27)%22&earliest=1743670800.000&latest=1743671400&sid=1743675070.41841&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=) where the email field in the session is undefined:
 
`TypeError: Cannot read properties of undefined (reading 'toLowerCase')`

An alternative fix would be to just rely on a known missing field such as email in order to check session validity, but a new field has been created specifically for this purpose because (1) it's meaning is clearer (2) there are at least two different flavours of this issue on different fields in the session (email and journey).

## How to review

1. Code Review
2. Reproduce the existing issue
3. Test the fix

### Reproduce the original issue.  

A silent login needs to happen before the aps cookie has expired, but after the redis ttl has expired so that there is no backing session in the database.

1. Reduce the session timeout to 90s by updating session expiry to 90000 in a dev env

- /deploy/authdev2/session_expiry
- /deploy/authdev1/session_expiry
- /deploy/dev/session_expiry

1. Deploy to a dev environment
1. Start to sign in using the orchstub
1. On the 'sign in or create page' open up cookies and note the expiry time for the 'aps' cookie.  This is when the session in Redis should expire.
1. Continue to sign in so you're returned to the orch stub.
1. Wait 30s then start again and sign in again as 'Authenticated' to reprodce a silent login.
1. Repeat this process to silent login until you see an error page.  This might not be exactly at the noted expiry time, but should be soon after.
1. Note the error page seen.  It should be the generic error page not the session timeout page.

<img width="495" alt="Screenshot 2025-04-02 at 16 26 03" src="https://github.com/user-attachments/assets/7b10856d-31bb-4165-9e8a-1b47bb4443e4" />


### Deploy the fix then repeat the test scenario above.

You should see the session timeout page rather than an error page.

<img width="472" alt="Screenshot 2025-04-02 at 16 20 24" src="https://github.com/user-attachments/assets/a566c737-a2a9-4518-9fe9-8a787efda66c" />

## Related PRs

#2705 

https://onelogingovuk.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D895e79cf83e4ea50510344547daad3c9%26sysparm_stack%3D%26sysparm_view%3D

