### PR TITLE
AUT-4150: Replace `asyncHandler` with `express-async-errors`

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "dompurify": "3.2.4",
     "ecdsa-sig-formatter": "1.0.11",
     "express": "4.21.2",
+    "express-async-errors": "3.1.1",
     "express-session": "1.18.1",
     "express-validator": "6.13.0",
     "globals": "16.0.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Application } from "express";
+import "express-async-errors";
 import cookieParser from "cookie-parser";
 import csurf from "csurf";
 import serveStatic from "serve-static";
@@ -100,7 +101,6 @@ import { Server } from "node:http";
 import { getAnalyticsPropertiesMiddleware } from "./middleware/get-analytics-properties-middleware";
 import { ipvCallbackRouter } from "./components/ipv-callback/ipv-callback-routes";
 import { mfaResetWithIpvRouter } from "./components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes";
-import { asyncHandler } from "./utils/async";
 import { environmentBannerMiddleware } from "./middleware/environment-banner-middleware";
 import UID from "uid-safe";
 
@@ -197,7 +197,7 @@ async function createApp(): Promise<express.Application> {
   );
   app.use(noCacheMiddleware);
   app.set("view engine", configureNunjucks(app, APP_VIEWS));
-  app.use(asyncHandler(setLocalVarsMiddleware));
+  app.use(setLocalVarsMiddleware);
   app.use(setGTM);
 
   await i18next
@@ -218,14 +218,12 @@ async function createApp(): Promise<express.Application> {
   // Generate a new session ID asynchronously if no session cookie
   // `express-session` does not support async session ID generation
   // https://github.com/expressjs/session/issues/107
-  app.use(
-    asyncHandler(async (req, res, next) => {
-      if (!req.cookies?.[SESSION_COOKIE_NAME]) {
-        req.generatedSessionId = await UID(24);
-      }
-      next();
-    })
-  );
+  app.use(async (req, res, next) => {
+    if (!req.cookies?.[SESSION_COOKIE_NAME]) {
+      req.generatedSessionId = await UID(24);
+    }
+    next();
+  });
 
   app.use(
     session({

--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-routes.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-routes.ts
@@ -6,7 +6,6 @@ import {
   resendMfaCodeGet,
   resendMfaCodePost,
 } from "./resend-mfa-code-controller";
-import { asyncHandler } from "../../../utils/async";
 import { allowUserJourneyMiddleware } from "../../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -22,7 +21,7 @@ router.post(
   PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resendMfaCodePost())
+  resendMfaCodePost()
 );
 
 export { router as resendMfaCodeAccountCreationRouter };

--- a/src/components/account-not-found/account-not-found-routes.ts
+++ b/src/components/account-not-found/account-not-found-routes.ts
@@ -5,7 +5,6 @@ import {
   accountNotFoundPost,
 } from "./account-not-found-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -21,7 +20,7 @@ router.post(
   PATH_NAMES.ACCOUNT_NOT_FOUND,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountNotFoundPost())
+  accountNotFoundPost()
 );
 
 export { router as accountNotFoundRouter };

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-routes.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-routes.ts
@@ -7,7 +7,6 @@ import {
 } from "./change-security-codes-confirmation-controller";
 import { validateSessionMiddleware } from "../../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../../middleware/allow-user-journey-middleware";
-import { asyncHandler } from "../../../utils/async";
 
 const router = express.Router();
 
