### PR TITLE
AUT-4256: present backup mfa method to user during password reset journey

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -497,7 +497,10 @@ const authStateMachine = createMachine(
           ],
         },
         meta: {
-          optionalPaths: [PATH_NAMES.RESEND_MFA_CODE],
+          optionalPaths: [
+            PATH_NAMES.RESEND_MFA_CODE,
+            PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES,
+          ],
         },
       },
       [PATH_NAMES.RESET_PASSWORD_RESEND_CODE]: {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -477,6 +477,9 @@ const authStateMachine = createMachine(
             },
           ],
         },
+        meta: {
+          optionalPaths: [PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES],
+        },
       },
       [PATH_NAMES.RESET_PASSWORD_2FA_SMS]: {
         on: {

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -14,9 +14,13 @@ export function howDoYouWantSecurityCodesGet(
   req: Request,
   res: Response
 ): void {
+  const { isPasswordResetJourney } = req.session.user;
+  const supportMfaReset = !isPasswordResetJourney;
+
   res.render("how-do-you-want-security-codes/index.njk", {
     mfaResetLink: PATH_NAMES.MFA_RESET_WITH_IPV,
     mfaMethods: sortMfaMethodsBackupFirst(req.session.user.mfaMethods || []),
+    supportMfaReset,
   });
 }
 

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-validation.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-validation.ts
@@ -16,12 +16,18 @@ export function validateHowDoYouWantSecurityCodesRequest(): ValidationChainFunc 
       }),
     validateBodyMiddleware(
       "how-do-you-want-security-codes/index.njk",
-      (req) => ({
-        mfaResetLink: PATH_NAMES.MFA_RESET_WITH_IPV,
-        mfaMethods: sortMfaMethodsBackupFirst(
-          req.session.user.mfaMethods || []
-        ),
-      })
+      (req) => {
+        const { isPasswordResetJourney } = req.session.user;
+        const supportMfaReset = !isPasswordResetJourney;
+
+        return {
+          mfaResetLink: PATH_NAMES.MFA_RESET_WITH_IPV,
+          mfaMethods: sortMfaMethodsBackupFirst(
+            req.session.user.mfaMethods || []
+          ),
+          supportMfaReset,
+        };
+      }
     ),
   ];
 }

--- a/src/components/how-do-you-want-security-codes/index.njk
+++ b/src/components/how-do-you-want-security-codes/index.njk
@@ -50,10 +50,12 @@
     }) }}
 </form>
 
-<p class="govuk-body">
-    {{ 'pages.howDoYouWantSecurityCodes.mfaReset.preamble' | translate }}<a href="{{ mfaResetLink }}" class="govuk-link"
-     rel="noreferrer noopener">{{ 'pages.howDoYouWantSecurityCodes.mfaReset.link' | translate }}</a>.
-</p>
+{% if supportMfaReset %}
+    <p class="govuk-body">
+        {{ 'pages.howDoYouWantSecurityCodes.mfaReset.preamble' | translate }}<a href="{{ mfaResetLink }}" class="govuk-link"
+        rel="noreferrer noopener">{{ 'pages.howDoYouWantSecurityCodes.mfaReset.link' | translate }}</a>.
+    </p>
+{% endif %}
 
 {% set ga4Params = { nonce: scriptNonce, statusCode: "200", englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
 {%- include "ga4-opl/template.njk" -%}

--- a/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-controller.test.ts
+++ b/src/components/how-do-you-want-security-codes/tests/how-do-you-want-security-codes-controller.test.ts
@@ -28,5 +28,35 @@ describe("how do you want security codes controller", () => {
         "how-do-you-want-security-codes/index.njk"
       );
     });
+
+    it("should render reset password auth app view with supportMfaReset false when completing a password reset journey", () => {
+      req.session.user.isPasswordResetJourney = true;
+
+      howDoYouWantSecurityCodesGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "how-do-you-want-security-codes/index.njk",
+        {
+          mfaResetLink: PATH_NAMES.MFA_RESET_WITH_IPV,
+          mfaMethods: [],
+          supportMfaReset: false,
+        }
+      );
+    });
+
+    it("should render reset password auth app view with supportMfaReset true when not completing a password reset journey", () => {
+      req.session.user.isPasswordResetJourney = false;
+
+      howDoYouWantSecurityCodesGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "how-do-you-want-security-codes/index.njk",
+        {
+          mfaResetLink: PATH_NAMES.MFA_RESET_WITH_IPV,
+          mfaMethods: [],
+          supportMfaReset: true,
+        }
+      );
+    });
   });
 });

--- a/src/components/reset-password-2fa-auth-app/index.njk
+++ b/src/components/reset-password-2fa-auth-app/index.njk
@@ -50,11 +50,12 @@
 
   </form>
 
-  {% if isAccountRecoveryPermitted === true %}
+  {% if hasMultipleMfaMethods %}
     {% set detailsHTML %}
       <p class="govuk-body">
