### PR TITLE
AUT-4251: Add FMS ignore tags cloaking Header WAF

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -1265,6 +1265,8 @@ Resources:
           Value: "auth-frontend"
         - Key: Source
           Value: govuk-one-login/authentication-frontend/cloudformation/deploy/template.yaml
+        - Key: FMSRegionalPolicy
+          Value: false
 
   ApplicationLoadBalancerTargetGroupA:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup


### PR DESCRIPTION
## What

AUT-4251: Add FMS ignore tags cloaking Header WAF
AUTh is using regional Cloaking WAF to protect the load balancer however since this WAF is not maintained by FMS it gets flagged as false positives in Security Hub for resources that may appear unprotected by Firewall Manager (FMS)

## How to review

1. Code Review
1. Deploy to any  Authdevs and see the new tags key with value is created on frontend ALB 