@@ -15,7 +14,7 @@ router.get(
   PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(changeSecurityCodesConfirmationGet())
+  changeSecurityCodesConfirmationGet()
 );
 
 router.post(

--- a/src/components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-routes.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-routes.ts
@@ -1,7 +1,6 @@
 import * as express from "express";
 import { PATH_NAMES } from "../../../app.constants";
 import { validateSessionMiddleware } from "../../../middleware/session-middleware";
-import { asyncHandler } from "../../../utils/async";
 import { checkAccountRecoveryPermitted } from "./check-account-recovery-middleware";
 import { sendEmailOtp } from "./send-email-otp-middleware";
 import {
@@ -18,7 +17,7 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   checkAccountRecoveryPermitted,
-  asyncHandler(sendEmailOtp()),
+  sendEmailOtp(),
   checkYourEmailSecurityCodesGet
 );
 
@@ -28,6 +27,6 @@ router.post(
   allowUserJourneyMiddleware,
   checkAccountRecoveryPermitted,
   validateCheckYourEmailRequest(),
-  asyncHandler(checkYourEmailSecurityCodesPost())
+  checkYourEmailSecurityCodesPost()
 );
 export { router as checkYourEmailSecurityCodesRouter };

--- a/src/components/auth-code/auth-code-routes.ts
+++ b/src/components/auth-code/auth-code-routes.ts
@@ -7,7 +7,6 @@ import {
 } from "../../middleware/session-middleware";
 import { authCodeGet } from "./auth-code-controller";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
-import { asyncHandler } from "../../utils/async";
 import { accountInterventionsMiddleware } from "../../middleware/account-interventions-middleware";
 
 const router = express.Router();
@@ -17,8 +16,8 @@ router.get(
   validateSessionMiddleware,
   requiredSessionFieldsMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware(false, true, true)),
-  asyncHandler(authCodeGet())
+  accountInterventionsMiddleware(false, true, true),
+  authCodeGet()
 );
 
 export { router as authCodeRouter };

--- a/src/components/authorize/authorize-routes.ts
+++ b/src/components/authorize/authorize-routes.ts
@@ -1,10 +1,9 @@
 import * as express from "express";
 import { authorizeGet } from "./authorize-controller";
-import { asyncHandler } from "../../utils/async";
 import { PATH_NAMES } from "../../app.constants";
 
 const router = express.Router();
 
-router.get(PATH_NAMES.AUTHORIZE, asyncHandler(authorizeGet()));
+router.get(PATH_NAMES.AUTHORIZE, authorizeGet());
 
 export { router as authorizeRouter };

--- a/src/components/check-your-email/check-your-email-routes.ts
+++ b/src/components/check-your-email/check-your-email-routes.ts
@@ -1,7 +1,6 @@
 import * as express from "express";
 import { PATH_NAMES } from "../../app.constants";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import {
   checkYourEmailGet,
   checkYourEmailPost,
@@ -23,7 +22,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateCheckYourEmailRequest(),
-  asyncHandler(checkYourEmailPost())
+  checkYourEmailPost()
 );
 
 export { router as checkYourEmailRouter };

--- a/src/components/check-your-phone/check-your-phone-routes.ts
+++ b/src/components/check-your-phone/check-your-phone-routes.ts
@@ -5,7 +5,6 @@ import {
   checkYourPhoneGet,
   checkYourPhonePost,
 } from "./check-your-phone-controller";
-import { asyncHandler } from "../../utils/async";
 import { validateSmsCodeRequest } from "./check-your-phone-validation";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
@@ -23,6 +22,6 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateSmsCodeRequest(),
-  asyncHandler(checkYourPhonePost())
+  checkYourPhonePost()
 );
 export { router as checkYourPhoneRouter };

--- a/src/components/contact-us/contact-us-routes.ts
+++ b/src/components/contact-us/contact-us-routes.ts
@@ -13,7 +13,6 @@ import {
 } from "./contact-us-controller";
 import { validateContactUsRequest } from "./contact-us-validation";
 import { validateContactUsQuestionsRequest } from "./contact-us-questions-validation";
-import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
@@ -40,7 +39,7 @@ router.get(PATH_NAMES.CONTACT_US_QUESTIONS, contactUsQuestionsGet);
 router.post(
   PATH_NAMES.CONTACT_US_QUESTIONS,
   validateContactUsQuestionsRequest(),
-  asyncHandler(contactUsQuestionsFormPostToSmartAgent())
+  contactUsQuestionsFormPostToSmartAgent()
 );
 
 router.get(PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS, contactUsSubmitSuccessGet);

