### PR TITLE
AUT-4203: Remove opens in new tab text on enter email create screen for app users

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -53,7 +53,9 @@ export function enterEmailGet(req: Request, res: Response): void {
 }
 
 export function enterEmailCreateGet(req: Request, res: Response): void {
-  return res.render("enter-email/index-create-account.njk");
+  return res.render("enter-email/index-create-account.njk", {
+    strategicAppChannel: res.locals.strategicAppChannel,
+  });
 }
 
 export function enterEmailPost(

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -35,9 +35,18 @@
 <h2 class="govuk-heading-s">{{'pages.createPassword.termsOfUse.heading' | translate}}</h2>
 
 <p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph1' | translate}}</p>
+
+{% if strategicAppChannel %}
+  {% set bullet1LinkText = 'pages.createPassword.termsOfUse.bullet1LinkTextApp' %}
+  {% set bullet2LinkText = 'pages.createPassword.termsOfUse.bullet2LinkTextApp' %}
+{% else %}
+  {% set bullet1LinkText = 'pages.createPassword.termsOfUse.bullet1LinkText' %}
+  {% set bullet2LinkText = 'pages.createPassword.termsOfUse.bullet2LinkText' %}
+{% endif %}
+
 <ul class="govuk-list govuk-list--bullet">
-  <li><a href="{{'pages.createPassword.termsOfUse.bullet1LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet1LinkText'| translate}}</a>{{'pages.createPassword.termsOfUse.bullet1Text'| translate}}</li>
-  <li><a href="{{'pages.createPassword.termsOfUse.bullet2LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet2LinkText'| translate}}</a></li>
+    <li><a href="{{'pages.createPassword.termsOfUse.bullet1LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ bullet1LinkText | translate}}</a>{{'pages.createPassword.termsOfUse.bullet1Text'| translate}}</li>
+    <li><a href="{{'pages.createPassword.termsOfUse.bullet2LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ bullet2LinkText | translate}}</a></li>
 </ul>
 
 {{ govukButton({

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -50,14 +50,19 @@ describe("enter email controller", () => {
       req.session.user = { email };
     });
 
-    it("should render enter email create account view when user selected create account", () => {
-      req.query.type = JOURNEY_TYPE.CREATE_ACCOUNT;
+    it("should render enter email create account view with the strategic app channel passed through when user selected create account", () => {
+      const STRATEGIC_APP_VALUES = [true, false];
+      STRATEGIC_APP_VALUES.forEach((strategicAppChannel) => {
+        res.locals.strategicAppChannel = strategicAppChannel;
+        req.query.type = JOURNEY_TYPE.CREATE_ACCOUNT;
 
-      enterEmailCreateGet(req as Request, res as Response);
+        enterEmailCreateGet(req as Request, res as Response);
 
-      expect(res.render).to.have.calledWith(
-        "enter-email/index-create-account.njk"
-      );
+        expect(res.render).to.have.calledWith(
+          "enter-email/index-create-account.njk",
+          { strategicAppChannel: strategicAppChannel }
+        );
+      });
     });
 
     it("should render enter email view when supportReauthentication flag is switched off", async () => {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -446,9 +446,11 @@
         "heading": "Cytuno i delerau defnyddio GOV.UK One Login",
         "paragraph1": "Drwy barhau, rydych yn cadarnhau eich bod yn cytuno i’n:",
         "bullet1LinkText": "hysbysiad preifatrwydd (agor mewn tab newydd)",
+        "bullet1LinkTextApp": "hysbysiad preifatrwydd",
         "bullet1Text": ", sy’n egluro sut rydym yn defnyddio eich gwybodaeth bersonol",
         "bullet1LinkHref": "/privacy-notice",
         "bullet2LinkText": "telerau ac amodau (agor mewn tab newydd)",
+        "bullet2LinkTextApp": "telerau ac amodau",
         "bullet2LinkHref": "/terms-and-conditions"
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -446,9 +446,11 @@
         "heading": "Agree to the GOV.UK One Login terms of use",
         "paragraph1": "By continuing, you confirm that you agree to our:",
         "bullet1LinkText": "privacy notice (opens in a new tab)",
+        "bullet1LinkTextApp": "privacy notice",
         "bullet1Text": ", which explains how we use your personal information",
         "bullet1LinkHref": "/privacy-notice",
         "bullet2LinkText": "terms and conditions (opens in a new tab)",
+        "bullet2LinkTextApp": "terms and conditions",
         "bullet2LinkHref": "/terms-and-conditions"
       }
     },


### PR DESCRIPTION
We are going to enable app users to create accounts. This is a small tweak in preparation for that, since for app users these links will not open on a new tab

## How to review

1. Code Review
1. This is harder to see locally since we haven't yet enabled strategic app create journeys, so I've been manually setting the res.locals.strategicAppChannel to true in the `enterEmailCreateGet` function as a way to check the text that appears in a strategic app journey.

## Screenshots

| | English | Welsh |
|---|---|---|
| How the create account screen appears for web users (no change to current) |<img width="732" alt="Screenshot 2025-04-04 at 15 47 19" src="https://github.com/user-attachments/assets/a3cd4e64-7053-4744-9731-9d0c6c5d96de" />|<img width="731" alt="Screenshot 2025-04-04 at 15 47 30" src="https://github.com/user-attachments/assets/a0ca5e2e-293a-4d74-94cd-5b8fba7026a4" />|
| How the create account screen now appears for strategic app users as a result of this PR |<img width="735" alt="Screenshot 2025-04-04 at 15 46 37" src="https://github.com/user-attachments/assets/94457c6d-f7de-4e47-ae33-23755be3e840" />|<img width="730" alt="Screenshot 2025-04-04 at 15 46 43" src="https://github.com/user-attachments/assets/43a69caa-24d3-4936-9104-491570f29a62" />|

