### PR TITLE
BAU: Working end-to-end local frontend to hosted orchstub connection 

### DIFF
--- a/dev-app-orchstub.js
+++ b/dev-app-orchstub.js
@@ -33,9 +33,10 @@ app.get("/", async (req, res) => {
   }
 
   const channel = req.query.channel || "none";
+  const reauthenticate = req.query.reauthenticate || "";
 
   return res.redirect(
-    `${stubUrl}?auto-submit=yes&level=Cl.Cm&authenticated=no&channel=${channel}`
+    `${stubUrl}?auto-submit=yes&level=Cl.Cm&authenticated=no&channel=${channel}&reauthenticate=${reauthenticate}`
   );
 });
 

--- a/dev-app-orchstub.js
+++ b/dev-app-orchstub.js
@@ -2,8 +2,6 @@
 
 import express from "express";
 import pino from "pino";
-import { default as axios } from "axios";
-import url from "url";
 
 const stubUrls = {
   authdev2: "https://orchstub-authdev2.signin.dev.account.gov.uk",
@@ -19,56 +17,12 @@ const app = express();
 const port = process.env.PORT || 3002;
 const frontendPort = process.env.FRONTEND_PORT || 3000;
 const stubUrl = stubUrls[process.env.DEPLOYMENT_NAME];
-const sessionExpiry = Number(process.env.SESSION_EXPIRY || 3600000);
 
 if (stubUrl === undefined) {
   logger.warn(
     `Warning: No orch stub configured for environment ${process.env.DEPLOYMENT_NAME}`
   );
 }
-
-const getCookieValue = (cookie, cookieName) => {
-  let value;
-  cookie.forEach((item) => {
-    const name = item.split("=")[0].toLowerCase().trim();
-    if (name.indexOf(cookieName) !== -1) {
-      value = item.split("=")[1];
-    }
-  });
-  return value;
-};
-
-const setGsCookie = (orchStubResponse, res) => {
-  let sessionCookieValue;
-  const sessionCookie = orchStubResponse.headers["set-cookie"][0];
-  if (sessionCookie) {
-    sessionCookieValue = getCookieValue(sessionCookie.split(";"), "gs");
-    res.cookie("gs", sessionCookieValue, {
-      maxAge: sessionExpiry,
-    });
-  }
-};
-
-const setLngCookie = (orchStubResponse, res) => {
-  let lngCookieValue;
-  const lngCookie = orchStubResponse.headers["set-cookie"][2];
-  if (lngCookie) {
-    lngCookieValue = getCookieValue(lngCookie.split(";"), "lng");
-    res.cookie("lng", lngCookieValue, {
-      maxAge: sessionExpiry,
-    });
-  }
-};
-
-const buildRedirectURL = (response) => {
-  const location = url.parse(response.headers.location, true);
-  logger.info(`orch response location is: ${JSON.stringify(location)}`);
-
-  const params = new URLSearchParams(location.query);
-  const redirectUri = new URL(`http://localhost:${frontendPort}/authorize`);
-  redirectUri.search = params.toString();
-  return redirectUri;
-};
 
 app.get("/", async (req, res) => {
   if (stubUrl === undefined) {
@@ -77,23 +31,12 @@ app.get("/", async (req, res) => {
         `Currently, this stub is for environments configured for the orchestration stub (${Object.keys(stubUrls).join(", ")})`
     );
   }
-  const channel = req.query.channel || "none";
-  // call orch stub
-  const orchStubResponse = await axios.post(
-    stubUrl,
-    `reauthenticate=&level=Cl.Cm&authenticated=no&authenticatedLevel=Cl.Cm&channel=${channel}`,
-    {
-      validateStatus: (status) => {
-        return status === 302;
-      },
-      maxRedirects: 0,
-    }
-  );
 
-  setGsCookie(orchStubResponse, res);
-  setLngCookie(orchStubResponse, res);
-  const redirectUrl = buildRedirectURL(orchStubResponse);
-  res.redirect(redirectUrl.toString());
+  const channel = req.query.channel || "none";
+
+  return res.redirect(
+    `${stubUrl}?auto-submit=yes&level=Cl.Cm&authenticated=no&channel=${channel}`
+  );
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## What

Previously our `dev-app-orchstub.js` would make a request to the orchstub and forward on the returned payload and cookies. When using this against a hosted orchstub and localhost frontend there would be a mismatch between the `gs` cookies set on the domains.

Here we utilise a new orchstub feature to allow the journey to start on a GET request, allowing successful setup of the same session across hostnames.

Also added is the ability to specify a url encoded `rp_pairwise_id` for reauth journeys.

## How to review

1. Code review
1. Start locally against dev (with https://github.com/govuk-one-login/authentication-stubs/pull/371 deployed)
1. Go to http://localhost:3002
1. Fully authenticate back to the stub
1. Copy the `rp_pairwise_id` and URL encode it
1. Go to http://localhost:3002?reauthenticate=[URL encoded ID here]
1. See reauth journey starts

## Related PRs

- https://github.com/govuk-one-login/authentication-stubs/pull/371