### PR TITLE
ATO-1621: Stop forwarding current_credential_strength to backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -56,9 +56,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
 
   body["authenticated"] = startRequestParameters.authenticated;
 
-  if (startRequestParameters.current_credential_strength !== undefined)
-    body["current-credential-strength"] =
-      startRequestParameters.current_credential_strength;
   if (startRequestParameters.previous_session_id !== undefined)
     body["previous-session-id"] = startRequestParameters.previous_session_id;
   if (

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -24,7 +24,6 @@ describe("authorize service", () => {
     headers: requestHeadersWithIpAndAuditEncoded,
   });
   const isAuthenticated = false;
-  const currentCredentialStrength = "MEDIUM_LEVEL";
 
   beforeEach(() => {
     setupApiKeyAndBaseUrlEnvVars();
@@ -141,7 +140,6 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
-      current_credential_strength: undefined,
       reauthenticate: undefined,
       previous_session_id: previousSessionId,
       requested_credential_strength: "Cl.Cm",
@@ -177,7 +175,6 @@ describe("authorize service", () => {
     process.env.SUPPORT_REAUTHENTICATION = "1";
     service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
       authenticated: isAuthenticated,
-      current_credential_strength: undefined,
       reauthenticate: "123456",
       previous_session_id: undefined,
       previous_govuk_signin_journey_id: "previous-journey-id",
@@ -205,44 +202,6 @@ describe("authorize service", () => {
           headers: {
             ...expectedHeadersFromCommonVarsWithSecurityHeaders,
             Reauthenticate: true,
-          },
-          proxy: false,
-        }
-      )
-    ).to.be.true;
-  });
-
-  it("sends a request with the current credential strength in the body when present", () => {
-    process.env.SUPPORT_REAUTHENTICATION = "1";
-    service.start(sessionId, clientSessionId, diPersistentSessionId, req, {
-      authenticated: isAuthenticated,
-      current_credential_strength: currentCredentialStrength,
-      reauthenticate: undefined,
-      previous_session_id: undefined,
-      previous_govuk_signin_journey_id: "previous-journey-id",
-      requested_credential_strength: "Cl.Cm",
-      rp_client_id: "test-client-id",
-      scope: "openid",
-      rp_redirect_uri: "http://example.com/redirect",
-      rp_state: "1234567890",
-    });
-
-    expect(
-      postStub.calledOnceWithExactly(
-        API_ENDPOINTS.START,
-        {
-          "current-credential-strength": currentCredentialStrength,
-          "previous-govuk-signin-journey-id": "previous-journey-id",
-          authenticated: isAuthenticated,
-          requested_credential_strength: "Cl.Cm",
-          client_id: "test-client-id",
-          scope: "openid",
-          redirect_uri: "http://example.com/redirect",
-          state: "1234567890",
-        },
-        {
-          headers: {
-            ...expectedHeadersFromCommonVarsWithSecurityHeaders,
           },
           proxy: false,
         }

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -4,7 +4,6 @@ import type { Request } from "express";
 
 export interface StartRequestParameters {
   authenticated: boolean;
-  current_credential_strength?: string;
   previous_session_id?: string;
   rp_pairwise_id_for_reauth?: string;
   previous_govuk_signin_journey_id?: string;


### PR DESCRIPTION
## What: 
Previously the value of Current credential strength was sent from Orchestration -> Authentication  and back again at userinfo. This was to compensate for the fact that the value was not set in all cases. We have now migrated to using Achieved Credential Strength instead, which has allowed this to be a solely Authentication owned value. We therefore no longer need to forward this to the backend as it doesn't use it anymore.

## How to review: 
Deploy to authdev2:
- Ran through a journey
- Ran through an uplift journey
- All as expected

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs:
- https://github.com/govuk-one-login/authentication-api/pull/6538 PR which removed the backend usage of this field