### PR TITLE
AUT-4179: Update `/account-not-found` strategic app page

### DIFF
--- a/src/components/account-not-found/index-mobile.njk
+++ b/src/components/account-not-found/index-mobile.njk
@@ -7,27 +7,38 @@
 
 {% block content %}
 
-    {% include "common/errors/errorSummary.njk" %}
+{% include "common/errors/errorSummary.njk" %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'mobileAppPages.accountNotFound.header' | translate }}</h1>
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'mobileAppPages.accountNotFound.header' | translate }}</h1>
+
+<form action="/account-not-found" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
     <p class="govuk-body">
         {{ 'mobileAppPages.accountNotFound.paragraph1' | translate }}
-        <span class="govuk-body govuk-!-font-weight-bold">{{ email }}</span>.
+        <span class="govuk-body govuk-!-font-weight-bold">{{ email }}</span>
     </p>
 
     <p class="govuk-body">{{ 'mobileAppPages.accountNotFound.paragraph2' | translate }}</p>
+
+    {{ govukInsetText({
+      text: 'pages.accountNotFoundMandatory.insetText1' | translate
+    }) }}
+
+    {{ govukButton({
+        "text": "pages.accountNotFoundMandatory.createAccountButtonText" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
 
     <p class="govuk-body">
         <a href="/enter-email" class="govuk-link"
            rel="noreferrer noopener">{{ 'mobileAppPages.accountNotFound.tryAnotherLinkText' | translate }}</a>
     </p>
 
-    <p class="govuk-body">
-        <a href="https://www.gov.uk/using-your-gov-uk-one-login" class="govuk-link"
-           rel="noreferrer noopener">{{ 'mobileAppPages.accountNotFound.findOutMoreLinkText' | translate }}</a>
-    </p>
+</form>
 
-    {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", loggedInStatus: false, dynamic: false } %}
-    {%- include "ga4-opl/template.njk" -%}
+{% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, taxonomyLevel1: "authentication", taxonomyLevel2: "sign in", loggedInStatus: false, dynamic: false } %}
+{%- include "ga4-opl/template.njk" -%}
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -214,9 +214,10 @@
       "title": "Nid oes gennych GOV.UK One Login",
       "header": "Nid oes gennych GOV.UK One Login",
       "paragraph1": "Nid oes GOV.UK One Login ar gyfer ",
-      "paragraph2": "Mae angen i chi fewngofnodi gyda chyfeiriad e-bost sydd â GOV.UK One Login i brofi eich hunaniaeth.",
-      "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",
-      "findOutMoreLinkText": "Darganfyddwch fwy am ddefnyddio GOV.UK One Login"
+      "paragraph2": "Bydd angen i chi greu GOV.UK One Login i ddefnyddio’r ap.",
+      "insetText1": "Ar hyn o bryd, mae cyfrifon ar wahân ar gyfer mewngofnodi i wahanol wasanaethau’r llywodraeth.",
+      "createAccountButtonText": "Creu GOV.UK One Login",
+      "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall"
     },
     "securityRequestsExceededExpired": {
       "info": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -214,9 +214,10 @@
       "title": "You do not have a GOV.UK One Login",
       "header": "You do not have a GOV.UK One Login",
       "paragraph1": "There is no GOV.UK One Login for ",
-      "paragraph2": "You need to sign in with an email address that has a GOV.UK One Login to prove your identity.",
-      "tryAnotherLinkText": "Try another email address",
-      "findOutMoreLinkText": "Find out more about using GOV.UK One Login"
+      "paragraph2": "You’ll need to create a GOV.UK One Login to use the app.",
+      "insetText1": "At the moment, there are separate accounts for signing in to different government services.",
+      "createAccountButtonText": "Create a GOV.UK One Login",
+      "tryAnotherLinkText": "Try another email address"
     },
     "securityRequestsExceededExpired": {
       "info": {


### PR DESCRIPTION
## What

Users will now be allowed to create accounts via the strategic app, so this exposes the account creation flow when a user tries to sign in with an account that does not yet exist.

Content is updated to match latest requirements and a form and button is introduced to initiate the existing account creation journey.

| Welsh | English |
| --- | --- |
| ![localhost_3000_account-not-found_lng=cy(iPhone 12 Pro)](https://github.com/user-attachments/assets/96d58e3c-deb9-4614-811c-539333e04e23) | ![localhost_3000_account-not-found_lng=en(iPhone 12 Pro)](https://github.com/user-attachments/assets/5adc9f64-2dcb-491b-ab5c-80451b26d309) |

## How to review

1. Code Review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.
