### PR TITLE
AUT-4306: Set Target5XX10PercentAlarm as ECS canary rollback trigger

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -1906,10 +1906,7 @@ Resources:
         DeploymentStrategy: !Ref DeploymentStrategy
         ContainerName: "frontend-application"
         ContainerPort: "3000"
-        CloudWatchAlarms: !Sub
-          - "${ELB5XXChosenAlarm},${ELB4XXChosenAlarm}"
-          - ELB5XXChosenAlarm: !Ref ELB5XX10PercentAlarm
-            ELB4XXChosenAlarm: !Ref ELB4XXAnomalyAlarm
+        CloudWatchAlarms: !Ref Target5XX10PercentAlarm
 
   #
   # Service down page


### PR DESCRIPTION
## What

Set Target5XX10PercentAlarm as ECS canary rollback trigger
This replaces ELB5XX10PercentAlarm and ELB4XXAnomalyAlarm as both appear volatile. See `#di-authentication-cloudwatch-alarms` channel
