### PR TITLE
ATO-1435: Pass new claims to auth backend

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -70,20 +70,7 @@ export function authorizeGet(
       persistentSessionId,
       req,
       {
-        authenticated: claims.authenticated,
-        current_credential_strength: claims.current_credential_strength,
-        previous_session_id: claims.previous_session_id,
-        previous_govuk_signin_journey_id:
-          claims.previous_govuk_signin_journey_id,
-        reauthenticate: claims.reauthenticate,
-        cookie_consent: claims.cookie_consent,
-        _ga: claims._ga,
-        scope: claims.scope,
-        client_id: claims.rp_client_id,
-        redirect_uri: claims.rp_redirect_uri,
-        state: claims.rp_state,
-        requested_credential_strength: claims.requested_credential_strength,
-        requested_level_of_confidence: claims.requested_level_of_confidence,
+        ...claims,
       }
     );
 

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -76,6 +76,14 @@ export function authorizeGet(
         previous_govuk_signin_journey_id:
           claims.previous_govuk_signin_journey_id,
         reauthenticate: claims.reauthenticate,
+        cookie_consent: claims.cookie_consent,
+        _ga: claims._ga,
+        scope: claims.scope,
+        client_id: claims.rp_client_id,
+        redirect_uri: claims.rp_redirect_uri,
+        state: claims.rp_state,
+        requested_credential_strength: claims.requested_credential_strength,
+        requested_level_of_confidence: claims.requested_level_of_confidence,
       }
     );
 

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -72,5 +72,18 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   )
     body["previous-govuk-signin-journey-id"] =
       startRequestParameters.previous_govuk_signin_journey_id;
+  if (startRequestParameters.cookie_consent !== undefined)
+    body["cookie_consent"] = startRequestParameters.cookie_consent;
+  if (startRequestParameters._ga !== undefined)
+    body["_ga"] = startRequestParameters._ga;
+  body["requested_credential_strength"] =
+    startRequestParameters.requested_credential_strength;
+  if (startRequestParameters.requested_level_of_confidence !== undefined)
+    body["requested_level_of_confidence"] =
+      startRequestParameters.requested_level_of_confidence;
+  body["client_id"] = startRequestParameters.client_id;
+  body["scope"] = startRequestParameters.scope;
+  body["redirect_uri"] = startRequestParameters.redirect_uri;
+  body["state"] = startRequestParameters.state;
   return body;
 }

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -81,9 +81,9 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   if (startRequestParameters.requested_level_of_confidence !== undefined)
     body["requested_level_of_confidence"] =
       startRequestParameters.requested_level_of_confidence;
-  body["client_id"] = startRequestParameters.client_id;
+  body["client_id"] = startRequestParameters.rp_client_id;
   body["scope"] = startRequestParameters.scope;