--- a/src/components/create-password/create-password-routes.ts
+++ b/src/components/create-password/create-password-routes.ts
@@ -6,7 +6,6 @@ import {
   createPasswordPost,
 } from "./create-password-controller";
 import { validateCreatePasswordRequest } from "./create-password-validation";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -22,7 +21,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateCreatePasswordRequest(),
-  asyncHandler(createPasswordPost())
+  createPasswordPost()
 );
 
 export { router as createPasswordRouter };

--- a/src/components/doc-checking-app/doc-checking-app-routes.ts
+++ b/src/components/doc-checking-app/doc-checking-app-routes.ts
@@ -2,7 +2,6 @@ import { PATH_NAMES } from "../../app.constants";
 
 import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { docCheckingAppGet } from "./doc-checking-app-controller";
 
@@ -12,7 +11,7 @@ router.get(
   PATH_NAMES.DOC_CHECKING_APP,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(docCheckingAppGet())
+  docCheckingAppGet()
 );
 
 export { router as docCheckingAppRouter };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-routes.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-routes.ts
@@ -5,7 +5,6 @@ import {
   enterAuthenticatorAppCodeGet,
   enterAuthenticatorAppCodePost,
 } from "./enter-authenticator-app-code-controller";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { validateEnterAuthenticatorAppCodeRequest } from "./enter-authenticator-app-code-validation";
 
@@ -15,7 +14,7 @@ router.get(
   PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(enterAuthenticatorAppCodeGet())
+  enterAuthenticatorAppCodeGet()
 );
 
 router.post(
@@ -23,6 +22,6 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterAuthenticatorAppCodeRequest(),
-  asyncHandler(enterAuthenticatorAppCodePost())
+  enterAuthenticatorAppCodePost()
 );
 export { router as enterAuthenticatorAppCodeRouter };

--- a/src/components/enter-email/enter-email-routes.ts
+++ b/src/components/enter-email/enter-email-routes.ts
@@ -9,7 +9,6 @@ import {
 } from "./enter-email-controller";
 import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -38,7 +37,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterEmailRequest(),
-  asyncHandler(enterEmailPost())
+  enterEmailPost()
 );
 
 router.post(
@@ -46,7 +45,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterEmailRequest("enter-email/index-create-account.njk"),
-  asyncHandler(enterEmailCreatePost())
+  enterEmailCreatePost()
 );
 
 export { router as enterEmailRouter };

--- a/src/components/enter-mfa/enter-mfa-routes.ts
+++ b/src/components/enter-mfa/enter-mfa-routes.ts
@@ -2,7 +2,6 @@ import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { PATH_NAMES } from "../../app.constants";
 import express from "express";
 import { enterMfaGet, enterMfaPost } from "./enter-mfa-controller";
-import { asyncHandler } from "../../utils/async";
 import { validateEnterMfaRequest } from "./enter-mfa-validation";
 import {
   allowAndPersistUserJourneyMiddleware,
@@ -14,8 +13,8 @@ const router = express.Router();
 router.get(
   PATH_NAMES.ENTER_MFA,
   validateSessionMiddleware,
-  asyncHandler(allowAndPersistUserJourneyMiddleware),
-  asyncHandler(enterMfaGet())
+  allowAndPersistUserJourneyMiddleware,
+  enterMfaGet()
 );
 
 router.post(
@@ -23,6 +22,6 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterMfaRequest(),
-  asyncHandler(enterMfaPost())
+  enterMfaPost()
 );
 export { router as enterMfaRouter };

--- a/src/components/enter-password/enter-password-routes.ts
+++ b/src/components/enter-password/enter-password-routes.ts
@@ -13,7 +13,6 @@ import {
   validateEnterPasswordRequest,
 } from "./enter-password-validation";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -39,17 +38,14 @@ router.get(
   enterPasswordAccountLockedGet
 );
 
-router.get(
-  PATH_NAMES.SIGN_IN_RETRY_BLOCKED,
-  asyncHandler(enterSignInRetryBlockedGet())
-);
+router.get(PATH_NAMES.SIGN_IN_RETRY_BLOCKED, enterSignInRetryBlockedGet());
 
 router.post(
   PATH_NAMES.ENTER_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterPasswordRequest(),
-  asyncHandler(enterPasswordPost())
+  enterPasswordPost()
 );
 
 router.post(
@@ -57,7 +53,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterPasswordAccountExistsRequest(),
-  asyncHandler(enterPasswordPost(true))
+  enterPasswordPost(true)
 );
 
 export { router as enterPasswordRouter };

--- a/src/components/enter-phone-number/enter-phone-number-routes.ts
+++ b/src/components/enter-phone-number/enter-phone-number-routes.ts
@@ -6,7 +6,6 @@ import {
 } from "./enter-phone-number-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { validateEnterPhoneNumberRequest } from "./enter-phone-number-validation";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -23,7 +22,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateEnterPhoneNumberRequest(),
-  asyncHandler(enterPhoneNumberPost())
+  enterPhoneNumberPost()
 );
 
 export { router as enterPhoneNumberRouter };

