### PR TITLE
AUT-1416: Structure to support multiple MFA methods in session

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -104,6 +104,7 @@ import { ipvCallbackRouter } from "./components/ipv-callback/ipv-callback-routes
 import { mfaResetWithIpvRouter } from "./components/mfa-reset-with-ipv/mfa-reset-with-ipv-routes";
 import { environmentBannerMiddleware } from "./middleware/environment-banner-middleware";
 import UID from "uid-safe";
+import { migrateMfaSessionStorageMiddleware } from "./middleware/migrate-mfa-session-storage-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -248,6 +249,8 @@ async function createApp(): Promise<express.Application> {
       },
     })
   );
+
+  app.use(migrateMfaSessionStorageMiddleware); // To be removed shortly
 
   app.use(csurf({ cookie: getCSRFCookieOptions(isProduction) }));
 

--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
@@ -13,6 +13,7 @@ import { sendNotificationService } from "../../common/send-notification/send-not
 import { BadRequestError } from "../../../utils/error";
 import { isLocked } from "../../../utils/lock-helper";
 import { isAccountRecoveryJourney } from "../../../utils/request";
+import { getDefaultSmsMfaMethod } from "../../../utils/mfa";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
   const newCodeLink = req.query?.isResendCodeRequest
@@ -35,7 +36,8 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
     });
   } else {
     res.render("account-creation/resend-mfa-code/index.njk", {
-      phoneNumber: req.session.user.redactedPhoneNumber,
+      phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+        ?.redactedPhoneNumber,
       isResendCodeRequest: req.query?.isResendCodeRequest,
     });
   }
