### PR TITLE
ATO-1673: Pass service_type claim to auth backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -83,5 +83,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["redirect_uri"] = startRequestParameters.rp_redirect_uri;
   body["state"] = startRequestParameters.rp_state;
   body["client_name"] = startRequestParameters.client_name;
+  body["service_type"] = startRequestParameters.service_type;
   return body;
 }

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -51,6 +51,7 @@ describe("authorize service", () => {
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
       client_name: "test-client-name",
+      service_type: "essential",
     });
 
     expect(
@@ -65,6 +66,7 @@ describe("authorize service", () => {
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
           client_name: "test-client-name",
+          service_type: "essential",
         },
         {
           headers: {
@@ -88,6 +90,7 @@ describe("authorize service", () => {
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
       client_name: "test-client-name",
+      service_type: "essential",
     });
 
     expect(
@@ -101,6 +104,7 @@ describe("authorize service", () => {
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
           client_name: "test-client-name",
+          service_type: "essential",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -120,6 +124,7 @@ describe("authorize service", () => {
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
       client_name: "test-client-name",
+      service_type: "essential",
     });
 
     expect(
@@ -133,6 +138,7 @@ describe("authorize service", () => {
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
           client_name: "test-client-name",
+          service_type: "essential",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -154,6 +160,7 @@ describe("authorize service", () => {
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
       client_name: "test-client-name",
+      service_type: "essential",
     });
 
     expect(
@@ -168,6 +175,7 @@ describe("authorize service", () => {
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
           client_name: "test-client-name",
+          service_type: "essential",
         },
         {
           headers: {
@@ -192,6 +200,7 @@ describe("authorize service", () => {
       rp_redirect_uri: "http://example.com/redirect",
       rp_state: "1234567890",
       client_name: "test-client-name",
+      service_type: "essential",
     });
 
     expect(
@@ -207,6 +216,7 @@ describe("authorize service", () => {
           redirect_uri: "http://example.com/redirect",
           state: "1234567890",
           client_name: "test-client-name",
+          service_type: "essential",
         },
         {
           headers: {
@@ -233,6 +243,7 @@ describe("authorize service", () => {
       cookie_consent: "accept",
       _ga: "987654321",
       client_name: "test-client-name",
+      service_type: "essential",
     });
 
     expect(
@@ -249,6 +260,7 @@ describe("authorize service", () => {
           cookie_consent: "accept",
           _ga: "987654321",
           client_name: "test-client-name",
+          service_type: "essential",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -17,6 +17,7 @@ export interface StartRequestParameters {
   requested_level_of_confidence?: string;
   requested_credential_strength: string;
   client_name: string;
+  service_type: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

We would like to send the service type to the auth backend, so auth does not need to rely on the client registry to get this value. We are already sending the claim from orch to auth frontend, this PR is passing this claim onto the backend.

Deployed to authdev and tested. Journeys went fine.

## Checklist

- [x] Performance analyst has been notified of the change. n/a
- [x] A UCD review has been performed. n/a
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. n/a
- [x] Documentation has been updated to reflect these changes. n/a