-        {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}
-        <a href="{{checkEmailLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.text2'| translate}}</a>{{'pages.enterAuthenticatorAppCode.details.text3' | translate}}
+        {{'pages.enterAuthenticatorAppCode.details.chooseMfaMethod.text1' | translate}}
+        <a href="{{ chooseMfaMethodHref }}" class="govuk-link"
+          rel="noreferrer noopener">{{'pages.enterAuthenticatorAppCode.details.chooseMfaMethod.text2' | translate}}</a>.
       </p>
     {% endset %}
 

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -20,7 +20,9 @@ import {
 import { BadRequestError } from "../../utils/error.js";
 import { getCodeEnteredWrongBlockDurationInMinutes } from "../../config.js";
 import { isLocked, timestampNMinutesFromNow } from "../../utils/lock-helper.js";
+
 const TEMPLATE_NAME = "reset-password-2fa-auth-app/index.njk";
+
 export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     if (isLocked(req.session.user.wrongCodeEnteredPasswordResetMfaLock)) {
@@ -33,9 +35,17 @@ export function resetPassword2FAAuthAppGet(): ExpressRouteFunc {
         }
       );
     }
-    return res.render(TEMPLATE_NAME, {});
+
+    const hasMultipleMfaMethods = req.session.user.mfaMethods?.length > 1;
+    const chooseMfaMethodHref = PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES;
+
+    return res.render(TEMPLATE_NAME, {
+      hasMultipleMfaMethods,
+      chooseMfaMethodHref,
+    });
   };
 }
