### PR TITLE
ATO-1677: pass is one login service to backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -85,5 +85,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["client_name"] = startRequestParameters.client_name;
   body["service_type"] = startRequestParameters.service_type;
   body["cookie_consent_shared"] = startRequestParameters.cookie_consent_shared;
+  body["is_one_login_service"] = startRequestParameters.is_one_login_service;
   return body;
 }

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -53,6 +53,7 @@ describe("authorize service", () => {
       client_name: "test-client-name",
       service_type: "essential",
       cookie_consent_shared: false,
+      is_one_login_service: false,
     });
 
     expect(
@@ -69,6 +70,7 @@ describe("authorize service", () => {
           client_name: "test-client-name",
           service_type: "essential",
           cookie_consent_shared: false,
+          is_one_login_service: false,
         },
         {
           headers: {
@@ -94,6 +96,7 @@ describe("authorize service", () => {
       client_name: "test-client-name",
       service_type: "essential",
       cookie_consent_shared: false,
+      is_one_login_service: false,
     });
 
     expect(
@@ -109,6 +112,7 @@ describe("authorize service", () => {
           client_name: "test-client-name",
           service_type: "essential",
           cookie_consent_shared: false,
+          is_one_login_service: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -130,6 +134,7 @@ describe("authorize service", () => {
       client_name: "test-client-name",
       service_type: "essential",
       cookie_consent_shared: false,
+      is_one_login_service: false,
     });
 
     expect(
@@ -145,6 +150,7 @@ describe("authorize service", () => {
           client_name: "test-client-name",
           service_type: "essential",
           cookie_consent_shared: false,
+          is_one_login_service: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -168,6 +174,7 @@ describe("authorize service", () => {
       client_name: "test-client-name",
       service_type: "essential",
       cookie_consent_shared: false,
+      is_one_login_service: false,
     });
 
     expect(
@@ -184,6 +191,7 @@ describe("authorize service", () => {
           client_name: "test-client-name",
           service_type: "essential",
           cookie_consent_shared: false,
+          is_one_login_service: false,
         },
         {
           headers: {
@@ -210,6 +218,7 @@ describe("authorize service", () => {
       client_name: "test-client-name",
       service_type: "essential",
       cookie_consent_shared: false,
+      is_one_login_service: false,
     });
 
     expect(
@@ -227,6 +236,7 @@ describe("authorize service", () => {
           client_name: "test-client-name",
           service_type: "essential",
           cookie_consent_shared: false,
+          is_one_login_service: false,
         },
         {
           headers: {
@@ -255,6 +265,7 @@ describe("authorize service", () => {
       client_name: "test-client-name",
       service_type: "essential",
       cookie_consent_shared: false,
+      is_one_login_service: false,
     });
 
     expect(
@@ -273,6 +284,7 @@ describe("authorize service", () => {
           client_name: "test-client-name",
           service_type: "essential",
           cookie_consent_shared: false,
+          is_one_login_service: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -19,6 +19,7 @@ export interface StartRequestParameters {
   client_name: string;
   service_type: string;
   cookie_consent_shared: boolean;
+  is_one_login_service: boolean;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

We would like to send the cookie consent shared to the auth backend, so auth does not need to rely on the client registry to get this value. We are already sending the claim from orch to auth frontend, this PR is passing this claim onto the backend.

Tested on authdev2 for a couple of journeys and all works

## Checklist

- [x] Performance analyst has been notified of the change. **N/A**
- [x] A UCD review has been performed. **N/A**
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **N/A**
- [x] Documentation has been updated to reflect these changes. **N/A**
