### PR TITLE
AUT-4250: Do not send x-powered-by header on static assets

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -176,6 +176,7 @@ async function createApp(): Promise<express.Application> {
   }
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
+  app.disable("x-powered-by");
 
   const staticAssetOptions: serveStatic.ServeStaticOptions<express.Response> = {
     cacheControl: true,

--- a/test/unit/static.test.ts
+++ b/test/unit/static.test.ts
@@ -11,4 +11,16 @@ describe("static assets", () => {
     );
     expect(response.header["cache-control"]).to.equal("public, max-age=60");
   });
+
+  it("should be served without the x-powered-by header", async () => {
+    const app = await createApp();
+    const response = await request(app).get(
+      "/assets/images/govuk-crest-2x.png"
+    );
+    expect(
+      Object.keys(response.headers)
+        .map((s) => s.toLowerCase())
+        .includes("x-powered-by")
+    ).to.be.false;
+  });
 });


### PR DESCRIPTION
## What
Do not send the `x-powered-by: express` header.This can help to prevent low-effort fingerprinting

## How to review

1. Code Review
