### PR TITLE
BAU: temporarily increase ECS scaling configuration to support higher load

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -467,7 +467,7 @@ Mappings:
     production:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
-      frontendAutoScalingMinCount: 9
+      frontendAutoScalingMinCount: 15
       frontendAutoScalingMaxCount: 240
       frontendTaskDefinitionCpu: 1024
       frontendTaskDefinitionMemory: 2048
@@ -652,7 +652,7 @@ Resources:
       Namespace: AWS/ECS
       Period: 60
       Statistic: Average
-      Threshold: 40
+      Threshold: 30
       DatapointsToAlarm: 1
       Dimensions:
         - Name: ClusterName


### PR DESCRIPTION
## What

Temporarily increase ECS scaling configuration to support higher load.

In case of higher expected load merge this PR to increase the default task count and decrease the % cpu where ECS starts to scale.  This results in a higher initial base load before scaling starts and faster scaling.

## How to review

1. Code Review

## Related PRs

#2859 


