### PR TITLE
AUT-4452: Method management password reset MFA lockout fixes

### DIFF
--- a/src/components/common/journey/journey.ts
+++ b/src/components/common/journey/journey.ts
@@ -4,6 +4,7 @@ type GetJourneyTypeFromUserSessionOptions = {
   fallbackJourneyType?: JOURNEY_TYPE;
   includeReauthentication?: true;
   includeAccountRecovery?: true;
+  includePasswordResetMfa?: true;
 };
 
 /**
@@ -37,6 +38,10 @@ function getJourneyTypeFromUserSession(
     userSession.isAccountRecoveryJourney
   ) {
     return JOURNEY_TYPE.ACCOUNT_RECOVERY;
+  }
+
+  if (options.includePasswordResetMfa && userSession.isPasswordResetJourney) {
+    return JOURNEY_TYPE.PASSWORD_RESET_MFA;
   }
 
   // We should be able to know the user journey at all

--- a/src/components/common/journey/tests/journey.test.ts
+++ b/src/components/common/journey/tests/journey.test.ts
@@ -62,6 +62,24 @@ describe("journey", () => {
         },
         expectedJourneyType: undefined,
       },
+      // Return PASSWORD_RESET_MFA as expected
+      {
+        options: {
+          includePasswordResetMfa: true,
+        },
+        userSession: {
+          isPasswordResetJourney: true,
+        },
+        expectedJourneyType: JOURNEY_TYPE.PASSWORD_RESET_MFA,
+      },
+      // Return PASSWORD_RESET_MFA prevented as not included in options
+      {
+        options: {},
+        userSession: {
+          isPasswordResetJourney: true,
+        },
+        expectedJourneyType: undefined,
+      },
     ];
 
     callVariants.forEach(({ options, userSession, expectedJourneyType }) => {

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -84,6 +84,7 @@ export function sendMfaGeneric(
       activeMfaMethodId,
       getJourneyTypeFromUserSession(req.session.user, {
         includeReauthentication: true,
+        includePasswordResetMfa: true,
       })
     );
 

--- a/src/components/common/mfa/tests/send-mfa-controller.test.ts
+++ b/src/components/common/mfa/tests/send-mfa-controller.test.ts
@@ -68,6 +68,7 @@ describe("send mfa controller", () => {
         getJourneyTypeFromUserSessionSpy
       ).to.have.been.calledOnceWithExactly(req.session.user, {
         includeReauthentication: true,
+        includePasswordResetMfa: true,
       });
       expect(getJourneyTypeFromUserSessionSpy.getCall(0).returnValue).to.equal(
         JOURNEY_TYPE.REAUTHENTICATION
@@ -113,6 +114,7 @@ describe("send mfa controller", () => {
         getJourneyTypeFromUserSessionSpy
       ).to.have.been.calledOnceWithExactly(req.session.user, {
         includeReauthentication: true,
+        includePasswordResetMfa: true,
       });
       expect(getJourneyTypeFromUserSessionSpy.getCall(0).returnValue).to.be
         .undefined;
@@ -156,6 +158,7 @@ describe("send mfa controller", () => {
         getJourneyTypeFromUserSessionSpy
       ).to.have.been.calledOnceWithExactly(req.session.user, {
         includeReauthentication: true,
+        includePasswordResetMfa: true,
       });
       expect(getJourneyTypeFromUserSessionSpy.getCall(0).returnValue).to.equal(
         JOURNEY_TYPE.REAUTHENTICATION

--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -87,6 +87,49 @@ describe("Verify code controller tests", () => {
         )
       );
     });
+
+    it("should render error when notificationType is RESET_PASSWORD_WITH_CODE and MFA_CODE_REQUESTS_BLOCKED error is returned", async () => {
+      const verifyCodeService = fakeVerifyCodeServiceHelper(
+        false,
+        ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED
+      );
+
+      req = createMockRequest(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL);
+      req.session.user = {
+        email: "test@test.com",
+      };
+
+      await verifyCodePost(verifyCodeService, noInterventionsService, {
+        ...verifyCodePostOptions,
+        notificationType: NOTIFICATION_TYPE.RESET_PASSWORD_WITH_CODE,
+      })(req as Request, res as Response);
+
+      expect(res.render).to.have.calledOnceWithExactly(
+        "security-code-error/index-wait.njk"
+      );
+    });
+
+    it("should render error when notificationType is RESET_PASSWORD_WITH_CODE and ENTERED_INVALID_MFA_MAX_TIMES error is returned", async () => {
+      const verifyCodeService = fakeVerifyCodeServiceHelper(
+        false,
+        ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES
+      );
+
+      req = createMockRequest(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL);
+      req.session.user = {
+        email: "test@test.com",
+      };
+
+      await verifyCodePost(verifyCodeService, noInterventionsService, {
+        ...verifyCodePostOptions,
+        notificationType: NOTIFICATION_TYPE.RESET_PASSWORD_WITH_CODE,
+      })(req as Request, res as Response);
+
+      expect(res.render).to.have.calledOnceWithExactly(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        { show2HrScreen: true }
+      );
+    });
   });
 
   describe("When code is valid and NOTIFICATION_TYPE.MFA_SMS", () => {

--- a/src/components/common/verify-code/tests/verify-code-controller.test.ts
+++ b/src/components/common/verify-code/tests/verify-code-controller.test.ts
@@ -18,6 +18,8 @@ import {
 import { ERROR_CODES, getErrorPathByCode } from "../../constants.js";
 import { createMockRequest } from "../../../../../test/helpers/mock-request-helper.js";
 import type { AccountInterventionsInterface } from "../../../account-intervention/types.js";
+import sinon from "sinon";
+
 describe("Verify code controller tests", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
@@ -225,6 +227,37 @@ describe("Verify code controller tests", () => {
       expect(res.redirect).to.have.calledWith(
         EXAMPLE_REDIRECT_URI.concat("?error=login_required")
       );
+    });
+  });
+
+  describe("callback option", () => {
+    async function testCallbackOption(callbackValue: boolean) {
+      const verifyCodeService = fakeVerifyCodeServiceHelper(true);
+      const callback = sinon.fake(() => Promise.resolve(callbackValue));
+
+      req = createMockRequest(PATH_NAMES.ENTER_PASSWORD);
+      req.session.user = { email: "test@test.com" };
+
+      await verifyCodePost(verifyCodeService, noInterventionsService, {
+        notificationType: NOTIFICATION_TYPE.VERIFY_EMAIL,
+        template: "check-your-email/index.njk",
+        validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
+        validationErrorCode: ERROR_CODES.INVALID_VERIFY_EMAIL_CODE,
+        beforeSuccessRedirectCallback: callback,
+      })(req as Request, res as Response);
+      return callback;
+    }
+
+    it("executes the callback option and returns early if true is returned", async () => {
+      const callback = await testCallbackOption(true);
+      expect(callback).to.be.called;
+      expect(res.redirect).to.not.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
+    });
+
+    it("executes the callback option and continue if false is returned", async () => {
+      const callback = await testCallbackOption(false);
+      expect(callback).to.be.called;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
     });
   });
 });

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -96,6 +96,21 @@ export function verifyCodePost(
       ) {
         req.session.user.isVerifyEmailCodeResendRequired = true;
       }
+
+      if (
+        options.notificationType === NOTIFICATION_TYPE.RESET_PASSWORD_WITH_CODE
+      ) {
+        if (ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED === result.data.code) {
+          return res.render("security-code-error/index-wait.njk");
+        }
+        if (ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES === result.data.code) {
+          return res.render(
+            "security-code-error/index-security-code-entered-exceeded.njk",
+            { show2HrScreen: true }
+          );
+        }
+      }
+
       const path = getErrorPathByCode(result.data.code);
 
       if (path) {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -136,6 +136,20 @@ export function enterPasswordPost(
         return res.redirect(PATH_NAMES.ERROR_PAGE);
       }
 
+      if (errorCode === ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED) {
+        return res.render("security-code-error/index-wait.njk");
+      }
+
+      if (errorCode === ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES) {
+        return res.render(
+          "security-code-error/index-security-code-entered-exceeded.njk",
+          {
+            show2HrScreen: true,
+            contentId: "727a0395-cc00-48eb-a411-bfe9d8ac5fc8",
+          }
+        );
+      }
+
       const validationKey = fromAccountExists
         ? ENTER_PASSWORD_ACCOUNT_EXISTS_VALIDATION_KEY
         : ENTER_PASSWORD_VALIDATION_KEY;

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -189,6 +189,64 @@ describe("enter password controller", () => {
       });
     });
 
+    it("should render error page when backend responds indicating mfa code request are blocked", async () => {
+      const fakePasswordService: EnterPasswordServiceInterface = {
+        loginUser: sinon.fake.returns({
+          success: false,
+          data: {
+            code: ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED,
+          },
+        }),
+      } as unknown as EnterPasswordServiceInterface;
+
+      const fakeMfaService: MfaServiceInterface = {
+        sendMfaCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as MfaServiceInterface;
+
+      await enterPasswordPost(
+        false,
+        fakePasswordService,
+        fakeMfaService
+      )(req as Request, res as Response);
+
+      expect(res.render).to.have.calledOnceWithExactly(
+        "security-code-error/index-wait.njk"
+      );
+    });
+
+    it("should render error page when backend responds indicating mfa code entries are blocked", async () => {
+      const fakePasswordService: EnterPasswordServiceInterface = {
+        loginUser: sinon.fake.returns({
+          success: false,
+          data: {
+            code: ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES,
+          },
+        }),
+      } as unknown as EnterPasswordServiceInterface;
+
+      const fakeMfaService: MfaServiceInterface = {
+        sendMfaCode: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as MfaServiceInterface;
+
+      await enterPasswordPost(
+        false,
+        fakePasswordService,
+        fakeMfaService
+      )(req as Request, res as Response);
+
+      expect(res.render).to.have.calledOnceWithExactly(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        {
+          show2HrScreen: true,
+          contentId: "727a0395-cc00-48eb-a411-bfe9d8ac5fc8",
+        }
+      );
+    });
+
     it("can send the journeyType when sending the password", async () => {
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -62,6 +62,7 @@ export function howDoYouWantSecurityCodesPost(
           req.session.user.activeMfaMethodId,
           getJourneyTypeFromUserSession(req.session.user, {
             includeReauthentication: true,
+            includePasswordResetMfa: true,
           })
         );
 

--- a/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-sms/tests/__snapshots__/reset-password-2fa-sms-integration.test.ts.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration::2fa sms (in reset password flow) should render index-security-code-entered-exceeded.njk when user is locked out due to too many incorrect codes 1`] = `
-Object {
-  "contentId": "",
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "account recovery",
-  "taxonomyLevel3": "",
-  "taxonomyLevel4": "",
-  "taxonomyLevel5": "",
-}
-`;
-
 exports[`Integration::2fa sms (in reset password flow) should return check your phone page 1`] = `
 Object {
   "contentId": "",

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe } from "mocha";
-import { expect, request, sinon } from "../../../../test/utils/test-utils.js";
+import { request, sinon } from "../../../../test/utils/test-utils.js";
 import * as cheerio from "cheerio";
 import {
   API_ENDPOINTS,
@@ -80,24 +80,6 @@ describe("Integration::2fa sms (in reset password flow)", () => {
     nock(baseApi).persist().post("/mfa").reply(204);
     await request(app, (test) =>
       test.get("/reset-password-2fa-sms").expect(200)
-    );
-  });
-
-  it("should render index-security-code-entered-exceeded.njk when user is locked out due to too many incorrect codes", async () => {
-    nock(baseApi).persist().post("/mfa").reply(400, {
-      code: ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES,
-    });
-    await request(app, (test) =>
-      test
-        .get("/reset-password-2fa-sms")
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($(".govuk-heading-l").text()).to.contains(
-            "You cannot sign in at the moment"
-          );
-          expect($(".govuk-body").text()).to.contains("Wait for 2 hours");
-        })
-        .expect(200)
     );
   });
 

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
@@ -33,6 +33,28 @@ Object {
 }
 `;
 
+exports[`Integration::reset password check email  should render expected error message when verifying email OTP results in 1026 error code 1`] = `
+Object {
+  "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::reset password check email  should render expected error message when verifying email OTP results in 1027 error code 1`] = `
+Object {
+  "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
 exports[`Integration::reset password check email  should return 2hr error page when 6 incorrect codes entered and flag is turned on 1`] = `
 Object {
   "contentId": "",

--- a/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
+++ b/src/components/reset-password-check-email/tests/__snapshots__/reset-password-check-email-integration.test.ts.snap
@@ -11,6 +11,28 @@ Object {
 }
 `;
 
+exports[`Integration::reset password check email  should render expected error message when sending SMS OTP code results in 1026 error code 1`] = `
+Object {
+  "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::reset password check email  should render expected error message when sending SMS OTP code results in 1027 error code 1`] = `
+Object {
+  "contentId": "b78d016b-0f2c-4599-9c2f-76b3a6397997",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
 exports[`Integration::reset password check email  should return 2hr error page when 6 incorrect codes entered and flag is turned on 1`] = `
 Object {
   "contentId": "",

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -239,6 +239,29 @@ describe("Integration::reset password check email ", () => {
       "you entered the wrong security code too many times",
     ],
   ].forEach(([errorCode, expectedString]) => {
+    it(`should render expected error message when verifying email OTP results in ${errorCode} error code`, async () => {
+      nock(baseApi)
+        .persist()
+        .post(API_ENDPOINTS.VERIFY_CODE)
+        .reply(HTTP_STATUS_CODES.BAD_REQUEST, { code: errorCode });
+
+      await request(app, (test) =>
+        test
+          .post(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            code: "123456",
+          })
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($(".govuk-body").text()).to.contains(expectedString);
+          })
+          .expect(200)
+      );
+    });
+
     it(`should render expected error message when sending SMS OTP code results in ${errorCode} error code`, async () => {
       nock(baseApi)
         .persist()

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -38,6 +38,11 @@ describe("Integration::reset password check email ", () => {
               journey: getPermittedJourneyForPath(
                 PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL
               ),
+              mfaMethods: buildMfaMethods({
+                redactedPhoneNumber: "123",
+                id: "test-id",
+              }),
+              activeMfaMethodId: "test-id",
             };
             req.session.user.enterEmailMfaType = "SMS";
             next();
@@ -205,6 +210,10 @@ describe("Integration::reset password check email ", () => {
       .persist()
       .post(API_ENDPOINTS.VERIFY_CODE)
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+    nock(baseApi)
+      .persist()
+      .post(API_ENDPOINTS.MFA)
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
 
     await request(app, (test) =>
       test
@@ -218,5 +227,42 @@ describe("Integration::reset password check email ", () => {
         .expect("Location", PATH_NAMES.RESET_PASSWORD_2FA_SMS)
         .expect(302)
     );
+  });
+
+  [
+    [
+      ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED,
+      "you asked to resend the security code too many times",
+    ],
+    [
+      ERROR_CODES.ENTERED_INVALID_MFA_MAX_TIMES,
+      "you entered the wrong security code too many times",
+    ],
+  ].forEach(([errorCode, expectedString]) => {
+    it(`should render expected error message when sending SMS OTP code results in ${errorCode} error code`, async () => {
+      nock(baseApi)
+        .persist()
+        .post(API_ENDPOINTS.VERIFY_CODE)
+        .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+      nock(baseApi).persist().post(API_ENDPOINTS.MFA).reply(400, {
+        code: errorCode,
+      });
+
+      await request(app, (test) =>
+        test
+          .post(PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            code: "123456",
+          })
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect($(".govuk-body").text()).to.contains(expectedString);
+          })
+          .expect(200)
+      );
+    });
   });
 });


### PR DESCRIPTION
## What

### Fix missing journey for SMS OTP requests
We have a bug on password reset journeys where when a user triggers resending an SMS OTP it was being misattributed to the SIGN_IN journey, not PASSWORD_RESET_MFA. This meant that the count was also assigned to SIGN_IN incorrectly.

Here this is corrected by ensuring when requesting an SMS OTP via the /mfa API we send the correct journey.

This bug was also apparent when an SMS was sent after a user chooses their backup SMS MFA method.


### Fix SMS OTP send trigger on password reset
We have a bug where a user will trigger two SMS OTP sends when attempting to try a resend on the password reset journey.

This happened as we were triggering an SMS OTP send on both the loading GET /reset-password-2fa-sms and POST /resend-code, and the "POST" was followed by a redirect to the "GET", thus triggering a second SMS send.

Now instead of sending an SMS on the GET /reset-password-2fa-sms, this is moved to the POST /reset-password-check-email.

i.e. user submits their email OTP on a password reset journey. If correct an SMS OTP is sent (if their DEFAULT MFA is SMS). If a user tries to resend, they follow links and trigger POST /resend-code, which redirects back to GET /reset-password-2fa-sms but crucially this redirect does not trigger another SMS.


### Check MFA lockout just after password entry
Now that we have merged counts so they are MFAMethodType agnostic, we need to ensure that when a BACKUP SMS MFA usage triggers a lockout, the user is not permitted to restart their journey using their DEFAULT AUTH_APP MFA.

They can do so currently. This is because we do not check after the user has entered their password for any MFA lockouts before redirecting to the AUTH_APP entry page. If their DEFAULT was an SMS MFA, then the API call to send the SMS OTP would return the error instead.

Here we add the MFA check to the POST /enter-password route. If the /login API returns an MFA lockout error code we instead render the error message straight away, rather than allowing them to proceed to the MFA OTP entry page.


### Ensure password reset email OTP verification returns error to user if MFA submission is locked out
In a previous commit support was added for the sending an SMS OTP (if applicable) following the successful submission of an email OTP during the password reset journey.

Here we expand this area to check for MFA lockouts as a result of an error returned from the email OTP (/verify-code) API. A lockout may already be in place from a previous password reset journey that we must use before we allow the sending of another SMS OTP.



## How to review

1. Code Review
2. Run acceptance tests (including https://github.com/govuk-one-login/authentication-acceptance-tests/tree/AUT-4377-and-AUT-4378-and-AUT4252)

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [X] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.

## Related PRs

- https://github.com/govuk-one-login/authentication-api/pull/6710