### PR TITLE
AUT-4178: PART I - Add new sessionRestored flag and initialise

### DIFF
--- a/@types/express-session/index.d.ts
+++ b/@types/express-session/index.d.ts
@@ -7,5 +7,6 @@ declare module "express-session" {
   interface SessionData {
     user: UserSession;
     client: UserSessionClient;
+    sessionRestored?: boolean;
   }
 }

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -29,6 +29,8 @@ export function initialiseSessionMiddleware(
       redactedPhoneNumber: redactedPhoneNumber,
       phoneNumber: phoneNumber,
     };
+
+    req.session.sessionRestored = true;
   }
 
   next();


### PR DESCRIPTION


## What

Part I of a two part change.  This change needs to spend at least an hour in prod before the second part arrives.

Adds a new 'sessionRestored' flag and initialises it when /authenticate is called, which is the front door for all journeys in to Authentication. A subsequent change will use this flag to determine if the session has actually been restored from the Redis database.

See 9396e656b6d423ce4c4f66faad09a9294acf17e9

## How to review

1. Code Review
1. Deploy to an environment and test a journey.

## Related PRs

#2701 

https://onelogingovuk.service-now.com/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3D895e79cf83e4ea50510344547daad3c9%26sysparm_stack%3D%26sysparm_view%3D