+
 export function resetPassword2FAAuthAppPost(
   service: VerifyMfaCodeInterface = verifyMfaCodeService()
 ): ExpressRouteFunc {

--- a/src/components/reset-password-2fa-sms/index.njk
+++ b/src/components/reset-password-2fa-sms/index.njk
@@ -48,6 +48,13 @@
                 <a href="{{resendCodeLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.passwordResetMfaSms.details.sendCodeLinkText'| translate}}</a>
                 {{'pages.passwordResetMfaSms.details.text 2' | translate}}
             </p>
+            {% if hasMultipleMfaMethods %}
+                <p class="govuk-body">
+                    {{ 'pages.passwordResetMfaSms.details.chooseMfaMethodText' | translate }}
+                    <a href="{{ chooseMfaMethodHref }}" class="govuk-link"
+                        rel="noreferrer noopener">{{ 'pages.passwordResetMfaSms.details.chooseMfaMethodLinkText'| translate }}</a>.
+                </p>
+            {% endif %}
         {% endset %}
 
         {{ govukButton({

--- a/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
+++ b/src/components/reset-password-2fa-sms/reset-password-2fa-sms-controller.ts
@@ -96,10 +96,18 @@ export function resetPassword2FASmsGet(
         mfaResponse.data.code
       );
     }
+
+    const { mfaMethods } = req.session.user;
+
+    const phoneNumber = getDefaultSmsMfaMethod(mfaMethods)?.redactedPhoneNumber;
+    const hasMultipleMfaMethods = mfaMethods?.length > 1;
+    const chooseMfaMethodHref = PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES;
+
     return res.render(TEMPLATE_NAME, {
-      phoneNumber: getDefaultSmsMfaMethod(req.session.user.mfaMethods)
-        ?.redactedPhoneNumber,
+      phoneNumber,
       resendCodeLink: RESEND_CODE_LINK,
+      hasMultipleMfaMethods,
+      chooseMfaMethodHref,
     });
   };
 }

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -11,7 +11,6 @@ import { NOTIFICATION_TYPE } from "../../app.constants.js";
 import type { AccountInterventionsInterface } from "../account-intervention/types.js";
 import { accountInterventionService } from "../account-intervention/account-intervention-service.js";
 import { isLocked } from "../../utils/lock-helper.js";
-import { upsertDefaultSmsMfaMethod } from "../../utils/mfa.js";
 
 const TEMPLATE_NAME = "reset-password-check-email/index.njk";
 
@@ -51,12 +50,10 @@ export function resetPasswordCheckEmailGet(
       );
     }
 
-    if (result.success && req.session.user.enterEmailMfaType === undefined) {
+    if (result.success) {
+      req.session.user.mfaMethods = result.data.mfaMethods;
+
       req.session.user.enterEmailMfaType = result.data.mfaMethodType;
-      req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
-        req.session.user.mfaMethods,
-        { redactedPhoneNumber: result.data.phoneNumberLastThree }
-      );
     }
 
     if (!requestCode || result.success) {

--- a/src/components/reset-password-check-email/types.ts
+++ b/src/components/reset-password-check-email/types.ts
@@ -1,4 +1,8 @@
-import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
+import type {
+  ApiResponseResult,
+  DefaultApiResponse,
+  MfaMethod,
+} from "../../types.js";
 import type { Request } from "express";
 
 export interface ResetPasswordCheckEmailServiceInterface {
@@ -14,5 +18,6 @@ export interface ResetPasswordCheckEmailServiceInterface {
 
 export interface ResetPasswordRequestResponse extends DefaultApiResponse {
   mfaMethodType: string;
+  mfaMethods: MfaMethod[];
   phoneNumberLastThree: string;
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -647,8 +647,8 @@
         "sendCodeLinkText": "anfon y cod eto",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn.",
-        "changeGetSecurityCodesText": "Os na allwch gyrchu’r rhif ffôn ar gyfer eich GOV.UK One Login, gallwch ",
-        "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch"
+        "chooseMfaMethodText": "Os na allwch gael cod i’r rhif ffôn hwn gallwch ",
+        "chooseMfaMethodLinkText": "roi cynnig ar ffordd arall o gael cod diogelwch"
       },
       "upliftRequired": {
         "title": "Rhowch god diogelwch i barhau",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -647,8 +647,8 @@
         "sendCodeLinkText": "send the code again",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " if the code is not working or you did not receive it.",
-        "changeGetSecurityCodesText": "If you cannot access the phone number for your GOV.UK One Login, you can securely ",
-        "changeGetSecurityCodesLinkText": "change how you get security codes"
+        "chooseMfaMethodText": "If you cannot get a code to this phone number you can ",
+        "chooseMfaMethodLinkText": "try another way to get a security code"
       },
       "upliftRequired": {
         "title": "Enter a security code to continue",


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

At present, we only allow the user to use a single MFA method (`mfaMethodType` in the session) to authenticate themselves. We want to allow the user to choose which MFA method they use, if they have multiple MFA methods set up.

This ticket covers adding the prompt to the auth app / SMS screens to allow the user to choose their method, if they have multiple MFA methods set up. This link should take them to the "how do you want security codes" page which provides them with a set of radio inputs for their MFA methods.

This ticket does not cover selecting the backup MFA method - see AUT-4183 for this.

[Backend work ~~is being~~ has been completed under a separate PR to update the resetPasswordRequest response to return the mfaMethods array](https://github.com/govuk-one-login/authentication-api/pull/6553) - this PR is dependent on that work.

## Scenario Screenshots

| Scenario | Further Description | Screenshot(s) |
|---|---|---|
| User has a single MFA method (SMS) | No prompt shown | <img width="994" alt="Screenshot 2025-05-22 at 12 08 22" src="https://github.com/user-attachments/assets/fd8838bd-d934-4bae-a222-7396f77abc6e" />  |
| User has a single MFA method (auth app) | No prompt shown | <img width="994" alt="Screenshot 2025-05-22 at 12 07 53" src="https://github.com/user-attachments/assets/a48a7dbd-d4cb-45ce-8398-d787cd961967" />  |
| User has multiple MFA methods, mfaMethodType is auth app | Prompt shown on auth app screen, clicks through to "how do you want security codes" screen, no MFA reset option at the bottom of that screen | <img width="994" alt="Screenshot 2025-05-22 at 11 58 34" src="https://github.com/user-attachments/assets/210472a8-13ba-44ab-9162-875207bcc1f0" /> <img width="994" alt="Screenshot 2025-05-22 at 11 59 07" src="https://github.com/user-attachments/assets/82b91f59-5a79-4037-a92e-b2d6e84b2a64" /> <img width="994" alt="Screenshot 2025-05-22 at 12 06 12" src="https://github.com/user-attachments/assets/7fea35c3-8345-46d8-ae3b-6f3d226d0764" /> |
| User has multiple MFA methods, mfaMethodType is SMS | Prompt shown on SMS screen, clicks through to "how do you want security codes" screen, no MFA reset option at the bottom of that screen | <img width="994" alt="Screenshot 2025-05-22 at 16 11 47" src="https://github.com/user-attachments/assets/e01f90aa-bbad-4dbd-af92-f09bfd812d13" /> <img width="994" alt="Screenshot 2025-05-22 at 12 00 48" src="https://github.com/user-attachments/assets/88d4f768-2d12-4b32-bc89-3551c7c88a54" /> <img width="994" alt="Screenshot 2025-05-22 at 12 05 12" src="https://github.com/user-attachments/assets/c29eb6c7-d161-4b76-a1d6-818f4c01aabc" /> |
| User has multiple MFA methods, views all MFA options, submits without selecting radio input | Clicks through to "how do you want security codes" screen, does not select any radio input, clicks submit, error message shown and no MFA reset option at the bottom of that screen | <img width="994" alt="Screenshot 2025-05-22 at 11 59 23" src="https://github.com/user-attachments/assets/0d2dafaa-288a-47a2-93c7-77243c228bf7" /> |

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Deploy
1. Run through password reset journey with a single MFA method - no prompt
1. Run through password reset journey with a multiple MFA methods - prompt linking to the "how do you want security codes" page
  a. Page does not show MFA reset text at the bottom
  a. Submitting with no radio selected renders and error and the MFA reset text at the bottom is not rendered

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change. **- N/A**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [x] A UCD review has been performed. - approved

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- TODO**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.
