### PR TITLE
BAU: Correct authdev signin URLs in env script

### DIFF
--- a/dev-app-orchstub.js
+++ b/dev-app-orchstub.js
@@ -6,8 +6,8 @@ const axios = require("axios").default;
 const url = require("url");
 
 const stubUrls = {
-  authdev2: "https://orchstub.authdev2.sandpit.account.gov.uk",
-  authdev1: "https://orchstub.authdev1.sandpit.account.gov.uk",
+  authdev2: "https://orchstub-authdev2.signin.dev.account.gov.uk",
+  authdev1: "https://orchstub-authdev1.signin.dev.account.gov.uk",
   dev: "https://orchstub.signin.dev.account.gov.uk",
 };
 

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -310,7 +310,7 @@ class StateGetter:
             raise KeyError(f"Key {key} not found in ecs task environment") from e
 
 
-def get_static_variables_from_remote(
+def get_static_variables(
     deployment_name: str,
     aws_profile_name: str,
     state_getter: StateGetter,
@@ -347,15 +347,13 @@ def get_static_variables_from_remote(
                 "ENCRYPTION_KEY_ID": state_getter.get_ecs_task_environment_value(
                     "ENCRYPTION_KEY_ID"
                 ),
-                "ORCH_TO_AUTH_AUDIENCE": state_getter.get_ecs_task_environment_value(
-                    "ORCH_TO_AUTH_AUDIENCE"
-                ),
+                "ORCH_TO_AUTH_AUDIENCE": get_signin_url(deployment_name),
                 "ORCH_TO_AUTH_SIGNING_KEY": state_getter.get_ecs_task_environment_value(
                     "ORCH_TO_AUTH_SIGNING_KEY"
                 ),
-                "ORCH_STUB_TO_AUTH_AUDIENCE": state_getter.get_ecs_task_environment_value(
-                    "ORCH_STUB_TO_AUTH_AUDIENCE"
-                ),
+                "ORCH_STUB_TO_AUTH_AUDIENCE": get_signin_url(deployment_name)
+                if "dev" in deployment_name
+                else "",
                 "ORCH_STUB_TO_AUTH_CLIENT_ID": state_getter.get_ecs_task_environment_value(
                     "ORCH_STUB_TO_AUTH_CLIENT_ID"
                 ),
@@ -365,6 +363,13 @@ def get_static_variables_from_remote(
             },
         },
     ]
+
+
+def get_signin_url(deployment_name: str) -> str:
+    if deployment_name.startswith("authdev"):
+        return "https://signin.{}.dev.account.gov.uk/".format(deployment_name)
+    else:
+        return "https://signin.{}.account.gov.uk/".format(deployment_name)
 
 
 def get_user_variables(
@@ -452,7 +457,7 @@ def main(
     state_getter: StateGetter,
 ):
     start_time = datetime.now()
-    static_variables = get_static_variables_from_remote(
+    static_variables = get_static_variables(
         deployment_name, aws_profile_name, state_getter
     )
     user_variables = get_user_variables(dotenv_file, static_variables)


### PR DESCRIPTION
## What

Since the authdev environments have moved AWS accounts and the old `*.sandpit.*` domains have been deactivated we've been unable to run the frontend locally targeting the authdev environments.

This updates the env build script to statically create the audience values needed for all environments.

This is needed because the state file needed for the authdev envs reference the incorrect values, which are still required at the moment.

## How to review

1. Code Review
