### PR TITLE
BAU: increase overloadProtection maxEventLoopDelay to 700ms in staging

### DIFF
--- a/src/middleware/overload-protection-middleware.ts
+++ b/src/middleware/overload-protection-middleware.ts
@@ -9,7 +9,7 @@ export const applyOverloadProtection = (
     production: isProduction,
     clientRetrySecs: 3,
     sampleInterval: 10,
-    maxEventLoopDelay: 500,
+    maxEventLoopDelay: 700,
     maxHeapUsedBytes: 0,
     maxRssBytes: 0,
     errorPropagationMode: false,

--- a/src/middleware/tests/overload-protection-middleware.test.ts
+++ b/src/middleware/tests/overload-protection-middleware.test.ts
@@ -43,7 +43,7 @@ function expectedOverloadProtectionConfig(isProduction: boolean) {
     production: isProduction,
     clientRetrySecs: 3,
     sampleInterval: 10,
-    maxEventLoopDelay: 500,
+    maxEventLoopDelay: 700,
     maxHeapUsedBytes: 0,
     maxRssBytes: 0,
     errorPropagationMode: false,


### PR DESCRIPTION

## What

Increase overloadProtection maxEventLoopDelay to 700ms in staging.

Protection triggering is currently too sensitive and has been triggered by low volume acceptance test runs in staging

This applies to staging only as overload protection is not enabled in any other environment.

## How to review

1. Code Review