-  body["redirect_uri"] = startRequestParameters.redirect_uri;
-  body["state"] = startRequestParameters.state;
+  body["redirect_uri"] = startRequestParameters.rp_redirect_uri;
+  body["state"] = startRequestParameters.rp_state;
   return body;
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -34,7 +34,6 @@ export type Claims = {
   is_one_login_service: boolean;
   service_type: string;
   govuk_signin_journey_id: string;
-  confidence: string;
   state: string;
   client_id: string;
   redirect_uri: string;
@@ -49,6 +48,11 @@ export type Claims = {
   channel?: string;
   authenticated: boolean;
   current_credential_strength?: string;
+  cookie_consent?: string;
+  _ga?: string;
+  scope: string;
+  requested_level_of_confidence?: string;
+  requested_credential_strength: string;
 };
 
 export const requiredClaimsKeys = [
@@ -63,10 +67,11 @@ export const requiredClaimsKeys = [
   "is_one_login_service",
   "service_type",
   "govuk_signin_journey_id",
-  "confidence",
   "state",
   "client_id",
   "redirect_uri",
   "rp_sector_host",
   "authenticated",
+  "scope",
+  "requested_credential_strength",
 ];

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -46,6 +46,11 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -54,6 +59,11 @@ describe("authorize service", () => {
         {
           "rp-pairwise-id-for-reauth": "123456",
           authenticated: isAuthenticated,
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -71,12 +81,24 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { authenticated: isAuthenticated },
+        {
+          authenticated: isAuthenticated,
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+        },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
@@ -89,12 +111,24 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
       postStub.calledOnceWithExactly(
         API_ENDPOINTS.START,
-        { authenticated: isAuthenticated },
+        {
+          authenticated: isAuthenticated,
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+        },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
@@ -110,6 +144,11 @@ describe("authorize service", () => {
       current_credential_strength: undefined,
       reauthenticate: undefined,
       previous_session_id: previousSessionId,
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -118,6 +157,11 @@ describe("authorize service", () => {
         {
           "previous-session-id": previousSessionId,
           authenticated: isAuthenticated,
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -137,6 +181,11 @@ describe("authorize service", () => {
       reauthenticate: "123456",
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -146,6 +195,11 @@ describe("authorize service", () => {
           "rp-pairwise-id-for-reauth": "123456",
           "previous-govuk-signin-journey-id": "previous-journey-id",
           authenticated: isAuthenticated,
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
@@ -166,6 +220,11 @@ describe("authorize service", () => {
       reauthenticate: undefined,
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
     });
 
     expect(
@@ -175,11 +234,53 @@ describe("authorize service", () => {
           "current-credential-strength": currentCredentialStrength,
           "previous-govuk-signin-journey-id": "previous-journey-id",
           authenticated: isAuthenticated,
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
         },
         {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,
           },
+          proxy: false,
+        }
+      )
+    ).to.be.true;
+  });
+
+  it("sends a request with optional parameters when present in start request", () => {
+    process.env.SUPPORT_REAUTHENTICATION = "0";
+    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
+      authenticated: isAuthenticated,
+      reauthenticate: "123456",
+      requested_level_of_confidence: "P2",
+      requested_credential_strength: "Cl.Cm",
+      client_id: "test-client-id",
+      scope: "openid",
+      redirect_uri: "http://example.com/redirect",
+      state: "1234567890",
+      cookie_consent: "accept",
+      _ga: "987654321",
+    });
+
+    expect(
+      postStub.calledOnceWithExactly(
+        API_ENDPOINTS.START,
+        {
+          authenticated: isAuthenticated,
+          requested_level_of_confidence: "P2",
+          requested_credential_strength: "Cl.Cm",
+          client_id: "test-client-id",
+          scope: "openid",
+          redirect_uri: "http://example.com/redirect",
+          state: "1234567890",
+          cookie_consent: "accept",
+          _ga: "987654321",
+        },
+        {
+          headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
           proxy: false,
         }
       )

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -47,10 +47,10 @@ describe("authorize service", () => {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
     });
 
     expect(
@@ -82,10 +82,10 @@ describe("authorize service", () => {
       authenticated: isAuthenticated,
       reauthenticate: "123456",
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
     });
 
     expect(
@@ -112,10 +112,10 @@ describe("authorize service", () => {
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
     });
 
     expect(
@@ -145,10 +145,10 @@ describe("authorize service", () => {
       reauthenticate: undefined,
       previous_session_id: previousSessionId,
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
     });
 
     expect(
@@ -182,10 +182,10 @@ describe("authorize service", () => {
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
     });
 
     expect(
@@ -221,10 +221,10 @@ describe("authorize service", () => {
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
     });
 
     expect(
@@ -257,10 +257,10 @@ describe("authorize service", () => {
       reauthenticate: "123456",
       requested_level_of_confidence: "P2",
       requested_credential_strength: "Cl.Cm",
-      client_id: "test-client-id",
+      rp_client_id: "test-client-id",
       scope: "openid",
-      redirect_uri: "http://example.com/redirect",
-      state: "1234567890",
+      rp_redirect_uri: "http://example.com/redirect",
+      rp_state: "1234567890",
       cookie_consent: "accept",
       _ga: "987654321",
     });

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -7,7 +7,6 @@ import type { Claims } from "../claims-config.js";
 export function createMockClaims(): Claims {
   const timestamp = Math.floor(new Date().getTime() / 1000);
   return {
-    confidence: "Cl.Cm",
     iss: "UNKNOWN",
     client_id: getOrchToAuthExpectedClientId(),
     govuk_signin_journey_id: "QOFzoB3o-9gGplMgdT1dJfH4vaI",
@@ -31,6 +30,8 @@ export function createMockClaims(): Claims {
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
     authenticated: false,
     current_credential_strength: "MEDIUM_LEVEL",
+    requested_credential_strength: "Cl.Cm",
+    scope: "openid",
   };
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -11,10 +11,10 @@ export interface StartRequestParameters {
   reauthenticate?: string;
   cookie_consent?: string;
   _ga?: string;
-  client_id: string;
+  rp_client_id: string;
   scope: string;
-  redirect_uri: string;
-  state: string;
+  rp_redirect_uri: string;
+  rp_state: string;
   requested_level_of_confidence?: string;
   requested_credential_strength: string;
 }

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -9,6 +9,14 @@ export interface StartRequestParameters {
   rp_pairwise_id_for_reauth?: string;
   previous_govuk_signin_journey_id?: string;
   reauthenticate?: string;
+  cookie_consent?: string;
+  _ga?: string;
+  client_id: string;
+  scope: string;
+  redirect_uri: string;
+  state: string;
+  requested_level_of_confidence?: string;
+  requested_credential_strength: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
Reintroducing this PR after fixing the smoke tests

## What

We have defined some new claims which will replace the need for auth client session. This PR passes these new claims from orch to the auth backend.

Note that we would like to get rid of the `confidence` claim we get from orch. In the backend changes, we added another  claim called `requested_credential_strength` which we can update the frontend to use. Both of these claims are set to the same value in orch. Once we've swapped to using the new claim with the better name, we can remove the old claim in orch.

## How to review

Deployed to sandpit with the backend changes
- Tested with VTR with level of confidence
- Tested with VTR without level of confidence
- Tested without providing a VTR

All journeys completed successfully and no fields were logged as being out of sync

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.
- [x] Documentation has been updated to reflect these changes.
