### PR TITLE
AUT-4280: Cookie banner should not be displayed for the GOV.UK App

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -141,7 +141,10 @@ export function authorizeGet(
 
     const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);
 
-    if (req.session.user.channel === CHANNEL.STRATEGIC_APP) {
+    if (
+      req.session.user.channel === CHANNEL.STRATEGIC_APP ||
+      req.session.user.channel === CHANNEL.GENERIC_APP
+    ) {
       const consentCookieValue = cookiesConsentService.createConsentCookieValue(
         COOKIE_CONSENT.REJECT
       );

--- a/test/helpers/mock-cookie-consent-service-helper.ts
+++ b/test/helpers/mock-cookie-consent-service-helper.ts
@@ -1,5 +1,6 @@
 import { sinon } from "../utils/test-utils.js";
 import type { CookieConsentServiceInterface } from "../../src/components/common/cookie-consent/types.js";
+import { cookieConsentService } from "../../src/components/common/cookie-consent/cookie-consent-service.js";
 export function createMockCookieConsentService(
   userCookieConsentPreference: string
 ): CookieConsentServiceInterface {
@@ -14,5 +15,30 @@ export function createMockCookieConsentService(
       }),
       expires: expiryDate,
     }),
+  };
+}
+
+export function createCookieConsentMock(): CookieConsentServiceInterface {
+  const expiryDate: Date = new Date();
+  expiryDate.setFullYear(expiryDate.getFullYear() + 1);
+
+  const stub = sinon.stub(cookieConsentService(), "createConsentCookieValue");
+  stub.withArgs("accept").returns({
+    value: JSON.stringify({
+      analytics: "true",
+    }),
+    expires: expiryDate,
+  });
+
+  stub.withArgs("reject").returns({
+    value: JSON.stringify({
+      analytics: "false",
+    }),
+    expires: expiryDate,
+  });
+
+  return {
+    getCookieConsent: sinon.fake(),
+    createConsentCookieValue: stub,
   };
 }


### PR DESCRIPTION


## What

### Cookie banner should not be displayed for the GOV.UK App

Cookies should be rejected by default like for the V2 App.

Includes changes to tests which check the cookie consent behaviour is correct for the channel.

Previously the test succeeded regardless of whether the channel should present consent or not, because the 'createMockCookieConsentService' created a mock which always returned a response with the consent value passed in when creating the mock, rather than the value passed in when using the mock.  A new mock has been created which responds to the values of paramaters passed in, see 'createCookieConsentMock'.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
