### PR TITLE
ATO-1710: send is_identity_verification_required to auth backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -88,5 +88,7 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["is_smoke_test"] = startRequestParameters.is_smoke_test;
   body["is_one_login_service"] = startRequestParameters.is_one_login_service;
   body["subject_type"] = startRequestParameters.subject_type;
+  body["is_identity_verification_required"] =
+    startRequestParameters.is_identity_verification_required;
   return body;
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -55,6 +55,7 @@ export type Claims = {
   requested_credential_strength: string;
   is_smoke_test: boolean;
   subject_type: string;
+  is_identity_verification_required: boolean;
 };
 
 export const requiredClaimsKeys = [
@@ -78,4 +79,5 @@ export const requiredClaimsKeys = [
   "requested_credential_strength",
   "is_smoke_test",
   "subject_type",
+  "is_identity_verification_required",
 ];

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -56,6 +56,7 @@ describe("authorize service", () => {
       is_smoke_test: false,
       is_one_login_service: false,
       subject_type: "pairwise",
+      is_identity_verification_required: false,
     });
 
     expect(
@@ -75,6 +76,7 @@ describe("authorize service", () => {
           is_smoke_test: false,
           is_one_login_service: false,
           subject_type: "pairwise",
+          is_identity_verification_required: false,
         },
         {
           headers: {
@@ -103,6 +105,7 @@ describe("authorize service", () => {
       is_smoke_test: false,
       is_one_login_service: false,
       subject_type: "pairwise",
+      is_identity_verification_required: false,
     });
 
     expect(
@@ -121,6 +124,7 @@ describe("authorize service", () => {
           is_smoke_test: false,
           is_one_login_service: false,
           subject_type: "pairwise",
+          is_identity_verification_required: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -145,6 +149,7 @@ describe("authorize service", () => {
       is_smoke_test: false,
       is_one_login_service: false,
       subject_type: "pairwise",
+      is_identity_verification_required: false,
     });
 
     expect(
@@ -163,6 +168,7 @@ describe("authorize service", () => {
           is_smoke_test: false,
           is_one_login_service: false,
           subject_type: "pairwise",
+          is_identity_verification_required: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -189,6 +195,7 @@ describe("authorize service", () => {
       is_smoke_test: false,
       is_one_login_service: false,
       subject_type: "pairwise",
+      is_identity_verification_required: false,
     });
 
     expect(
@@ -208,6 +215,7 @@ describe("authorize service", () => {
           is_smoke_test: false,
           is_one_login_service: false,
           subject_type: "pairwise",
+          is_identity_verification_required: false,
         },
         {
           headers: {
@@ -237,6 +245,7 @@ describe("authorize service", () => {
       is_smoke_test: false,
       is_one_login_service: false,
       subject_type: "pairwise",
+      is_identity_verification_required: false,
     });
 
     expect(
@@ -257,6 +266,7 @@ describe("authorize service", () => {
           is_smoke_test: false,
           is_one_login_service: false,
           subject_type: "pairwise",
+          is_identity_verification_required: false,
         },
         {
           headers: {
@@ -288,6 +298,7 @@ describe("authorize service", () => {
       is_smoke_test: false,
       is_one_login_service: false,
       subject_type: "pairwise",
+      is_identity_verification_required: false,
     });
 
     expect(
@@ -309,6 +320,7 @@ describe("authorize service", () => {
           is_smoke_test: false,
           is_one_login_service: false,
           subject_type: "pairwise",
+          is_identity_verification_required: false,
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -34,6 +34,7 @@ export function createMockClaims(): Claims {
     scope: "openid",
     is_smoke_test: false,
     subject_type: "pairwise",
+    is_identity_verification_required: false,
   };
 }
 

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -22,6 +22,7 @@ export interface StartRequestParameters {
   is_smoke_test: boolean;
   is_one_login_service: boolean;
   subject_type: string;
+  is_identity_verification_required: boolean;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

This PR sends is_identity_verification_required to the backend.

## Checklist

- [x] Performance analyst has been notified of the change. **N/A**
- [x] A UCD review has been performed. **N/A**
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **N/A**
- [x] Documentation has been updated to reflect these changes. **N/A**
