### PR TITLE
ATO-1435: Log whether clientSessionIds are in sync

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -64,6 +64,12 @@ export function authorizeGet(
       throw new BadRequestError(error.message);
     }
 
+    if (claims.govuk_signin_journey_id !== clientSessionId) {
+      logger.warn(
+        `clientSessionId in claims (${claims.govuk_signin_journey_id}) does not match one found in cookie (${clientSessionId})`
+      );
+    }
+
     const startAuthResponse = await authService.start(
       sessionId,
       clientSessionId,


### PR DESCRIPTION
## What

We send a clientSessionId from orch to auth frontend (as govuk_signin_journey_id). This adds logging to check if this clientSessionId matches the one set in the gs cookie.

## How to review

1. Code Review

## Checklist

Just logging changes
- [x] Performance analyst has been notified of the change. 
- [x] A UCD review has been performed.
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.
- [x] Documentation has been updated to reflect these changes.
