### PR TITLE
AUT 4246: How do you want to get sec codes for AUTH APP user

### DIFF
--- a/src/components/authorize/tests/__snapshots__/authorize-integration.test.ts.snap
+++ b/src/components/authorize/tests/__snapshots__/authorize-integration.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Integration:: authorize should redirect to /sign-in-or-create with Google Analytics tag if 'result' query exists 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;

--- a/src/components/how-do-you-want-security-codes/index.njk
+++ b/src/components/how-do-you-want-security-codes/index.njk
@@ -17,6 +17,13 @@
                 checked: false
             }) %}
         {% endif %}
+        {% if mfaMethod.type == "AUTH_APP" %}
+            {% set _ = items.push({
+                value: mfaMethod.id,
+                html: ('pages.howDoYouWantSecurityCodes.choice.authApp' | translate),
+                checked: false
+            }) %}
+        {% endif %}
     {% endfor %}
     {{ govukRadios({
         name: "mfa-method-id",

--- a/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
+++ b/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
@@ -32,3 +32,25 @@ Object {
   "taxonomyLevel5": "",
 }
 `;
+
+exports[`Integration::how do you want security codes should return how do you want security codes page as expected for SMS user with AUTH APP backup 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::how do you want security codes should return how do you want security codes page as expected for SMS user with SMS backup 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;

--- a/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
+++ b/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
@@ -55,6 +55,17 @@ Object {
 }
 `;
 
+exports[`Integration::how do you want security codes should return page as expected for AUTH APP user with SMS backup 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
 exports[`Integration::how do you want security codes should return page as expected for SMS user with AUTH APP backup 1`] = `
 Object {
   "contentId": "",

--- a/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
+++ b/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
@@ -54,3 +54,25 @@ Object {
   "taxonomyLevel5": "",
 }
 `;
+
+exports[`Integration::how do you want security codes should return page as expected for SMS user with AUTH APP backup 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::how do you want security codes should return page as expected for SMS user with SMS backup 1`] = `
+Object {
+  "contentId": "",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;

--- a/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
+++ b/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
@@ -7,6 +7,7 @@ import type { NextFunction, Request, Response } from "express";
 import { buildMfaMethods } from "../../../../test/helpers/mfa-helper.js";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import * as cheerio from "cheerio";
+import type { MfaMethod } from "../../../types.js";
 
 const getTokenAndCookies = async (app: any) => {
   let cookies, token;
@@ -23,6 +24,18 @@ const getTokenAndCookies = async (app: any) => {
   });
   return { token, cookies };
 };
+
+const mockSessionMiddleware = (mfaMethods: MfaMethod[]) =>
+  sinon.fake(function (req: Request, res: Response, next: NextFunction) {
+    res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+    req.session.user = {
+      email: "test@test.com",
+      mfaMethods: mfaMethods,
+      journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
+      isAccountRecoveryPermitted: true,
+    };
+    next();
+  });
 
 describe("Integration::how do you want security codes", () => {
   let app: any;
@@ -47,30 +60,18 @@ describe("Integration::how do you want security codes", () => {
       {},
       {
         "../../../middleware/session-middleware.js": {
-          validateSessionMiddleware: sinon.fake(function (
-            req: Request,
-            res: Response,
-            next: NextFunction
-          ): void {
-            res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
-
-            req.session.user = {
-              email: "test@test.com",
-              mfaMethods: buildMfaMethods([
-                {
-                  id: DEFAULT_PHONE_NUMBER_ID,
-                  redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
-                },
-                {
-                  id: BACKUP_PHONE_NUMBER_ID,
-                  redactedPhoneNumber: BACKUP_PHONE_NUMBER,
-                },
-              ]),
-              journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
-              isAccountRecoveryPermitted: true,
-            };
-            next();
-          }),
+          validateSessionMiddleware: mockSessionMiddleware(
+            buildMfaMethods([
+              {
+                id: DEFAULT_PHONE_NUMBER_ID,
+                redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
+              },
+              {
+                id: BACKUP_PHONE_NUMBER_ID,
+                redactedPhoneNumber: BACKUP_PHONE_NUMBER,
+              },
+            ])
+          ),
         },
       }
     );
@@ -124,30 +125,18 @@ describe("Integration::how do you want security codes", () => {
       {},
       {
         "../../../middleware/session-middleware.js": {
-          validateSessionMiddleware: sinon.fake(function (
-            req: Request,
-            res: Response,
-            next: NextFunction
-          ): void {
-            res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
-
-            req.session.user = {
-              email: "test@test.com",
-              mfaMethods: buildMfaMethods([
-                {
-                  id: DEFAULT_PHONE_NUMBER_ID,
-                  redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
-                },
-                {
-                  id: BACKUP_AUTH_APP_ID,
-                  authApp: true,
-                },
-              ]),
-              journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
-              isAccountRecoveryPermitted: true,
-            };
-            next();
-          }),
+          validateSessionMiddleware: mockSessionMiddleware(
+            buildMfaMethods([
+              {
+                id: DEFAULT_PHONE_NUMBER_ID,
+                redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
+              },
+              {
+                id: BACKUP_AUTH_APP_ID,
+                authApp: true,
+              },
+            ])
+          ),
         },
       }
     );
@@ -201,30 +190,18 @@ describe("Integration::how do you want security codes", () => {
       {},
       {
         "../../../middleware/session-middleware.js": {
-          validateSessionMiddleware: sinon.fake(function (
-            req: Request,
-            res: Response,
-            next: NextFunction
-          ): void {
-            res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
-
-            req.session.user = {
-              email: "test@test.com",
-              mfaMethods: buildMfaMethods([
-                {
-                  id: DEFAULT_PHONE_NUMBER_ID,
-                  redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
-                },
-                {
-                  id: BACKUP_PHONE_NUMBER_ID,
-                  redactedPhoneNumber: BACKUP_PHONE_NUMBER,
-                },
-              ]),
-              journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
-              isAccountRecoveryPermitted: true,
-            };
-            next();
-          }),
+          validateSessionMiddleware: mockSessionMiddleware(
+            buildMfaMethods([
+              {
+                id: DEFAULT_PHONE_NUMBER_ID,
+                redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
+              },
+              {
+                id: BACKUP_AUTH_APP_ID,
+                authApp: true,
+              },
+            ])
+          ),
         },
       }
     );

--- a/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
+++ b/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
@@ -1,6 +1,5 @@
 import { describe } from "mocha";
 import { expect, request, sinon } from "../../../../test/utils/test-utils.js";
-import nock from "nock";
 import { PATH_NAMES } from "../../../app.constants.js";
 import esmock from "esmock";
 import type { NextFunction, Request, Response } from "express";
@@ -44,10 +43,6 @@ describe("Integration::how do you want security codes", () => {
   const BACKUP_PHONE_NUMBER = "1234";
   const BACKUP_PHONE_NUMBER_ID = "6ae3be91-708f-45b2-9374-6a595eb76bce";
   const BACKUP_AUTH_APP_ID = "8f40b828-2928-492f-a277-8432d9e76d2a";
-
-  beforeEach(() => {
-    nock.cleanAll();
-  });
 
   after(() => {
     sinon.restore();

--- a/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
+++ b/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
@@ -8,7 +8,7 @@ import { buildMfaMethods } from "../../../../test/helpers/mfa-helper.js";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import * as cheerio from "cheerio";
 
-const getTokenAndCookies = async (app: express.Application) => {
+const getTokenAndCookies = async (app: any) => {
   let cookies, token;
   await request(
     app,
@@ -81,7 +81,7 @@ describe("Integration::how do you want security codes", () => {
       test
         .get(PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES)
         .expect(200)
-        .expect(function (res) {
+        .expect(function (res: any) {
           const $ = cheerio.load(res.text);
           expect(
             $("a")
@@ -158,7 +158,7 @@ describe("Integration::how do you want security codes", () => {
       test
         .get(PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES)
         .expect(200)
-        .expect(function (res) {
+        .expect(function (res: any) {
           const $ = cheerio.load(res.text);
           expect(
             $("a")

--- a/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
+++ b/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
@@ -30,8 +30,18 @@ describe("Integration::how do you want security codes", () => {
   const DEFAULT_PHONE_NUMBER_ID = "532b14c2-a11d-4882-a83b-e8d7184e0b70";
   const BACKUP_PHONE_NUMBER = "1234";
   const BACKUP_PHONE_NUMBER_ID = "6ae3be91-708f-45b2-9374-6a595eb76bce";
+  const BACKUP_AUTH_APP_ID = "8f40b828-2928-492f-a277-8432d9e76d2a";
 
-  before(async () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return how do you want security codes page as expected for SMS user with SMS backup", async () => {
     const { createApp } = await esmock(
       "../../../app.js",
       {},
@@ -66,18 +76,7 @@ describe("Integration::how do you want security codes", () => {
     );
 
     app = await createApp();
-  });
 
-  beforeEach(() => {
-    nock.cleanAll();
-  });
-
-  after(() => {
-    sinon.restore();
-    app = undefined;
-  });
-
-  it("should return how do you want security codes page as expected", async () => {
     await request(app, (test) =>
       test
         .get(PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES)
@@ -119,7 +118,119 @@ describe("Integration::how do you want security codes", () => {
     );
   });
 
+  it("should return how do you want security codes page as expected for SMS user with AUTH APP backup", async () => {
+    const { createApp } = await esmock(
+      "../../../app.js",
+      {},
+      {
+        "../../../middleware/session-middleware.js": {
+          validateSessionMiddleware: sinon.fake(function (
+            req: Request,
+            res: Response,
+            next: NextFunction
+          ): void {
+            res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+            req.session.user = {
+              email: "test@test.com",
+              mfaMethods: buildMfaMethods([
+                {
+                  id: DEFAULT_PHONE_NUMBER_ID,
+                  redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
+                },
+                {
+                  id: BACKUP_AUTH_APP_ID,
+                  authApp: true,
+                },
+              ]),
+              journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
+              isAccountRecoveryPermitted: true,
+            };
+            next();
+          }),
+        },
+      }
+    );
+
+    app = await createApp();
+
+    await request(app, (test) =>
+      test
+        .get(PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES)
+        .expect(200)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect(
+            $("a")
+              .toArray()
+              .some(
+                (link) =>
+                  $(link).attr("href") === PATH_NAMES.MFA_RESET_WITH_IPV &&
+                  $(link).text().trim() ===
+                    "check if you can change how you get security codes"
+              )
+          ).to.be.eq(true, "mfa reset link presence");
+
+          const form = $(`form[action="/how-do-you-want-security-codes"]`);
+          expect(form.toArray().some(Boolean)).to.be.eq(true, "form presence");
+          expect(
+            form
+              .first()
+              .find("button[type=Submit]")
+              .toArray()
+              .some((link) => $(link).text().trim() === "Continue")
+          ).to.be.eq(true, "submit button presence");
+
+          const radioArray = form.first().find("input[type=radio]").toArray();
+          expect(radioArray.length).to.be.eq(2);
+          expect($(radioArray[0]).val() === BACKUP_AUTH_APP_ID).to.be.eq(
+            true,
+            `radio input presence for auth app in correct order`
+          );
+          expect($(radioArray[1]).val() === DEFAULT_PHONE_NUMBER_ID).to.be.eq(
+            true,
+            `radio input presence for ${DEFAULT_PHONE_NUMBER} in correct order`
+          );
+        })
+    );
+  });
+
   it("returns a validation error when no option is selected", async () => {
+    const { createApp } = await esmock(
+      "../../../app.js",
+      {},
+      {
+        "../../../middleware/session-middleware.js": {
+          validateSessionMiddleware: sinon.fake(function (
+            req: Request,
+            res: Response,
+            next: NextFunction
+          ): void {
+            res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+            req.session.user = {
+              email: "test@test.com",
+              mfaMethods: buildMfaMethods([
+                {
+                  id: DEFAULT_PHONE_NUMBER_ID,
+                  redactedPhoneNumber: DEFAULT_PHONE_NUMBER,
+                },
+                {
+                  id: BACKUP_PHONE_NUMBER_ID,
+                  redactedPhoneNumber: BACKUP_PHONE_NUMBER,
+                },
+              ]),
+              journey: getPermittedJourneyForPath(PATH_NAMES.ENTER_MFA),
+              isAccountRecoveryPermitted: true,
+            };
+            next();
+          }),
+        },
+      }
+    );
+
+    app = await createApp();
+
     const { token, cookies } = await getTokenAndCookies(app);
 
     await request(

--- a/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
+++ b/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-integration.test.ts
@@ -42,6 +42,7 @@ describe("Integration::how do you want security codes", () => {
   const DEFAULT_PHONE_NUMBER_ID = "532b14c2-a11d-4882-a83b-e8d7184e0b70";
   const BACKUP_PHONE_NUMBER = "1234";
   const BACKUP_PHONE_NUMBER_ID = "6ae3be91-708f-45b2-9374-6a595eb76bce";
+  const DEFAULT_AUTH_APP_ID = "9a51c939-3a39-4a30-b388-9543e0f87e3b";
   const BACKUP_AUTH_APP_ID = "8f40b828-2928-492f-a277-8432d9e76d2a";
 
   after(() => {
@@ -74,6 +75,20 @@ describe("Integration::how do you want security codes", () => {
         { id: BACKUP_AUTH_APP_ID, authApp: true },
       ],
       expectedRadioValues: [BACKUP_AUTH_APP_ID, DEFAULT_PHONE_NUMBER_ID],
+    },
+    {
+      description: "AUTH APP user with SMS backup",
+      mfaMethods: [
+        {
+          id: DEFAULT_AUTH_APP_ID,
+          authApp: true,
+        },
+        {
+          id: BACKUP_PHONE_NUMBER_ID,
+          redactedPhoneNumber: BACKUP_PHONE_NUMBER,
+        },
+      ],
+      expectedRadioValues: [BACKUP_PHONE_NUMBER_ID, DEFAULT_AUTH_APP_ID],
     },
   ];
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2660,7 +2660,8 @@
     "howDoYouWantSecurityCodes": {
       "title": "Sut ydych chi am gael cod diogelwch?",
       "choice": {
-        "smsPrefix": "Neges destun i’ch rhif ffôn sy’n gorffen gyda "
+        "smsPrefix": "Neges destun i’ch rhif ffôn sy’n gorffen gyda ",
+        "authApp": "Defnyddiwch eich ap dilysu"
       },
       "mfaReset": {
         "preamble": "Os ydych chi wedi colli mynediad parhaol i’r ddau ddull yma, ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2659,7 +2659,8 @@
     "howDoYouWantSecurityCodes": {
       "title": "How do you want to get a security code?",
       "choice": {
-        "smsPrefix": "Text message to your phone number ending with "
+        "smsPrefix": "Text message to your phone number ending with ",
+        "authApp": "Use your authenticator app"
       },
       "mfaReset": {
         "preamble": "If you have permanently lost access to both of these methods, ",


### PR DESCRIPTION
## What

- Adds logic for auth app to the how do you want to get security codes page.
- If auth app is in present in req.session.user.mfaMethods, auth app radio button
  is shown.
- This PR covers both scenarios where auth app is either default or back up

### English
<img width="558" alt="Screenshot 2025-05-13 at 09 45 45" src="https://github.com/user-attachments/assets/895158cb-be3f-4406-aa87-10f09bd77052" />

### Welsh
<img width="531" alt="Screenshot 2025-05-13 at 09 45 56" src="https://github.com/user-attachments/assets/2c444497-4a75-46ad-8d70-014a2ee82174" />

## How to review

1. Code Review
2. Run against environment where you have two MFA methods set up
3. See radio buttons on 'How do you want to get a security code?' page

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.
