### PR TITLE
BAU: Vital signs log less frequently locally

### DIFF
--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -137,6 +137,10 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
                 "value": "localhost",
                 "comment": "Analytics cookie domain where cookie is set",
             },
+            "VITAL_SIGNS_INTERVAL_SECONDS": {
+                "value": "360",
+                "comment": "How often the vital signs statistics will be written to logs",
+            },
         },
     },
 ]

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import {
   getNodeEnv,
   getSessionExpiry,
   getSessionSecret,
+  getVitalSignsIntervalSeconds,
   supportAccountInterventions,
   supportAccountRecovery,
   supportAuthorizeController,
@@ -301,6 +302,7 @@ async function startServer(app: Application): Promise<{
 
     stopVitalSigns = frontendVitalSignsInit(server, {
       staticPaths: [/^\/assets\/.*/, /^\/public\/.*/],
+      interval: getVitalSignsIntervalSeconds() * 1000,
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,10 @@ export function getKmsKeyId(): string {
   return process.env.ENCRYPTION_KEY_ID;
 }
 
+export function getVitalSignsIntervalSeconds(): number {
+  return Number(process.env.VITAL_SIGNS_INTERVAL_SECONDS) || 10;
+}
+
 export function getOrchToAuthSigningPublicKey(): string {
   return process.env.ORCH_TO_AUTH_SIGNING_KEY;
 }

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -46,7 +46,7 @@ describe("app", () => {
 
       expect(frontendVitalSigns.frontendVitalSignsInit).to.be.calledOnceWith(
         server,
-        { staticPaths: [/^\/assets\/.*/, /^\/public\/.*/] }
+        { staticPaths: [/^\/assets\/.*/, /^\/public\/.*/], interval: 10000 }
       );
       await closeServer();
     });


### PR DESCRIPTION
## What

Currently the server vital signs are logged in accordance with the defaults (every 10 seconds) in all environments.

This can obscure important logs when developing the frontend locally.

Here this 10 seconds default is overridden by 360 seconds when run locally.

## How to review

1. Code Review
1. Run locally, but first run `./scripts/create-env-file.sh` to get the new setting.
2. See the logs are less frequent
