### PR TITLE
AUT-4189: add uplift journey to journeys where 2hr lockout shown

### DIFF
--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -201,11 +201,13 @@ function isJourneyWhere2HourLockoutScreenShown(
   const isAccountRecoveryEmail = isEmailCode && user.isAccountRecoveryJourney;
   const isNonAccountCreationEmail =
     isEmailCode && !user.isAccountCreationJourney;
+  const isUpliftRequired = user.isUpliftRequired;
   return (
     isStandardSignInJourney ||
     isPasswordResetJourney ||
     isNonAccountCreationEmail ||
     isAccountRecoveryEmail ||
+    isUpliftRequired ||
     false
   );
 }

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -221,6 +221,30 @@ describe("security code controller", () => {
 
     it(
       "should render security-code-error/index.njk and set lock when user entered too many SMS OTPs " +
+        "in the uplift journey",
+      () => {
+        process.env.CODE_ENTERED_WRONG_BLOCKED_MINUTES = "120";
+        req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
+        req.session.user.isUpliftRequired = true;
+        securityCodeInvalidGet(req as Request, res as Response);
+        expect(res.render).to.have.calledWith("security-code-error/index.njk", {
+          newCodeLink: pathWithQueryParam(
+            PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
+            "actionType",
+            "mfaMaxRetries"
+          ),
+          isAuthApp: false,
+          isBlocked: true,
+          show2HrScreen: true,
+        });
+        expect(req.session.user.wrongCodeEnteredLock).to.eq(
+          "Mon, 01 Jan 2024 02:00:00 GMT"
+        );
+      }
+    );
+
+    it(
+      "should render security-code-error/index.njk and set lock when user entered too many SMS OTPs " +
         "in the account creation journey",
       () => {
         process.env.CODE_ENTERED_WRONG_BLOCKED_MINUTES = "30";


### PR DESCRIPTION
## What

- Adds uplift journey to journeys where 2hr lockout shown in the security-code-controller
- 15 minute lockouts should only be shown on account creation journeys as a measure to prevent spamming.
- See: https://govukverify.atlassian.net/wiki/spaces/LO/pages/3957162012/Business+Rules+Logic+for+Lockouts

## How to review

1. Code Review
2. Go through uplift journey, enter SMS MFA 6 times and see 2 hour lockout
