### PR TITLE
ATO-1675: pass cookie_consent_shared claim to backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -84,5 +84,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["state"] = startRequestParameters.rp_state;
   body["client_name"] = startRequestParameters.client_name;
   body["service_type"] = startRequestParameters.service_type;
+  body["cookie_consent_shared"] = startRequestParameters.cookie_consent_shared;
   return body;
 }

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -52,6 +52,7 @@ describe("authorize service", () => {
       rp_state: "1234567890",
       client_name: "test-client-name",
       service_type: "essential",
+      cookie_consent_shared: false,
     });
 
     expect(
@@ -67,6 +68,7 @@ describe("authorize service", () => {
           state: "1234567890",
           client_name: "test-client-name",
           service_type: "essential",
+          cookie_consent_shared: false,
         },
         {
           headers: {
@@ -91,6 +93,7 @@ describe("authorize service", () => {
       rp_state: "1234567890",
       client_name: "test-client-name",
       service_type: "essential",
+      cookie_consent_shared: false,
     });
 
     expect(
@@ -105,6 +108,7 @@ describe("authorize service", () => {
           state: "1234567890",
           client_name: "test-client-name",
           service_type: "essential",
+          cookie_consent_shared: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -125,6 +129,7 @@ describe("authorize service", () => {
       rp_state: "1234567890",
       client_name: "test-client-name",
       service_type: "essential",
+      cookie_consent_shared: false,
     });
 
     expect(
@@ -139,6 +144,7 @@ describe("authorize service", () => {
           state: "1234567890",
           client_name: "test-client-name",
           service_type: "essential",
+          cookie_consent_shared: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -161,6 +167,7 @@ describe("authorize service", () => {
       rp_state: "1234567890",
       client_name: "test-client-name",
       service_type: "essential",
+      cookie_consent_shared: false,
     });
 
     expect(
@@ -176,6 +183,7 @@ describe("authorize service", () => {
           state: "1234567890",
           client_name: "test-client-name",
           service_type: "essential",
+          cookie_consent_shared: false,
         },
         {
           headers: {
@@ -201,6 +209,7 @@ describe("authorize service", () => {
       rp_state: "1234567890",
       client_name: "test-client-name",
       service_type: "essential",
+      cookie_consent_shared: false,
     });
 
     expect(
@@ -217,6 +226,7 @@ describe("authorize service", () => {
           state: "1234567890",
           client_name: "test-client-name",
           service_type: "essential",
+          cookie_consent_shared: false,
         },
         {
           headers: {
@@ -244,6 +254,7 @@ describe("authorize service", () => {
       _ga: "987654321",
       client_name: "test-client-name",
       service_type: "essential",
+      cookie_consent_shared: false,
     });
 
     expect(
@@ -261,6 +272,7 @@ describe("authorize service", () => {
           _ga: "987654321",
           client_name: "test-client-name",
           service_type: "essential",
+          cookie_consent_shared: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -18,6 +18,7 @@ export interface StartRequestParameters {
   requested_credential_strength: string;
   client_name: string;
   service_type: string;
+  cookie_consent_shared: boolean;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

We would like to send the cookie consent shared to the auth backend, so auth does not need to rely on the client registry to get this value. We are already sending the claim from orch to auth frontend, this PR is passing this claim onto the backend.

Will deploy to dev and test when dev is free

## Checklist

- [x] Performance analyst has been notified of the change. **N/A**
- [x] A UCD review has been performed. **N/A**
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **N/A**
- [x] Documentation has been updated to reflect these changes. **N/A**
