### PR TITLE
ATO-1669: Pass client_name claim to backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -82,5 +82,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["scope"] = startRequestParameters.scope;
   body["redirect_uri"] = startRequestParameters.rp_redirect_uri;
   body["state"] = startRequestParameters.rp_state;
+  body["client_name"] = startRequestParameters.client_name;
   return body;
 }

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -50,6 +50,7 @@ describe("authorize service", () => {
       scope: "openid",
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
+      client_name: "test-client-name",
     });
 
     expect(
@@ -63,6 +64,7 @@ describe("authorize service", () => {
           scope: "openid",
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
+          client_name: "test-client-name",
         },
         {
           headers: {
@@ -85,6 +87,7 @@ describe("authorize service", () => {
       scope: "openid",
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
+      client_name: "test-client-name",
     });
 
     expect(
@@ -97,6 +100,7 @@ describe("authorize service", () => {
           scope: "openid",
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
+          client_name: "test-client-name",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -115,6 +119,7 @@ describe("authorize service", () => {
       scope: "openid",
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
+      client_name: "test-client-name",
     });
 
     expect(
@@ -127,6 +132,7 @@ describe("authorize service", () => {
           scope: "openid",
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
+          client_name: "test-client-name",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -147,6 +153,7 @@ describe("authorize service", () => {
       scope: "openid",
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
+      client_name: "test-client-name",
     });
 
     expect(
@@ -160,6 +167,7 @@ describe("authorize service", () => {
           scope: "openid",
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
+          client_name: "test-client-name",
         },
         {
           headers: {
@@ -183,6 +191,7 @@ describe("authorize service", () => {
       scope: "openid",
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
+      client_name: "test-client-name",
     });
 
     expect(
@@ -197,6 +206,7 @@ describe("authorize service", () => {
           scope: "openid",
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
+          client_name: "test-client-name",
         },
         {
           headers: {
@@ -222,6 +232,7 @@ describe("authorize service", () => {
       rp_state: "1234567890",
       cookie_consent: "accept",
       _ga: "987654321",
+      client_name: "test-client-name",
     });
 
     expect(
@@ -237,6 +248,7 @@ describe("authorize service", () => {
           state: "1234567890",
           cookie_consent: "accept",
           _ga: "987654321",
+          client_name: "test-client-name",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -16,6 +16,7 @@ export interface StartRequestParameters {
   rp_state: string;
   requested_level_of_confidence?: string;
   requested_credential_strength: string;
+  client_name: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

We would like to send the client name to the auth backend, so auth does not need to rely on the client registry to get this value. We are already sending the claim from orch to auth frontend, this PR is passing this claim onto the backend.

Deployed to authdev and tested a few journeys. All were successful

## Checklist

- [x] Performance analyst has been notified of the change. n/a
- [x] A UCD review has been performed. n/a
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. n/a
- [x] Documentation has been updated to reflect these changes. n/a