--- a/src/components/ipv-callback/ipv-callback-routes.ts
+++ b/src/components/ipv-callback/ipv-callback-routes.ts
@@ -1,5 +1,4 @@
 import * as express from "express";
-import { asyncHandler } from "../../utils/async";
 import { PATH_NAMES } from "../../app.constants";
 import {
   cannotChangeSecurityCodesGet,
@@ -16,10 +15,10 @@ const router = express.Router();
 
 router.get(
   PATH_NAMES.IPV_CALLBACK,
-  asyncHandler(crossBrowserMiddleware(new CrossBrowserService())),
+  crossBrowserMiddleware(new CrossBrowserService()),
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(ipvCallbackGet())
+  ipvCallbackGet()
 );
 
 router.get(

--- a/src/components/landing/landing-route.ts
+++ b/src/components/landing/landing-route.ts
@@ -2,14 +2,9 @@ import * as express from "express";
 import { landingGet } from "./landing-controller";
 import { PATH_NAMES } from "../../app.constants";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
-router.get(
-  PATH_NAMES.ROOT,
-  validateSessionMiddleware,
-  asyncHandler(landingGet)
-);
+router.get(PATH_NAMES.ROOT, validateSessionMiddleware, landingGet);
 
 export { router as landingRouter };

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes.ts
@@ -2,7 +2,6 @@ import express from "express";
 import { PATH_NAMES } from "../../app.constants";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
-import { asyncHandler } from "../../utils/async";
 import {
   mfaResetOpenInBrowserGet,
   mfaResetWithIpvGet,
@@ -14,14 +13,14 @@ router.get(
   PATH_NAMES.MFA_RESET_WITH_IPV,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(mfaResetWithIpvGet())
+  mfaResetWithIpvGet()
 );
 
 router.get(
   PATH_NAMES.OPEN_IN_WEB_BROWSER,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(mfaResetOpenInBrowserGet())
+  mfaResetOpenInBrowserGet()
 );
 
 export { router as mfaResetWithIpvRouter };

--- a/src/components/prove-identity-callback/prove-identity-callback-routes.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-routes.ts
@@ -8,7 +8,6 @@ import {
   proveIdentityCallbackSessionExpiryError,
   proveIdentityStatusCallbackGet,
 } from "./prove-identity-callback-controller";
-import { asyncHandler } from "../../utils/async";
 import { processIdentityRateLimitMiddleware } from "../../middleware/process-identity-rate-limit-middleware";
 
 const router = express.Router();
@@ -18,7 +17,7 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   processIdentityRateLimitMiddleware,
-  asyncHandler(proveIdentityCallbackGetOrPost())
+  proveIdentityCallbackGetOrPost()
 );
 
 router.post(
@@ -26,7 +25,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   processIdentityRateLimitMiddleware,
-  asyncHandler(proveIdentityCallbackGetOrPost())
+  proveIdentityCallbackGetOrPost()
 );
 
 router.get(
@@ -39,7 +38,7 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   processIdentityRateLimitMiddleware,
-  asyncHandler(proveIdentityStatusCallbackGet())
+  proveIdentityStatusCallbackGet()
 );
 
 export { router as proveIdentityCallbackRouter };

--- a/src/components/resend-email-code/resend-email-code-routes.ts
+++ b/src/components/resend-email-code/resend-email-code-routes.ts
@@ -6,7 +6,6 @@ import {
   resendEmailCodePost,
   securityCodeCheckTimeLimit,
 } from "./resend-email-code-controller";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import express from "express";
 
@@ -23,13 +22,13 @@ router.post(
   PATH_NAMES.RESEND_EMAIL_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resendEmailCodePost())
+  resendEmailCodePost()
 );
 
 router.get(
   PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT,
   validateSessionMiddleware,
-  asyncHandler(securityCodeCheckTimeLimit())
+  securityCodeCheckTimeLimit()
 );
 
 export { router as resendEmailCodeRouter };

--- a/src/components/resend-mfa-code/resend-mfa-code-routes.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-routes.ts
@@ -6,7 +6,6 @@ import {
   resendMfaCodeGet,
   resendMfaCodePost,
 } from "./resend-mfa-code-controller";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -22,7 +21,7 @@ router.post(
   PATH_NAMES.RESEND_MFA_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resendMfaCodePost())
+  resendMfaCodePost()
 );
 
 export { router as resendMfaCodeRouter };

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
@@ -6,7 +6,6 @@ import {
 import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
-import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
@@ -14,14 +13,14 @@ router.get(
   PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resetPassword2FAAuthAppGet())
+  resetPassword2FAAuthAppGet()
 );
 
 router.post(
   PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resetPassword2FAAuthAppPost())
