### PR TITLE
AUT-4178: Check required session field 'email' when calling auth-code

### DIFF
--- a/src/components/auth-code/auth-code-routes.ts
+++ b/src/components/auth-code/auth-code-routes.ts
@@ -1,7 +1,10 @@
 import { PATH_NAMES } from "../../app.constants";
 
 import * as express from "express";
-import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import {
+  requiredSessionFieldsMiddleware,
+  validateSessionMiddleware,
+} from "../../middleware/session-middleware";
 import { authCodeGet } from "./auth-code-controller";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { asyncHandler } from "../../utils/async";
@@ -12,6 +15,7 @@ const router = express.Router();
 router.get(
   PATH_NAMES.AUTH_CODE,
   validateSessionMiddleware,
+  requiredSessionFieldsMiddleware,
   allowUserJourneyMiddleware,
   asyncHandler(accountInterventionsMiddleware(false, true, true)),
   asyncHandler(authCodeGet())


### PR DESCRIPTION
## What

Check that the 'email' field is present on the session before handing over to the 'auth-code' route.  If the email is not present then route to the standard session error page.

Fixes a second issue where the frontend session in the Redis datastore expires after 1hr, whereas the frontend session cookie (aps) is rolling and can last longer after being extended on each silent login.

The issue manifests in the logs as

`TypeError: Cannot read properties of undefined (reading 'toLowerCase')
    at /app/dist/middleware/account-interventions-middleware.js:13:50`

The first issue was resolved by #2705, but that change did not resolve this second issue.

### Why the issue happens

- The frontend session in the Redis datastore will always expire after 1hr regardless of any silent logins (issue to be resolved later)
- The frontend session cookie (aps) has its expiry time extended on every silent login so there is a mismatch between the cookie expiry and the datastore ttl
- If a silent login takes place when the datastore item has disappeared then the frontend session will not be correctly restored to what it was before and some fields will (obviously) be missing
- This issue is caused by the 'email' field not being set in the session.  You can see why [here](https://github.com/govuk-one-login/authentication-frontend/blob/ad4d9249ae3dc00826fa0f50881869bc545c2cdd/src/middleware/session-middleware.ts#L16), if email is not in the session then it is set to 'undefined.
- Email is only set on the session by enter-email-controller ([1](https://github.com/govuk-one-login/authentication-frontend/blob/ad4d9249ae3dc00826fa0f50881869bc545c2cdd/src/components/enter-email/enter-email-controller.ts#L68)) ([2](https://github.com/govuk-one-login/authentication-frontend/blob/ad4d9249ae3dc00826fa0f50881869bc545c2cdd/src/components/enter-email/enter-email-controller.ts#L156)), so if email is no longer on the session, or if a journey does not go through that page (such as silent login), then the email will not be populated and an error will happen on auth-code

### The fix

This is a temporary fix to display the standard session expired error page rather than a generic error page in this scenario as the session has actually expired.  Further work may be done to make the session rolling.

### Reproduce the original issue.  

A silent login needs to happen before the aps cookie has expired, but after the redis ttl has expired so that there is no backing session in the database.

1. Reduce the session timeout to 90s by updating session expiry to 90000 in a dev env

- /deploy/authdev2/session_expiry
- /deploy/authdev1/session_expiry
- /deploy/dev/session_expiry

1. Deploy to a dev environment
1. Start to sign in using the orchstub
1. On the 'sign in or create page' open up cookies and note the expiry time for the 'aps' cookie.  This is when the session in Redis should expire.
1. Continue to sign in so you're returned to the orch stub.
1. Wait 30s then start again and sign in again as 'Authenticated' to reprodce a silent login.
1. Repeat this process to silent login until you see an error page.  This might not be exactly at the noted expiry time, but should be soon after.
1. Note the error page seen.  It should be the session timeout page.

<img width="472" alt="Screenshot 2025-04-02 at 16 20 24" src="https://github.com/user-attachments/assets/a566c737-a2a9-4518-9fe9-8a787efda66c" />

1. Repeat again and do another silent login now that the session has expired.
1. Note the error page seen.  It should be the generic error page not the session timeout page.

<img width="495" alt="Screenshot 2025-04-02 at 16 26 03" src="https://github.com/user-attachments/assets/7b10856d-31bb-4165-9e8a-1b47bb4443e4" />

### Deploy the fix then repeat the test scenario above.

You should now see only the session timeout page rather than an error page.

Check the frontend logs to see that the following message has been printed:

`required session field 'email' is missing`

## Related PRs

#2705 
#2701 
