### PR TITLE
BAU: enable FMS WAF on sandpit legacy CloudFront Frontend

### DIFF
--- a/ci/terraform/cloudfront.tf
+++ b/ci/terraform/cloudfront.tf
@@ -8,7 +8,6 @@ resource "aws_cloudformation_stack" "cloudfront" {
   parameters = {
     AddWWWPrefix                 = var.Add_WWWPrefix
     CloudFrontCertArn            = aws_acm_certificate.cloudfront_frontend_certificate.arn
-    CloudFrontWafACL             = aws_wafv2_web_acl.frontend_cloudfront_waf_web_acl.arn
     DistributionAlias            = local.frontend_fqdn
     FraudHeaderEnabled           = var.Fraud_Header_Enabled
     OriginCloakingHeader         = var.auth_origin_cloakingheader
@@ -22,6 +21,15 @@ resource "aws_cloudformation_stack" "cloudfront" {
   lifecycle {
     ignore_changes = [parameters["OriginCloakingHeader"], parameters["PreviousOriginCloakingHeader"]]
   }
+
+
+  tags = (
+    var.environment == "sandpit" ?
+    {
+      "FMSGlobalCustomPolicy"     = "true"
+      "FMSGlobalCustomPolicyName" = "frontend"
+    } : {}
+  )
 
 }
 

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -85,7 +85,7 @@ if [[ $BUILD == "1" ]]; then
     echo "Digest = ${IMAGE_DIGEST}"
     echo "Complete"
 else
-    docker pull "${REPO_URL}:${IMAGE_TAG}"
+    docker pull --platform=linux/amd64 "${REPO_URL}:${IMAGE_TAG}"
     IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
 fi
 

--- a/scripts/dev_deploy_common.sh
+++ b/scripts/dev_deploy_common.sh
@@ -85,6 +85,9 @@ if [[ $BUILD == "1" ]]; then
     echo "Digest = ${IMAGE_DIGEST}"
     echo "Complete"
 else
+    # Adding --platform=linux/amd64 to ensure the image is pulled for the correct architecture
+    # This is required for the buildx build command to work on M1 Macs
+    echo "Pulling image..."
     docker pull --platform=linux/amd64 "${REPO_URL}:${IMAGE_TAG}"
     IMAGE_DIGEST="$(docker inspect "${REPO_URL}:${IMAGE_TAG}" | jq -r '.[0].RepoDigests[0] | split("@") | .[1]')"
 fi


### PR DESCRIPTION
## What

BAU: enable FMS WAF on sandpit legacy CloudFront Frontend

Note : terraform in frontend is only used in sandpit, other env are migrated to secure pipeline 

## How to review

For example:
code review 