@@ -46,7 +48,8 @@ export const resendMfaCodePost = (
 ): ExpressRouteFunc => {
   return async function (req: Request, res: Response) {
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
-    const { email, phoneNumber } = req.session.user;
+    const { email, mfaMethods } = req.session.user;
+    const phoneNumber = getDefaultSmsMfaMethod(mfaMethods)?.phoneNumber;
 
     const journeyType = isAccountRecoveryJourney(req)
       ? JOURNEY_TYPE.ACCOUNT_RECOVERY

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../app.constants";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../../test/helpers/mfa-helper";
 
 describe("Integration:: resend SMS mfa code (account creation variant)", () => {
   let token: string | string[];
@@ -32,7 +33,7 @@ describe("Integration:: resend SMS mfa code (account creation variant)", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(
             PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION
           ),

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -4,6 +4,7 @@ import { ExpressRouteFunc } from "../../../types";
 import { USER_JOURNEY_EVENTS } from "../../common/state-machine/state-machine";
 import { getNextPathAndUpdateJourney } from "../../common/constants";
 import { supportMfaResetWithIpv } from "../../../config";
+import { getDefaultSmsMfaMethod } from "../../../utils/mfa";
 
 export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
@@ -13,7 +14,8 @@ export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {
         "account-recovery/change-security-codes-confirmation/index.njk",
         {
           mfaMethodType: type,
-          phoneNumber: req.session.user.redactedPhoneNumber,
+          phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+            ?.redactedPhoneNumber,
           supportMfaResetWithIpv: supportMfaResetWithIpv(),
         }
       );

--- a/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
@@ -11,6 +11,7 @@ import {
   changeSecurityCodesConfirmationPost,
 } from "../change-security-codes-confirmation-controller";
 import { createMockRequest } from "../../../../../test/helpers/mock-request-helper";
+import { buildMfaMethods } from "../../../../../test/helpers/mfa-helper";
 
 describe("change security codes confirmation controller", () => {
   let req: RequestOutput;
@@ -50,7 +51,7 @@ describe("change security codes confirmation controller", () => {
       it(`should render the change security codes codes confirmation page for mfaMethodType ${testParams.methodType}`, async () => {
         req.session.user.accountRecoveryVerifiedMfaType = testParams.methodType;
         req.session.user.email = "security.codes.changed@testtwofactorauth.org";
-        req.session.user.redactedPhoneNumber = redactedPhoneNumber;
+        req.session.user.mfaMethods = buildMfaMethods({ redactedPhoneNumber });
         if (testParams.supportMfaResetWithIpv) {
           process.env.SUPPORT_MFA_RESET_WITH_IPV = "1";
         }

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -26,6 +26,7 @@ import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-
 import { getJourneyTypeFromUserSession } from "../common/journey/journey";
 import { isLocked } from "../../utils/lock-helper";
 import { isAccountRecoveryJourneyAndEnabled } from "../../utils/request";
+import { getDefaultSmsMfaMethod } from "../../utils/mfa";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 const RESEND_CODE_LINK = pathWithQueryParam(
@@ -42,7 +43,8 @@ export function checkYourPhoneGet(req: Request, res: Response): void {
     });
   }
   return res.render(TEMPLATE_NAME, {
-    phoneNumber: req.session.user.redactedPhoneNumber,
+    phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+      ?.redactedPhoneNumber,
     resendCodeLink: RESEND_CODE_LINK,
   });
 }
@@ -67,7 +69,7 @@ export const checkYourPhonePost = (
       persistentSessionId,
       req,
       journeyType,
-      req.session.user.phoneNumber
+      getDefaultSmsMfaMethod(req.session.user.mfaMethods)?.phoneNumber
     );
 
     if (!result.success) {

--- a/src/components/common/layout/tests/base-integration.test.ts
+++ b/src/components/common/layout/tests/base-integration.test.ts
@@ -8,6 +8,7 @@ import { sinon } from "../../../../../test/utils/test-utils";
 import { CHANNEL, PATH_NAMES } from "../../../../app.constants";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../../test/helpers/mfa-helper";
 
 describe("Integration:: base page ", () => {
   let app: any;
@@ -35,8 +36,7 @@ describe("Integration:: base page ", () => {
         };
         req.session.user = {
           email: "test@test.com",
-
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(PATH_NAMES.SIGN_IN_OR_CREATE),
         };
 

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -5,6 +5,7 @@ import * as cheerio from "cheerio";
 import decache from "decache";
 import { PATH_NAMES, CONTACT_US_THEMES } from "../../../app.constants";
 import { NextFunction, Request, Response } from "express";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration:: contact us - public user", () => {
   let token: string | string[];
@@ -26,7 +27,7 @@ describe("Integration:: contact us - public user", () => {
       ): void {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user.email = "test@test.com";
-        req.session.user.phoneNumber = "7867";
+        req.session.user.mfaMethods = buildMfaMethods({ phoneNumber: "7867" });
 
         next();
       });

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -29,6 +29,7 @@ import { getNewCodePath } from "../security-code-error/security-code-error-contr
 import { isLocked, timestampNSecondsFromNow } from "../../utils/lock-helper";
 import { getChannelSpecificErrorMessage } from "../../utils/get-channel-specific-error-message";
 import { isReauth } from "../../utils/request";
+import { upsertDefaultSmsMfaMethod } from "../../utils/mfa";
 
 export const RE_ENTER_EMAIL_TEMPLATE =
   "enter-email/index-re-enter-email-account.njk";
@@ -141,7 +142,10 @@ export function enterEmailPost(
     }
 
     req.session.user.enterEmailMfaType = result.data.mfaMethodType;
-    req.session.user.redactedPhoneNumber = result.data.phoneNumberLastThree;
+    req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
+      req.session.user.mfaMethods,
+      { redactedPhoneNumber: result.data.phoneNumberLastThree }
+    );
     req.session.user.isAccountCreationJourney = !result.data.doesUserExist;
 
     const nextState = result.data.doesUserExist

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -27,6 +27,7 @@ import { accountInterventionService } from "../account-intervention/account-inte
 import { getNewCodePath } from "../security-code-error/security-code-error-controller";
 import { isLocked } from "../../utils/lock-helper";
 import { isUpliftRequired } from "../../utils/request";
+import { getDefaultSmsMfaMethod } from "../../utils/mfa";
 
 export const ENTER_MFA_DEFAULT_TEMPLATE_NAME = "enter-mfa/index.njk";
 export const UPLIFT_REQUIRED_SMS_TEMPLATE_NAME =
@@ -61,7 +62,8 @@ export function enterMfaGet(
 
     if (!isAccountRecoveryEnabledForEnvironment) {
       return res.render(templateName, {
-        phoneNumber: req.session.user.redactedPhoneNumber,
+        phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+          ?.redactedPhoneNumber,
         supportAccountRecovery: false,
       });
     }
@@ -99,7 +101,8 @@ export function enterMfaGet(
         );
 
     res.render(templateName, {
-      phoneNumber: req.session.user.redactedPhoneNumber,
+      phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+        ?.redactedPhoneNumber,
       supportAccountRecovery: req.session.user.isAccountRecoveryPermitted,
       mfaResetPath: mfaResetPath,
       routeUserViaIpvReset: routeUserViaIpvReset,

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -17,6 +17,7 @@ import { ERROR_CODES } from "../../common/constants";
 import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import * as journey from "../../common/journey/journey";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 const TEST_PHONE_NUMBER = "07582930495";
 
@@ -39,7 +40,9 @@ describe("enter mfa controller", () => {
 
   beforeEach(() => {
     req = createMockRequest(PATH_NAMES.ENTER_MFA);
-    req.session.user = { redactedPhoneNumber: TEST_PHONE_NUMBER };
+    req.session.user = {
+      mfaMethods: buildMfaMethods({ redactedPhoneNumber: TEST_PHONE_NUMBER }),
+    };
     res = mockResponse();
     process.env.SUPPORT_ACCOUNT_RECOVERY = "1";
   });

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -18,6 +18,7 @@ import { createApiResponse } from "../../../utils/http";
 import { Request, Response, NextFunction } from "express";
 import { SendNotificationServiceInterface } from "../../common/send-notification/types";
 import { DefaultApiResponse } from "../../../types";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration:: enter mfa", () => {
   let token: string | string[];
@@ -64,8 +65,10 @@ describe("Integration:: enter mfa", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: PHONE_NUMBER,
-          redactedPhoneNumber: PHONE_NUMBER,
+          mfaMethods: buildMfaMethods({
+            phoneNumber: PHONE_NUMBER,
+            redactedPhoneNumber: PHONE_NUMBER,
+          }),
           journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
           isAccountRecoveryPermitted: true,
         };

--- a/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-reauth-integration.test.ts
@@ -17,6 +17,7 @@ import {
 import { createApiResponse } from "../../../utils/http";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration:: enter mfa", () => {
   let token: string | string[];
@@ -43,8 +44,10 @@ describe("Integration:: enter mfa", () => {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: PHONE_NUMBER,
-          redactedPhoneNumber: PHONE_NUMBER,
+          mfaMethods: buildMfaMethods({
+            phoneNumber: PHONE_NUMBER,
+            redactedPhoneNumber: PHONE_NUMBER,
+          }),
           reauthenticate: "12345",
           journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
         };

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -23,6 +23,7 @@ import { supportAccountInterventions } from "../../config";
 import { getJourneyTypeFromUserSession } from "../common/journey/journey";
 import { accountInterventionService } from "../account-intervention/account-intervention-service";
 import { AccountInterventionsInterface } from "../account-intervention/types";
+import { upsertDefaultSmsMfaMethod } from "../../utils/mfa";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
 const ENTER_PASSWORD_VALIDATION_KEY =
@@ -148,7 +149,10 @@ export function enterPasswordPost(
 
     const isPasswordChangeRequired = userLogin.data.passwordChangeRequired;
 
-    req.session.user.redactedPhoneNumber = userLogin.data.redactedPhoneNumber;
+    req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
+      req.session.user.mfaMethods,
+      { redactedPhoneNumber: userLogin.data.redactedPhoneNumber }
+    );
     req.session.user.isAccountPartCreated = !userLogin.data.mfaMethodVerified;
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -16,6 +16,7 @@ import { convertInternationalPhoneNumberToE164Format } from "../../utils/phone-n
 import xss from "xss";
 import { getNewCodePath } from "../security-code-error/security-code-error-controller";
 import { isAccountRecoveryJourneyAndEnabled } from "../../utils/request";
+import { upsertDefaultSmsMfaMethod } from "../../utils/mfa";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
   res.render("enter-phone-number/index.njk", {
@@ -40,8 +41,10 @@ export function enterPhoneNumberPost(
       phoneNumber = req.body.phoneNumber;
     }
 
-    req.session.user.redactedPhoneNumber = redactPhoneNumber(phoneNumber);
-    req.session.user.phoneNumber = phoneNumber;
+    req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
+      req.session.user.mfaMethods,
+      { phoneNumber, redactedPhoneNumber: redactPhoneNumber(phoneNumber) }
+    );
 
     const journeyType = isAccountRecoveryJourneyAndEnabled(req)
       ? JOURNEY_TYPE.ACCOUNT_RECOVERY

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -14,6 +14,7 @@ import { mockResponse, RequestOutput, ResponseOutput } from "mock-req-res";
 import { ERROR_CODES } from "../../common/constants";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
 import { strict as assert } from "assert";
+import { getDefaultSmsMfaMethod } from "../../../utils/mfa";
 
 const OLD_ENV = process.env;
 
@@ -71,7 +72,9 @@ describe("enter phone number controller", () => {
 
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
-      expect(req.session.user.redactedPhoneNumber).to.be.eq("3990");
+      expect(
+        getDefaultSmsMfaMethod(req.session.user.mfaMethods).redactedPhoneNumber
+      ).to.be.eq("3990");
     });
 
     it("should redirect to /check-your-phone when success with valid international number", async () => {
@@ -91,7 +94,9 @@ describe("enter phone number controller", () => {
 
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
-      expect(req.session.user.redactedPhoneNumber).to.be.eq("3322");
+      expect(
+        getDefaultSmsMfaMethod(req.session.user.mfaMethods).redactedPhoneNumber
+      ).to.be.eq("3322");
     });
 
     it("should throw error when API call to /send-notification throws error", async () => {

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -7,6 +7,7 @@ import { ERROR_CODES, pathWithQueryParam } from "../../common/constants";
 import nock = require("nock");
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration::enter phone number", () => {
   let token: string | string[];
@@ -29,7 +30,7 @@ describe("Integration::enter phone number", () => {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(
             PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
           ),

--- a/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
+++ b/src/components/ipv-callback/tests/ipv-callback-integration.test.ts
@@ -11,6 +11,7 @@ import express, { NextFunction, Request, Response } from "express";
 import nock from "nock";
 import * as cheerio from "cheerio";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 const TEST_CONTACT_US_LINK_URL = "https://example.com/contact-us";
 
@@ -215,7 +216,7 @@ const stubMiddlewareAndCreateApp = async (
 
       req.session.user = {
         email: "test@test.com",
-        phoneNumber: "7867",
+        mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
         journey: getPermittedJourneyForPath(nextPath),
         mfaMethodType: mfaMethodType,
       };

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -11,6 +11,7 @@ import {
 import { ERROR_CODES } from "../../common/constants";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration:: resend email code", () => {
   let token: string | string[];
@@ -33,7 +34,7 @@ describe("Integration:: resend email code", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(PATH_NAMES.RESEND_EMAIL_CODE),
         };
 

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -8,6 +8,7 @@ import { pathWithQueryParam } from "../common/constants";
 import { supportReauthentication } from "../../config";
 import { isLocked } from "../../utils/lock-helper";
 import { getJourneyTypeFromUserSession } from "../common/journey/journey";
+import { getDefaultSmsMfaMethod } from "../../utils/mfa";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
   if (isLocked(req.session.user.wrongCodeEnteredLock)) {
@@ -35,7 +36,8 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
     });
 
     res.render("resend-mfa-code/index.njk", {
-      redactedPhoneNumber: req.session.user.redactedPhoneNumber,
+      redactedPhoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+        ?.redactedPhoneNumber,
       isResendCodeRequest: req.query?.isResendCodeRequest,
       supportReauthentication: supportReauthentication(),
       isReauthJourney: journeyType === JOURNEY_TYPE.REAUTHENTICATION,

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -12,6 +12,7 @@ import { ERROR_CODES } from "../../common/constants";
 import { commonVariables } from "../../../../test/helpers/common-test-variables";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 const { testPhoneNumber, testRedactedPhoneNumber } = commonVariables;
 
 describe("Integration:: resend mfa code", () => {
@@ -36,8 +37,10 @@ describe("Integration:: resend mfa code", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: testPhoneNumber,
-          redactedPhoneNumber: testRedactedPhoneNumber,
+          mfaMethods: buildMfaMethods({
+            phoneNumber: testPhoneNumber,
+            redactedPhoneNumber: testRedactedPhoneNumber,
+          }),
           journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
           reauthenticate: "reauth",
         };

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -22,6 +22,7 @@ import { AccountInterventionsInterface } from "../account-intervention/types";
 import { accountInterventionService } from "../account-intervention/account-intervention-service";
 import { getNewCodePath } from "../security-code-error/security-code-error-controller";
 import { isLocked } from "../../utils/lock-helper";
+import { getDefaultSmsMfaMethod } from "../../utils/mfa";
 
 const TEMPLATE_NAME = "reset-password-2fa-sms/index.njk";
 const RESEND_CODE_LINK = pathWithQueryParam(
@@ -96,7 +97,8 @@ export function resetPassword2FASmsGet(
       );
     }
     return res.render(TEMPLATE_NAME, {
-      phoneNumber: req.session.user.redactedPhoneNumber,
+      phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
+        ?.redactedPhoneNumber,
       resendCodeLink: RESEND_CODE_LINK,
     });
   };

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -11,6 +11,7 @@ import { NOTIFICATION_TYPE } from "../../app.constants";
 import { AccountInterventionsInterface } from "../account-intervention/types";
 import { accountInterventionService } from "../account-intervention/account-intervention-service";
 import { isLocked } from "../../utils/lock-helper";
+import { upsertDefaultSmsMfaMethod } from "../../utils/mfa";
 
 const TEMPLATE_NAME = "reset-password-check-email/index.njk";
 
@@ -52,7 +53,10 @@ export function resetPasswordCheckEmailGet(
 
     if (result.success && req.session.user.enterEmailMfaType === undefined) {
       req.session.user.enterEmailMfaType = result.data.mfaMethodType;
-      req.session.user.redactedPhoneNumber = result.data.phoneNumberLastThree;
+      req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
+        req.session.user.mfaMethods,
+        { redactedPhoneNumber: result.data.phoneNumberLastThree }
+      );
     }
 
     if (!requestCode || result.success) {

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../../test/helpers/account-interventions-helpers";
 import { fakeVerifyCodeServiceHelper } from "../../../../test/helpers/verify-code-helpers";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper";
+import { getDefaultSmsMfaMethod } from "../../../utils/mfa";
 
 describe("reset password check email controller", () => {
   let req: RequestOutput;
@@ -56,7 +57,9 @@ describe("reset password check email controller", () => {
       );
 
       expect(req.session.user.enterEmailMfaType).to.eq("SMS");
-      expect(req.session.user.redactedPhoneNumber).to.eq("123");
+      expect(
+        getDefaultSmsMfaMethod(req.session.user.mfaMethods).redactedPhoneNumber
+      ).to.eq("123");
 
       expect(res.render).to.have.calledWith(
         "reset-password-check-email/index.njk"

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -15,6 +15,7 @@ import {
   routeUsersToNewIpvJourney,
   supportMfaResetWithIpv,
 } from "../../config";
+import { upsertDefaultSmsMfaMethod } from "../../utils/mfa";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -99,8 +100,10 @@ export function resetPasswordPost(
       );
     }
 
-    req.session.user.redactedPhoneNumber =
-      loginResponse.data.redactedPhoneNumber;
+    req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
+      req.session.user.mfaMethods,
+      { redactedPhoneNumber: loginResponse.data.redactedPhoneNumber }
+    );
     req.session.user.isLatestTermsAndConditionsAccepted =
       loginResponse.data.latestTermsAndConditionsAccepted;
     req.session.user.isAccountPartCreated =

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../test/helpers/account-interventions-helpers";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration::reset password (in 6 digit code flow)", () => {
   let token: string | string[];
@@ -36,7 +37,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(PATH_NAMES.RESET_PASSWORD),
         };
 

--- a/src/components/reset-password/tests/reset-password-required-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-required-integration.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../test/helpers/account-interventions-helpers";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration::reset password required", () => {
   let token: string | string[];
@@ -34,7 +35,7 @@ describe("Integration::reset password required", () => {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(ENDPOINT),
           isAuthenticated: true,
           isAccountPartCreated: false,

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -3,7 +3,10 @@ import QRCode from "qrcode";
 import { ExpressRouteFunc } from "../../types";
 import { ERROR_CODES, getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { generateQRCodeValue } from "../../utils/mfa";
+import {
+  generateQRCodeValue,
+  removeDefaultSmsMfaMethod,
+} from "../../utils/mfa";
 import { BadRequestError } from "../../utils/error";
 import { splitSecretKeyIntoFragments } from "../../utils/strings";
 import {
@@ -95,8 +98,9 @@ export function setupAuthenticatorAppPost(
     }
 
     req.session.user.authAppSecret = null;
-    req.session.user.phoneNumber = null;
-    req.session.user.redactedPhoneNumber = null;
+    req.session.user.mfaMethods = removeDefaultSmsMfaMethod(
+      req.session.user.mfaMethods
+    );
 
     const accountRecoveryEnabledJourney =
       isAccountRecoveryJourneyAndEnabled(req);

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../app.constants";
 import { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import { buildMfaMethods } from "../../../../test/helpers/mfa-helper";
 
 describe("Integration:: updated-terms-code", () => {
   let token: string | string[];
@@ -35,7 +36,7 @@ describe("Integration:: updated-terms-code", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          mfaMethods: buildMfaMethods({ phoneNumber: "7867" }),
           journey: getPermittedJourneyForPath(
             PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS
           ),

--- a/src/middleware/migrate-mfa-session-storage-middleware.ts
+++ b/src/middleware/migrate-mfa-session-storage-middleware.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from "express";
+import { upsertDefaultSmsMfaMethod } from "../utils/mfa";
+import { UserSession } from "../types";
+
+export function migrateMfaSessionStorageMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const userSession: UserSession & {
+    redactedPhoneNumber?: string;
+    phoneNumber?: string;
+  } = req.session?.user;
+  const redactedPhoneNumber = userSession?.redactedPhoneNumber;
+  const phoneNumber = userSession?.phoneNumber;
+  if (
+    userSession &&
+    !userSession.mfaMethods &&
+    (redactedPhoneNumber || phoneNumber)
+  ) {
+    req.session.user = {
+      ...userSession,
+      mfaMethods: upsertDefaultSmsMfaMethod(req.session.user.mfaMethods, {
+        redactedPhoneNumber,
+        phoneNumber,
+      }),
+    };
+  }
+
+  next();
+}

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -13,22 +13,9 @@ export function initialiseSessionMiddleware(
   if (req.path === PATH_NAMES.AUTHORIZE) {
     req.session.client = {};
 
-    const email =
-      req.session && req.session.user ? req.session.user.email : undefined;
-    const redactedPhoneNumber =
-      req.session && req.session.user
-        ? req.session.user.redactedPhoneNumber
-        : undefined;
-
-    const phoneNumber =
-      req.session && req.session.user
-        ? req.session.user.phoneNumber
-        : undefined;
-
     req.session.user = {
-      email: email,
-      redactedPhoneNumber: redactedPhoneNumber,
-      phoneNumber: phoneNumber,
+      email: req.session?.user?.email,
+      mfaMethods: req.session?.user?.mfaMethods,
     };
 
     req.session.sessionRestored = true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { ValidationChain } from "express-validator";
 
 import express, { NextFunction, Request, Response } from "express";
+import { MFA_METHOD_TYPE } from "./app.constants";
 
 export type ExpressRouteFunc = (
   req: Request,
@@ -108,3 +109,22 @@ export interface UserSessionClient {
 }
 
 export type ContentIdFunction = (req: Request) => string;
+
+export enum MfaMethodPriorityIdentifier {
+  DEFAULT = "DEFAULT",
+  BACKUP = "BACKUP",
+}
+
+export type SmsMfaMethod = {
+  type: MFA_METHOD_TYPE.SMS;
+  priorityIdentifier: MfaMethodPriorityIdentifier;
+  phoneNumber?: string;
+  redactedPhoneNumber?: string;
+};
+
+export type AuthAppMfaMethod = {
+  type: MFA_METHOD_TYPE.AUTH_APP;
+  priorityIdentifier: MfaMethodPriorityIdentifier;
+};
+
+export type MfaMethod = SmsMfaMethod | AuthAppMfaMethod;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,8 +58,6 @@ export interface UserSession {
   [key: string]: unknown;
   isAuthenticated?: boolean;
   email?: string;
-  redactedPhoneNumber?: string;
-  phoneNumber?: string;
   mfaMethods?: MfaMethod[];
   journey?: UserJourney;
   isLatestTermsAndConditionsAccepted?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,10 @@ export type SmsMfaMethod = {
   redactedPhoneNumber?: string;
 };
 
+export const isSmsMfaMethod = (
+  mfaMethod: MfaMethod
+): mfaMethod is SmsMfaMethod => mfaMethod.type === MFA_METHOD_TYPE.SMS;
+
 export type AuthAppMfaMethod = {
   type: MFA_METHOD_TYPE.AUTH_APP;
   priorityIdentifier: MfaMethodPriorityIdentifier;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface UserSession {
   email?: string;
   redactedPhoneNumber?: string;
   phoneNumber?: string;
+  mfaMethods?: MfaMethod[];
   journey?: UserJourney;
   isLatestTermsAndConditionsAccepted?: boolean;
   isIdentityRequired?: boolean;

--- a/src/utils/mfa.test.ts
+++ b/src/utils/mfa.test.ts
@@ -1,7 +1,7 @@
 import { expect } from "../../test/utils/test-utils";
 import { MfaMethod, MfaMethodPriorityIdentifier } from "../types";
 import { MFA_METHOD_TYPE } from "../app.constants";
-import { upsertDefaultSmsMfaMethod } from "./mfa";
+import { getDefaultSmsMfaMethod, upsertDefaultSmsMfaMethod } from "./mfa";
 
 describe("mfa", () => {
   describe("upsertDefaultSmsMfaMethod", () => {
@@ -129,6 +129,45 @@ describe("mfa", () => {
               phoneNumber: test.phoneNumber,
             })
           ).to.deep.eq(test.expectedMfaMethods);
+        });
+      }
+    );
+  });
+
+  describe("getDefaultSmsMfaMethodDetail", () => {
+    [
+      {
+        title: "returns undefined with empty array",
+        mfaMethods: [] as MfaMethod[],
+        expectedMfaMethod: undefined,
+      },
+      {
+        title: "returns expected redactedPhoneNumber with SMS DEFAULT",
+        mfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+            phoneNumber: "089",
+          },
+        ] as MfaMethod[],
+        expectedMfaMethod: {
+          type: MFA_METHOD_TYPE.SMS,
+          priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+          redactedPhoneNumber: "123",
+          phoneNumber: "089",
+        },
+      },
+    ].forEach(
+      (test: {
+        title: string;
+        mfaMethods: MfaMethod[];
+        expectedMfaMethod: MfaMethod;
+      }) => {
+        it(test.title, async () => {
+          expect(getDefaultSmsMfaMethod(test.mfaMethods)).to.deep.eq(
+            test.expectedMfaMethod
+          );
         });
       }
     );

--- a/src/utils/mfa.test.ts
+++ b/src/utils/mfa.test.ts
@@ -1,0 +1,136 @@
+import { expect } from "../../test/utils/test-utils";
+import { MfaMethod, MfaMethodPriorityIdentifier } from "../types";
+import { MFA_METHOD_TYPE } from "../app.constants";
+import { upsertDefaultSmsMfaMethod } from "./mfa";
+
+describe("mfa", () => {
+  describe("upsertDefaultSmsMfaMethod", () => {
+    [
+      {
+        title: "redactedPhoneNumber added correctly to empty array",
+        initialMfaMethods: [] as MfaMethod[],
+        redactedPhoneNumber: "123",
+        phoneNumber: undefined,
+        expectedMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+          },
+        ] as MfaMethod[],
+      },
+      {
+        title: "redactedPhoneNumber replaces existing SMS DEFAULT",
+        initialMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+          },
+        ] as MfaMethod[],
+        redactedPhoneNumber: "890",
+        phoneNumber: undefined,
+        expectedMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "890",
+          },
+        ] as MfaMethod[],
+      },
+      {
+        title:
+          "redactedPhoneNumber does not reset phoneNumber with existing SMS DEFAULT",
+        initialMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+            phoneNumber: "98534567123",
+          },
+        ] as MfaMethod[],
+        redactedPhoneNumber: "890",
+        phoneNumber: undefined,
+        expectedMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "890",
+            phoneNumber: "98534567123",
+          },
+        ] as MfaMethod[],
+      },
+      {
+        title: "phoneNumber added correctly to empty array",
+        initialMfaMethods: [] as MfaMethod[],
+        redactedPhoneNumber: undefined,
+        phoneNumber: "123",
+        expectedMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            phoneNumber: "123",
+          },
+        ] as MfaMethod[],
+      },
+      {
+        title: "phoneNumber replaces existing SMS DEFAULT",
+        initialMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            phoneNumber: "123",
+          },
+        ] as MfaMethod[],
+        redactedPhoneNumber: undefined,
+        phoneNumber: "890",
+        expectedMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            phoneNumber: "890",
+          },
+        ] as MfaMethod[],
+      },
+      {
+        title:
+          "phoneNumber does not reset redactedPhoneNumber with existing SMS DEFAULT",
+        initialMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+            phoneNumber: "98534567123",
+          },
+        ] as MfaMethod[],
+        redactedPhoneNumber: undefined,
+        phoneNumber: "123456789",
+        expectedMfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+            phoneNumber: "123456789",
+          },
+        ] as MfaMethod[],
+      },
+    ].forEach(
+      (test: {
+        title: string;
+        initialMfaMethods: MfaMethod[];
+        redactedPhoneNumber: string | undefined;
+        phoneNumber: string | undefined;
+        expectedMfaMethods: MfaMethod[];
+      }) => {
+        it(test.title, async () => {
+          expect(
+            upsertDefaultSmsMfaMethod(test.initialMfaMethods, {
+              redactedPhoneNumber: test.redactedPhoneNumber,
+              phoneNumber: test.phoneNumber,
+            })
+          ).to.deep.eq(test.expectedMfaMethods);
+        });
+      }
+    );
+  });
+});

--- a/src/utils/mfa.test.ts
+++ b/src/utils/mfa.test.ts
@@ -1,7 +1,11 @@
 import { expect } from "../../test/utils/test-utils";
 import { MfaMethod, MfaMethodPriorityIdentifier } from "../types";
 import { MFA_METHOD_TYPE } from "../app.constants";
-import { getDefaultSmsMfaMethod, upsertDefaultSmsMfaMethod } from "./mfa";
+import {
+  getDefaultSmsMfaMethod,
+  removeDefaultSmsMfaMethod,
+  upsertDefaultSmsMfaMethod,
+} from "./mfa";
 
 describe("mfa", () => {
   describe("upsertDefaultSmsMfaMethod", () => {
@@ -167,6 +171,35 @@ describe("mfa", () => {
         it(test.title, async () => {
           expect(getDefaultSmsMfaMethod(test.mfaMethods)).to.deep.eq(
             test.expectedMfaMethod
+          );
+        });
+      }
+    );
+  });
+
+  describe("removeDefaultSmsMfaMethod", () => {
+    [
+      {
+        title: "returns empty array with one SMS DEFAULT",
+        mfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "123",
+            phoneNumber: "089",
+          },
+        ] as MfaMethod[],
+        expectedMfaMethods: [],
+      },
+    ].forEach(
+      (test: {
+        title: string;
+        mfaMethods: MfaMethod[];
+        expectedMfaMethods: MfaMethod[];
+      }) => {
+        it(test.title, async () => {
+          expect(removeDefaultSmsMfaMethod(test.mfaMethods)).to.deep.eq(
+            test.expectedMfaMethods
           );
         });
       }

--- a/src/utils/mfa.ts
+++ b/src/utils/mfa.ts
@@ -92,3 +92,16 @@ export function getDefaultSmsMfaMethod(
         mfaMethod.priorityIdentifier === MfaMethodPriorityIdentifier.DEFAULT
     );
 }
+
+export function removeDefaultSmsMfaMethod(
+  mfaMethod: MfaMethod[] | undefined
+): MfaMethod[] {
+  if (!mfaMethod) return undefined;
+  return mfaMethod.filter(
+    (mfaMethod) =>
+      !(
+        mfaMethod.priorityIdentifier === MfaMethodPriorityIdentifier.DEFAULT &&
+        isSmsMfaMethod(mfaMethod)
+      )
+  );
+}

--- a/src/utils/mfa.ts
+++ b/src/utils/mfa.ts
@@ -7,8 +7,13 @@ import {
 } from "@otplib/core";
 import * as base32EncDec from "@otplib/plugin-base32-enc-dec";
 import crypto from "crypto";
-import { APP_ENV_NAME } from "../app.constants";
+import { APP_ENV_NAME, MFA_METHOD_TYPE } from "../app.constants";
 import { getAppEnv } from "../config";
+import {
+  MfaMethod,
+  MfaMethodPriorityIdentifier,
+  SmsMfaMethod,
+} from "../types";
 
 function createRandomBytes(size: number, encoding: KeyEncodings): string {
   return crypto.randomBytes(size).toString(encoding);
@@ -42,4 +47,35 @@ export function generateQRCodeValue(
     issuer: issuer,
     type: Strategy.TOTP,
   });
+}
+
+export function upsertDefaultSmsMfaMethod(
+  mfaMethodArray: MfaMethod[] | undefined,
+  newMfaMethod: Partial<SmsMfaMethod>
+): MfaMethod[] {
+  const previousMfaMethods = mfaMethodArray || [];
+  const index = previousMfaMethods.findIndex(
+    (mfaMethod: MfaMethod) => mfaMethod.type === MFA_METHOD_TYPE.SMS
+  );
+
+  const previousMfa = index > -1 && previousMfaMethods[index];
+  const nextMfa: MfaMethod = {
+    ...previousMfa,
+    type: MFA_METHOD_TYPE.SMS,
+    priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+    ...(newMfaMethod.redactedPhoneNumber && {
+      redactedPhoneNumber: newMfaMethod.redactedPhoneNumber,
+    }),
+    ...(newMfaMethod.phoneNumber && {
+      phoneNumber: newMfaMethod.phoneNumber,
+    }),
+  };
+
+  const nextMfaMethods = previousMfaMethods.slice();
+  if (previousMfa) {
+    nextMfaMethods.splice(index, 1, nextMfa);
+  } else {
+    nextMfaMethods.push(nextMfa);
+  }
+  return nextMfaMethods;
 }

--- a/src/utils/mfa.ts
+++ b/src/utils/mfa.ts
@@ -11,6 +11,7 @@ import { APP_ENV_NAME, MFA_METHOD_TYPE } from "../app.constants";
 import { getAppEnv } from "../config";
 import {
   MfaMethod,
+  isSmsMfaMethod,
   MfaMethodPriorityIdentifier,
   SmsMfaMethod,
 } from "../types";
@@ -78,4 +79,16 @@ export function upsertDefaultSmsMfaMethod(
     nextMfaMethods.push(nextMfa);
   }
   return nextMfaMethods;
+}
+
+export function getDefaultSmsMfaMethod(
+  mfaMethods: MfaMethod[] | undefined
+): SmsMfaMethod | undefined {
+  if (!mfaMethods) return undefined;
+  return mfaMethods
+    .filter(isSmsMfaMethod)
+    .find(
+      (mfaMethod) =>
+        mfaMethod.priorityIdentifier === MfaMethodPriorityIdentifier.DEFAULT
+    );
 }

--- a/test/helpers/mfa-helper.ts
+++ b/test/helpers/mfa-helper.ts
@@ -1,0 +1,22 @@
+import { MfaMethod, MfaMethodPriorityIdentifier } from "../../src/types";
+import { MFA_METHOD_TYPE } from "../../src/app.constants";
+
+export function buildMfaMethods({
+  phoneNumber,
+  redactedPhoneNumber,
+}: {
+  phoneNumber?: string;
+  redactedPhoneNumber?: string;
+}): MfaMethod[] {
+  if (redactedPhoneNumber || phoneNumber) {
+    return [
+      {
+        type: MFA_METHOD_TYPE.SMS,
+        priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+        phoneNumber,
+        redactedPhoneNumber,
+      },
+    ];
+  }
+  return [];
+}

--- a/test/unit/middleware/migrate-mfa-session-storage-middleware.test.ts
+++ b/test/unit/middleware/migrate-mfa-session-storage-middleware.test.ts
@@ -1,0 +1,101 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { Request, Response } from "express";
+import { sinon } from "../../utils/test-utils";
+import { migrateMfaSessionStorageMiddleware } from "../../../src/middleware/migrate-mfa-session-storage-middleware";
+import { MfaMethodPriorityIdentifier, UserSession } from "../../../src/types";
+import { MFA_METHOD_TYPE } from "../../../src/app.constants";
+import { Session } from "express-session";
+
+describe("migrateMfaSessionStorageMiddleware", () => {
+  let request: Request;
+  const response = {} as Response;
+  let next: () => void;
+
+  beforeEach(() => {
+    request = {} as Request;
+    next = sinon.fake();
+  });
+
+  it("should call next", () => {
+    migrateMfaSessionStorageMiddleware(request, response, next);
+    expect(next).to.have.been.called;
+  });
+
+  it("does not migrate if mfaMethods exists in user session", () => {
+    const expectedUserSession: UserSession = {
+      phoneNumber: "01234567890",
+      redactedPhoneNumber: "089",
+      mfaMethods: [
+        {
+          type: MFA_METHOD_TYPE.SMS,
+          priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+          phoneNumber: "555555555555",
+          redactedPhoneNumber: "555",
+        },
+      ],
+    };
+    request.session = {
+      user: expectedUserSession,
+    } as any as Session;
+    migrateMfaSessionStorageMiddleware(request, response, next);
+    expect(request.session.user).to.deep.equals(expectedUserSession);
+  });
+
+  [
+    {
+      existingUserSession: {
+        phoneNumber: "01234567890",
+      },
+      expectedUserSession: {
+        phoneNumber: "01234567890",
+        mfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            phoneNumber: "01234567890",
+          },
+        ],
+      },
+    },
+    {
+      existingUserSession: {
+        redactedPhoneNumber: "890",
+      },
+      expectedUserSession: {
+        redactedPhoneNumber: "890",
+        mfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            redactedPhoneNumber: "890",
+          },
+        ],
+      },
+    },
+    {
+      existingUserSession: {
+        phoneNumber: "01234567890",
+        redactedPhoneNumber: "890",
+      },
+      expectedUserSession: {
+        phoneNumber: "01234567890",
+        redactedPhoneNumber: "890",
+        mfaMethods: [
+          {
+            type: MFA_METHOD_TYPE.SMS,
+            priorityIdentifier: MfaMethodPriorityIdentifier.DEFAULT,
+            phoneNumber: "01234567890",
+            redactedPhoneNumber: "890",
+          },
+        ],
+      },
+    },
+  ].forEach(({ existingUserSession, expectedUserSession }) =>
+    it(`correctly migrates session with keys ${JSON.stringify(Object.keys(existingUserSession))}`, () => {
+      request.session = { user: existingUserSession } as any as Session;
+      migrateMfaSessionStorageMiddleware(request, response, next);
+      expect(request.session.user).to.deep.equals(expectedUserSession);
+    })
+  );
+});


### PR DESCRIPTION
## What

We will soon need data for multiple MFA methods in the user session (specifically the need for multiple SMS methods in session is new) as we introduce `BACKUP` methods. Here we make a change to how this data is stored in preparation.

Uses of `session.user.phoneNumber` and `session.user.redactedPhoneNumber` will be replaced with `session.user.mfaMethods` which can contain multiple MFA methods. 

We are explicitly not handling `BACKUP` `SMS` or any `AUTH_APP` within `mfaMethods` at the moment. Modifications will be made when required, not before, to keep this migration pretty straightforward.

Further explanation of individual steps of this PR can be found in commit messages.

## How to review

1. Code review (commit-by-commit)
1. Deploy to dev
1. Spot test the create, sign in and password reset journeys
