### PR TITLE
ATO-1605: pass subject_type to backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -87,5 +87,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["cookie_consent_shared"] = startRequestParameters.cookie_consent_shared;
   body["is_smoke_test"] = startRequestParameters.is_smoke_test;
   body["is_one_login_service"] = startRequestParameters.is_one_login_service;
+  body["subject_type"] = startRequestParameters.subject_type;
   return body;
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -54,6 +54,7 @@ export type Claims = {
   requested_level_of_confidence?: string;
   requested_credential_strength: string;
   is_smoke_test: boolean;
+  subject_type: string;
 };
 
 export const requiredClaimsKeys = [
@@ -76,4 +77,5 @@ export const requiredClaimsKeys = [
   "scope",
   "requested_credential_strength",
   "is_smoke_test",
+  "subject_type",
 ];

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -55,6 +55,7 @@ describe("authorize service", () => {
       cookie_consent_shared: false,
       is_smoke_test: false,
       is_one_login_service: false,
+      subject_type: "pairwise",
     });
 
     expect(
@@ -73,6 +74,7 @@ describe("authorize service", () => {
           cookie_consent_shared: false,
           is_smoke_test: false,
           is_one_login_service: false,
+          subject_type: "pairwise",
         },
         {
           headers: {
@@ -100,6 +102,7 @@ describe("authorize service", () => {
       cookie_consent_shared: false,
       is_smoke_test: false,
       is_one_login_service: false,
+      subject_type: "pairwise",
     });
 
     expect(
@@ -117,6 +120,7 @@ describe("authorize service", () => {
           cookie_consent_shared: false,
           is_smoke_test: false,
           is_one_login_service: false,
+          subject_type: "pairwise",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -140,6 +144,7 @@ describe("authorize service", () => {
       cookie_consent_shared: false,
       is_smoke_test: false,
       is_one_login_service: false,
+      subject_type: "pairwise",
     });
 
     expect(
@@ -157,6 +162,7 @@ describe("authorize service", () => {
           cookie_consent_shared: false,
           is_smoke_test: false,
           is_one_login_service: false,
+          subject_type: "pairwise",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -182,6 +188,7 @@ describe("authorize service", () => {
       cookie_consent_shared: false,
       is_smoke_test: false,
       is_one_login_service: false,
+      subject_type: "pairwise",
     });
 
     expect(
@@ -200,6 +207,7 @@ describe("authorize service", () => {
           cookie_consent_shared: false,
           is_smoke_test: false,
           is_one_login_service: false,
+          subject_type: "pairwise",
         },
         {
           headers: {
@@ -228,6 +236,7 @@ describe("authorize service", () => {
       cookie_consent_shared: false,
       is_smoke_test: false,
       is_one_login_service: false,
+      subject_type: "pairwise",
     });
 
     expect(
@@ -247,6 +256,7 @@ describe("authorize service", () => {
           cookie_consent_shared: false,
           is_smoke_test: false,
           is_one_login_service: false,
+          subject_type: "pairwise",
         },
         {
           headers: {
@@ -277,6 +287,7 @@ describe("authorize service", () => {
       cookie_consent_shared: false,
       is_smoke_test: false,
       is_one_login_service: false,
+      subject_type: "pairwise",
     });
 
     expect(
@@ -297,6 +308,7 @@ describe("authorize service", () => {
           cookie_consent_shared: false,
           is_smoke_test: false,
           is_one_login_service: false,
+          subject_type: "pairwise",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -33,6 +33,7 @@ export function createMockClaims(): Claims {
     requested_credential_strength: "Cl.Cm",
     scope: "openid",
     is_smoke_test: false,
+    subject_type: "pairwise",
   };
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -21,6 +21,7 @@ export interface StartRequestParameters {
   cookie_consent_shared: boolean;
   is_smoke_test: boolean;
   is_one_login_service: boolean;
+  subject_type: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

We would like to send the subject type to the auth backend, so auth does not need to rely on the client registry to get this value. We are already sending the claim from orch to auth frontend, this PR is passing this claim onto the backend.

Tested on authdev2 for a couple of journeys and all works

## Checklist

- [x] Performance analyst has been notified of the change.
- [x] A UCD review has been performed.
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.
- [x] Documentation has been updated to reflect these changes.
