### PR TITLE
Redeploy "AUT-4255: mfa reset content changes"

### DIFF
--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -19,6 +19,7 @@
 {% set authAppDetailsTextHtml %}
   <p class="govuk-body">{{'pages.getSecurityCodes.authAppDetails.paragraph1' | translate}}</p>
   <p class="govuk-body">{{'pages.getSecurityCodes.authAppDetails.paragraph2' | translate}}</p>
+  <p class="govuk-body">{{'pages.getSecurityCodes.authAppDetails.paragraph3' | translate}}</p>
 {% endset %}
 
 {% if isAccountPartCreated %}
@@ -55,7 +56,10 @@
     },
     {
       text: 'pages.getSecurityCodes.secondFactorRadios.authAppText' | translate,
-      value: "AUTH_APP"
+      value: "AUTH_APP",
+      hint: {
+        text: 'pages.getSecurityCodes.secondFactorRadios.authAppHintText' | translate
+      }
     }
   ],
   errorMessage: {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -526,7 +526,7 @@
         "text 2": " neu gallwch ",
         "changePhoneNumberLinkText": "ddefnyddio rhif ffôn gwahanol",
         "changePhoneNumberLinkHref": "/enter-phone-number",
-        "changeMfaChoiceLinkText": "Cael cod mewn ffordd arall",
+        "changeMfaChoiceLinkText": "Dewiswch ffordd arall o gael codau diogelwch",
         "changeMfaChoiceLinkHref": "/get-security-codes"
       }
     },
@@ -2536,19 +2536,21 @@
       "summaryAccountPartCreated": "Dewiswch ffordd o gael codau diogelwch pan fyddwch yn mewngofnodi. Mae hyn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
       "secondFactorRadios": {
         "textMessageText": "Neges destun",
-        "authAppText": "Ap dilysydd ar gyfer ffôn clyfar, llechen neu gyfrifiadur",
+        "authAppText": "Ap dilysydd",
+        "authAppHintText": "Gallwch ddefnyddio unrhyw ap dilysydd i greu codau diogelwch pan fyddwch yn mewngofnodi",
         "errorMessage": "Dewiswch y ffordd rydych am gael codau diogelwch"
       },
       "authAppDetails": {
         "summaryText": "Beth yw ap dilysydd?",
-        "paragraph1": "Mae ap dilysu yn creu codau diogelwch y gallwch eu defnyddio i fewngofnodi i wefannau neu wasanaethau ar-lein.",
-        "paragraph2": "Gallwch ddefnyddio ap dilysydd ar eich ffôn clyfar, llechen neu gyfrifiadur bwrdd gwaith.  Lawrlwythwch ap dilysydd ar gyfer eich ffôn clyfar neu lechen o’ch siop apiau neu chwiliwch ar-lein am ap dilysydd ar gyfer eich cyfrifiadur."
+        "paragraph1": "Mae ap dilysydd yn creu cod diogelwch sy’n helpu i gadarnhau mai chi yw chi pan fyddwch yn mewngofnodi.",
+        "paragraph2": "Gallwch ddefnyddio ap dilysydd ar eich ffôn clyfar, tabled neu gyfrifiadur.",
+        "paragraph3": "Lawrlwythwch ap dilysydd o’ch ’app store’ neu chwiliwch ar-lein am un y gallwch ddefnyddio ar eich cyfrifiadur."
       },
       "continueButtonText": "Parhau",
       "accountRecoveryVariants": {
         "title": "Sut ydych chi am gael codau diogelwch?",
         "header": "Sut ydych chi am gael codau diogelwch?",
-        "summary": "Dewis sut byddwch yn cael codau diogelwch pan rydych yn mewngofnodi i’ch GOV.UK One Login. Bydd hyn yn dileu eich hen rhif ffôn neu ap dilysydd o’ch GOV.UK One Login."
+        "summary": "Dewiswch sut ydych chi am gael codau diogelwch wrth fewngofnodi i’ch GOV.UK One Login. Bydd hyn yn dileu’r holl ddulliau rydych wedi’u sefydlu’n barod."
       }
     },
     "setupAuthenticatorApp": {
@@ -2579,7 +2581,7 @@
         }
       },
       "continueButtonText": "Parhau",
-      "changeMfaChoiceLinkText": "Cael cod mewn ffordd arall"
+      "changeMfaChoiceLinkText": "Dewiswch ffordd arall o gael codau diogelwch"
     },
     "enterAuthenticatorAppCode": {
       "title": "Rhowch y cod diogelwch 6 digid a ddangosir yn eich ap dilysydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -526,7 +526,7 @@
         "text 2": " or you can ",
         "changePhoneNumberLinkText": "use a different phone number",
         "changePhoneNumberLinkHref": "/enter-phone-number",
-        "changeMfaChoiceLinkText": "Get a code another way",
+        "changeMfaChoiceLinkText": "Choose another way to get security codes",
         "changeMfaChoiceLinkHref": "/get-security-codes"
       }
     },
@@ -2535,19 +2535,21 @@
       "summaryAccountPartCreated": "Choose a way to get security codes when you sign in. This helps keep your GOV.UK One Login secure.",
       "secondFactorRadios": {
         "textMessageText": "Text message",
-        "authAppText": "Authenticator app for smartphone, tablet or computer",
+        "authAppText": "Authenticator app",
+        "authAppHintText": "You can use any authenticator app to create security codes when you sign in",
         "errorMessage": "Select how you want to get security codes"
       },
       "authAppDetails": {
         "summaryText": "What is an authenticator app?",
-        "paragraph1": "An authenticator app creates security codes that you can use to sign in to websites or online services.",
-        "paragraph2": "You can use an authenticator app on your smartphone, tablet or desktop computer.  Download an authenticator app for your smartphone or tablet from your app store or search online for an authenticator app for your computer."
+        "paragraph1": "An authenticator app creates a security code that helps confirm it’s you when you sign in.",
+        "paragraph2": "You can use an authenticator app on your smartphone, tablet or desktop computer.",
+        "paragraph3": "Download an authenticator app from your app store or search online for one you can use on your computer."
       },
       "continueButtonText": "Continue",
       "accountRecoveryVariants": {
         "title": "How do you want to get security codes?",
         "header": "How do you want to get security codes?",
-        "summary": "Choose how you’ll get security codes when signing in to your GOV.UK One Login. This will remove your old phone number or authenticator app from your GOV.UK One Login."
+        "summary": "Choose how you’ll get security codes when signing in to your GOV.UK One Login. This will remove all methods you already have set up."
       }
     },
     "setupAuthenticatorApp": {
@@ -2578,7 +2580,7 @@
         }
       },
       "continueButtonText": "Continue",
-      "changeMfaChoiceLinkText": "Get a code another way"
+      "changeMfaChoiceLinkText": "Choose another way to get security codes"
     },
     "enterAuthenticatorAppCode": {
       "title": "Enter the 6 digit security code shown in your authenticator app",


### PR DESCRIPTION
Reverts govuk-one-login/authentication-frontend#2867

Rdeploys https://github.com/govuk-one-login/authentication-frontend/pull/2847 following a rollback of the implementation on Thu 3 July 2025.