### PR TITLE
Alert0010950: Log RP client id in response logger

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -203,6 +203,7 @@ function setSessionDataFromClaims(req: Request, claims: Claims) {
   req.session.client.rpSectorHost = claims.rp_sector_host;
   req.session.client.rpRedirectUri = claims.rp_redirect_uri;
   req.session.client.rpState = claims.rp_state;
+  req.session.client.rpClientId = claims.rp_client_id;
   req.session.user.reauthenticate = supportReauthentication()
     ? claims.reauthenticate
     : null;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -39,6 +39,7 @@ export type Claims = {
   state: string;
   client_id: string;
   redirect_uri: string;
+  rp_client_id: string;
   rp_sector_host: string;
   rp_redirect_uri: string;
   rp_state: string;

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -26,6 +26,7 @@ export function createMockClaims(): Claims {
     jti: "fvvMWAladDtl35O_xyBTRLwwojA",
     rp_redirect_uri: "https://rp.service.gov.uk/redirect/",
     rp_state: "baeb1828-131f-40ef-9574-eee677d1cdd7",
+    rp_client_id: "RP_CLIENT_ID",
     previous_govuk_signin_journey_id: "a7349515-9154-4d20-b282-c42d2d35ac10",
     claim:
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -53,6 +53,9 @@ export function getSessionIdMiddleware(
       req.cookies["di-persistent-session-id"]
     );
   }
+  if (req.session?.client?.rpClientId) {
+    res.locals.clientId = req.session.client.rpClientId;
+  }
   next();
 }
 

--- a/src/middleware/tests/session-middleware.test.ts
+++ b/src/middleware/tests/session-middleware.test.ts
@@ -57,6 +57,20 @@ describe("session-middleware", () => {
       expect(res.locals.persistentSessionId).to.equal("psid123456xyz");
       expect(next).to.be.calledOnce;
     });
+    it("should add clientId to response when present on session", () => {
+      req = {
+        session: {
+          client: {
+            rpClientId: "an-rp-client-id",
+          },
+        },
+      } as any;
+      getSessionIdMiddleware(req as Request, res as Response, next);
+
+      expect(res.locals).to.have.property("clientId");
+      expect(res.locals.clientId).to.equal("an-rp-client-id");
+      expect(next).to.be.calledOnce;
+    });
     it("should not have session id on response when no session cookie present", () => {
       req.cookies = undefined;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export interface UserSessionClient {
   state?: string;
   isOneLoginService?: boolean;
   claim?: string[];
+  rpClientId?: string;
   rpSectorHost?: string;
   rpRedirectUri?: string;
   rpState?: string;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -23,6 +23,7 @@ const logger = pino({
         clientSessionId: res.locals.clientSessionId,
         persistentSessionId: res.locals.persistentSessionId,
         languageFromCookie: res.locals.language?.toUpperCase(),
+        clientId: res.locals.clientId,
       };
     },
   },


### PR DESCRIPTION


## What

Adds facility to track frontend response status by RP

- Log RP client id in response logger.
- Reads the mandatory rp_client_id claim from orchestration and makes this available as a local:

https://github.com/govuk-one-login/authentication-api/blob/72fdbb879debf7f547bf4e564e94ed3386397db9/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java#L944

## How to review

1. Code Review
1. Deploy to an environment for testing
1. Run a journey and check that the clientId appears in the response logs