+  resetPassword2FAAuthAppPost()
 );
 
 export { router as resetPassword2FAAuthAppRouter };

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-routes.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-routes.ts
@@ -6,7 +6,6 @@ import {
 import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
-import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
@@ -14,14 +13,14 @@ router.get(
   PATH_NAMES.RESET_PASSWORD_2FA_SMS,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resetPassword2FASmsGet())
+  resetPassword2FASmsGet()
 );
 
 router.post(
   PATH_NAMES.RESET_PASSWORD_2FA_SMS,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resetPassword2FASmsPost())
+  resetPassword2FASmsPost()
 );
 
 export { router as resetPassword2FARouter };

--- a/src/components/reset-password-check-email/reset-password-check-email-routes.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-routes.ts
@@ -6,7 +6,6 @@ import {
   resetPasswordResendCodeGet,
 } from "./reset-password-check-email-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { validateResetPasswordCheckEmailRequest } from "./reset-password-check-email-validation";
 
@@ -16,7 +15,7 @@ router.get(
   PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(resetPasswordCheckEmailGet())
+  resetPasswordCheckEmailGet()
 );
 
 router.post(
@@ -24,7 +23,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateResetPasswordCheckEmailRequest(),
-  asyncHandler(resetPasswordCheckEmailPost())
+  resetPasswordCheckEmailPost()
 );
 
 router.get(

--- a/src/components/reset-password/reset-password-routes.ts
+++ b/src/components/reset-password/reset-password-routes.ts
@@ -1,7 +1,6 @@
 import * as express from "express";
 import { PATH_NAMES } from "../../app.constants";
 
-import { asyncHandler } from "../../utils/async";
 import { validateResetPasswordRequest } from "./reset-password-validation";
 import {
   resetPasswordGet,
@@ -26,7 +25,7 @@ router.get(
   PATH_NAMES.RESET_PASSWORD,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(accountInterventionsMiddleware(true, false)),
+  accountInterventionsMiddleware(true, false),
   resetPasswordGet
 );
 
@@ -35,7 +34,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateResetPasswordRequest(),
-  asyncHandler(resetPasswordPost())
+  resetPasswordPost()
 );
 
 router.get(
@@ -50,7 +49,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateResetPasswordRequest(),
-  asyncHandler(resetPasswordPost())
+  resetPasswordPost()
 );
 
 export { router as resetPasswordRouter };

--- a/src/components/setup-authenticator-app/setup-authenticator-app-routes.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-routes.ts
@@ -7,7 +7,6 @@ import {
   setupAuthenticatorAppGet,
   setupAuthenticatorAppPost,
 } from "./setup-authenticator-app-controller";
-import { asyncHandler } from "../../utils/async";
 import { validateSetupAuthAppRequest } from "./setup-authenticator-app-validation";
 
 const router = express.Router();
@@ -24,7 +23,7 @@ router.post(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   validateSetupAuthAppRequest(),
-  asyncHandler(setupAuthenticatorAppPost())
+  setupAuthenticatorAppPost()
 );
 
 export { router as setupAuthenticatorAppRouter };

--- a/src/components/sign-in-or-create/sign-in-or-create-routes.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-routes.ts
@@ -6,21 +6,20 @@ import {
 } from "./sign-in-or-create-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowAndPersistUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
-import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
 router.get(
   PATH_NAMES.SIGN_IN_OR_CREATE,
   validateSessionMiddleware,
-  asyncHandler(allowAndPersistUserJourneyMiddleware),
+  allowAndPersistUserJourneyMiddleware,
   signInOrCreateGet
 );
 
 router.post(
   PATH_NAMES.SIGN_IN_OR_CREATE,
   validateSessionMiddleware,
-  asyncHandler(allowAndPersistUserJourneyMiddleware),
+  allowAndPersistUserJourneyMiddleware,
   signInOrCreatePost
 );
 

--- a/src/components/updated-terms-conditions/updated-terms-conditions-routes.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-routes.ts
@@ -6,7 +6,6 @@ import {
   updatedTermsConditionsPost,
 } from "./updated-terms-conditions-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
 const router = express.Router();
@@ -22,7 +21,7 @@ router.post(
   PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(updatedTermsConditionsPost())
+  updatedTermsConditionsPost()
 );
 
 export { router as updatedTermsConditionsRouter };

--- a/src/components/uplift-journey/uplift-journey-routes.ts
+++ b/src/components/uplift-journey/uplift-journey-routes.ts
@@ -3,7 +3,6 @@ import { PATH_NAMES } from "../../app.constants";
 import * as express from "express";
 
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
-import { asyncHandler } from "../../utils/async";
 import { upliftJourneyGet } from "./uplift-journey-controller";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
@@ -13,7 +12,7 @@ router.get(
   PATH_NAMES.UPLIFT_JOURNEY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  asyncHandler(upliftJourneyGet())
+  upliftJourneyGet()
 );
 
 export { router as upliftJourneyRouter };

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,9 +1,0 @@
-import { NextFunction, RequestHandler, Response, Request } from "express";
-
-export function asyncHandler(
-  fn: RequestHandler
-): (req: Request, res: Response, next: NextFunction) => Promise<void> {
-  return function (req: Request, res: Response, next: NextFunction) {
-    return Promise.resolve(fn(req, res, next)).catch(next);
-  };
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3437,6 +3437,11 @@ expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+express-async-errors@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
+  integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==
+
 express-session@1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.18.1.tgz#88d0bbd41878882840f24ec6227493fcb167e8d5"


### PR DESCRIPTION
## What

Following an incident that caused FE downtime due to uncaught async error we are changing our approach to handling them.

Previously we would wrap async controllers with `asyncHandler`, but this was prone to being a forgotten step.

Here we utilise a new package to patch express itself to handle these async errors.

Express v5 promises to handle these themselves, but we've not got to upgrading yet.

## How to review

1. Code Review
2. Apply diff
```
diff --git a/src/components/sign-in-or-create/sign-in-or-create-controller.ts b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
index 978ac4f4..1ee8277c 100644
--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -30,6 +30,7 @@ export async function signInOrCreatePost(
   req: Request,
   res: Response
 ): Promise<void> {
+  throw new Error("Oh no! something went wrong");
   res.redirect(
     await getNextPathAndUpdateJourney(
       req,
```
3. `./startup.sh -lc`
4. Go to the start page, press a button and see the something went wrong page, instead of server crash.