### PR TITLE
AUT-4284: Add feature flag to redirect to new privacy notice

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -278,6 +278,29 @@ Conditions:
       ]
       - "Yes"
 
+  PrivacyNoticeRedirectEnabled:
+    Fn::Or:
+      - Fn::And:
+          - !Condition UseSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                EnvironmentConfiguration,
+                !Ref SubEnvironment,
+                PrivacyNoticeRedirectEnabled,
+                DefaultValue: "No",
+              ]
+              - "Yes"
+      - Fn::And:
+          - !Condition NotSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                EnvironmentConfiguration,
+                !Ref Environment,
+                PrivacyNoticeRedirectEnabled,
+                DefaultValue: "No",
+              ]
+              - "Yes"
+
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -301,6 +324,7 @@ Mappings:
       UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       DeviceIntelligenceEnabled: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
     authdev2:
       cloudfrontDistributionStackName: "authdev2-cloudfront"
       orchToAuthSigningPublicKey: |
@@ -318,6 +342,7 @@ Mappings:
       UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       DeviceIntelligenceEnabled: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
     dev:
       DeployServiceDownPage: "No"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -345,6 +370,7 @@ Mappings:
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       DeviceIntelligenceEnabled: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -372,6 +398,7 @@ Mappings:
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       DeviceIntelligenceEnabled: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -406,6 +433,7 @@ Mappings:
       Enableipvspinner: "No"
       UseAlarmActions: "Yes"
       DeviceIntelligenceEnabled: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
     integration:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -434,6 +462,7 @@ Mappings:
       Enableipvspinner: "No"
       orchStubToAuth: ""
       UseAlarmActions: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
     production:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -464,6 +493,7 @@ Mappings:
       Enableipvspinner: "No"
       orchStubToAuth: ""
       UseAlarmActions: "Yes"
+      PrivacyNoticeRedirectEnabled: "No"
 
 Globals:
   Function:
@@ -987,6 +1017,8 @@ Resources:
               Value: !If [UseRouteUsersToNewIpvJourney, "1", "0"]
             - Name: DEVICE_INTELLIGENCE_ENABLED
               Value: !If [DeviceIntelligenceEnabled, "1", "0"]
+            - Name: PRIVACY_NOTICE_REDIRECT_ENABLED
+              Value: !If [PrivacyNoticeRedirectEnabled, "1", "0"]
           Secrets:
             - Name: API_KEY
               ValueFrom: !If

--- a/src/components/common/footer/footer-pages-controller.ts
+++ b/src/components/common/footer/footer-pages-controller.ts
@@ -1,8 +1,14 @@
 import type { Request, Response } from "express";
 import { PATH_NAMES } from "../../../app.constants.js";
 import { supportTypeIsGovService } from "../../../utils/request.js";
+import { getPrivacyNoticeRedirectEnabled } from "../../../config.js";
+
 export function privacyStatementGet(req: Request, res: Response): void {
-  res.render("common/footer/privacy-statement.njk");
+  if (getPrivacyNoticeRedirectEnabled()) {
+    redirectToExternalPrivacyNotice(req, res);
+  } else {
+    res.render("common/footer/privacy-statement.njk");
+  }
 }
 
 export function termsConditionsGet(req: Request, res: Response): void {
@@ -29,6 +35,17 @@ export function supportPost(req: Request, res: Response): void {
   } else {
     res.redirect(res.locals.contactUsLinkUrl);
   }
+}
+
+function redirectToExternalPrivacyNotice(req: Request, res: Response) {
+  if (req.i18n.language === "cy") {
+    return res.redirect(
+      "https://gov.uk/government/publications/govuk-one-login-privacy-notice.cy"
+    );
+  }
+  res.redirect(
+    "https://gov.uk/government/publications/govuk-one-login-privacy-notice"
+  );
 }
 
 function appendQueryParam(param: string, value: string, url: string) {

--- a/src/components/common/footer/tests/footer-pages.integration.test.ts
+++ b/src/components/common/footer/tests/footer-pages.integration.test.ts
@@ -1,0 +1,69 @@
+import { describe } from "mocha";
+import { request } from "../../../../../test/utils/test-utils.js";
+import { PATH_NAMES } from "../../../../app.constants.js";
+import { createApp } from "../../../../app.js";
+import { expect } from "chai";
+
+describe("Integration:: privacy notice link", () => {
+  it("should render the privacy notice when the feature flag is disabled", async () => {
+    process.env.PRIVACY_NOTICE_REDIRECT_ENABLED = "0";
+    const app = await createApp();
+    await request(app, (test) => test.get(PATH_NAMES.PRIVACY_POLICY), {
+      expectAnalyticsPropertiesMatchSnapshot: false,
+    })
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.contain("GOV.UK One Login privacy notice");
+      });
+  });
+
+  it("should redirect to the privacy notice when the feature flag is enabled", async () => {
+    process.env.PRIVACY_NOTICE_REDIRECT_ENABLED = "1";
+    const app = await createApp();
+    await request(app, (test) => test.get(PATH_NAMES.PRIVACY_POLICY), {
+      expectAnalyticsPropertiesMatchSnapshot: false,
+    })
+      .expect(302)
+      .then((res) => {
+        expect(res.headers["location"]).to.equal(
+          "https://gov.uk/government/publications/govuk-one-login-privacy-notice"
+        );
+      });
+  });
+
+  it("should redirect to the welsh privacy notice when the lng cookie is cy", async () => {
+    process.env.PRIVACY_NOTICE_REDIRECT_ENABLED = "1";
+    const app = await createApp();
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.PRIVACY_POLICY).set("cookie", ["lng=cy"]),
+      {
+        expectAnalyticsPropertiesMatchSnapshot: false,
+      }
+    )
+      .expect(302)
+      .then((res) => {
+        expect(res.headers["location"]).to.equal(
+          "https://gov.uk/government/publications/govuk-one-login-privacy-notice.cy"
+        );
+      });
+  });
+
+  it("should redirect to the welsh privacy notice when the lng query param is cy", async () => {
+    process.env.PRIVACY_NOTICE_REDIRECT_ENABLED = "1";
+    const app = await createApp();
+    await request(
+      app,
+      (test) => test.get(PATH_NAMES.PRIVACY_POLICY + "?lng=cy"),
+      {
+        expectAnalyticsPropertiesMatchSnapshot: false,
+      }
+    )
+      .expect(302)
+      .then((res) => {
+        expect(res.headers["location"]).to.equal(
+          "https://gov.uk/government/publications/govuk-one-login-privacy-notice.cy"
+        );
+      });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -186,3 +186,7 @@ export function showTestBanner(): boolean {
 export function getDeviceIntelligenceEnabled(): boolean {
   return process.env.DEVICE_INTELLIGENCE_ENABLED === "1";
 }
+
+export function getPrivacyNoticeRedirectEnabled(): boolean {
+  return process.env.PRIVACY_NOTICE_REDIRECT_ENABLED === "1";
+}


### PR DESCRIPTION

## What
This is disabled in all environments as the new privacy notice page does not exist yet

Add a redirect to the new privacy notice page, behind a feature flag. 

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
