### PR TITLE
AUT-4467: Fix resending SMS MFA OTP to number already sent OTP

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -147,20 +147,20 @@ export function enterPasswordPost(
           );
 
         default: {
-          const validationKey = fromAccountExists
-            ? ENTER_PASSWORD_ACCOUNT_EXISTS_VALIDATION_KEY
-            : ENTER_PASSWORD_VALIDATION_KEY;
+          let validationKey;
+          let template;
+
+          if (fromAccountExists) {
+            validationKey = ENTER_PASSWORD_ACCOUNT_EXISTS_VALIDATION_KEY;
+            template = ENTER_PASSWORD_ACCOUNT_EXISTS_TEMPLATE;
+          } else {
+            validationKey = ENTER_PASSWORD_VALIDATION_KEY;
+            template = ENTER_PASSWORD_TEMPLATE;
+          }
+
           const error = formatValidationError("password", req.t(validationKey));
 
-          return renderBadRequest(
-            res,
-            req,
-            fromAccountExists
-              ? ENTER_PASSWORD_ACCOUNT_EXISTS_TEMPLATE
-              : ENTER_PASSWORD_TEMPLATE,
-            error,
-            { email }
-          );
+          return renderBadRequest(res, req, template, error, { email });
         }
       }
     }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -226,6 +226,10 @@ export function enterPasswordPost(
 
       if (!result.success) {
         return handleSendMfaCodeError(result, res);
+      } else {
+        req.session.user.sentOtpMfaMethodIds = [
+          req.session.user.activeMfaMethodId,
+        ];
       }
     }
     return res.redirect(

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -361,6 +361,7 @@ describe("enter password controller", () => {
       } as unknown as MfaServiceInterface;
 
       it("should redirect to enter-code when the password is correct", async () => {
+        req.session.user.activeMfaMethodId = DEFAULT_MFA_METHOD_ID;
         const fakeService: EnterPasswordServiceInterface = {
           loginUser: sinon.fake.returns({
             data: {
@@ -386,6 +387,9 @@ describe("enter password controller", () => {
 
         expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_MFA);
         expect(req.session.user.isAccountPartCreated).to.be.eq(false);
+        expect(req.session.user.sentOtpMfaMethodIds).to.deep.equal([
+          DEFAULT_MFA_METHOD_ID,
+        ]);
       });
 
       it("should redirect to account locked page when max password attempts exceeded", async () => {

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -27,7 +27,7 @@ export function howDoYouWantSecurityCodesGet(
 
   res.render("how-do-you-want-security-codes/index.njk", {
     mfaResetLink: PATH_NAMES.MFA_RESET_WITH_IPV,
-    mfaMethods: sortMfaMethodsBackupFirst(req.session.user.mfaMethods || []),
+    mfaMethods: sortMfaMethodsBackupFirst(req.session.user.mfaMethods ?? []),
     supportMfaReset,
   });
 }

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -49,25 +49,33 @@ export function howDoYouWantSecurityCodesPost(
     if (selectedMethod.type === MFA_METHOD_TYPE.SMS) {
       if (mfaMethodId !== req.session.user.activeMfaMethodId) {
         req.session.user.activeMfaMethodId = mfaMethodId;
-        const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
-        const result = await mfaCodeService.sendMfaCode(
-          sessionId,
-          clientSessionId,
-          email,
-          persistentSessionId,
-          false,
-          xss(req.cookies.lng as string),
-          req,
-          req.session.user.activeMfaMethodId,
-          getJourneyTypeFromUserSession(req.session.user, {
-            includeReauthentication: true,
-            includePasswordResetMfa: true,
-          })
-        );
+        req.session.user.sentOtpMfaMethodIds ??= [];
 
-        if (!result.success) {
-          return handleSendMfaCodeError(result, res);
+        if (!req.session.user.sentOtpMfaMethodIds.includes(mfaMethodId)) {
+          const { sessionId, clientSessionId, persistentSessionId } =
+            res.locals;
+
+          const result = await mfaCodeService.sendMfaCode(
+            sessionId,
+            clientSessionId,
+            email,
+            persistentSessionId,
+            false,
+            xss(req.cookies.lng as string),
+            req,
+            req.session.user.activeMfaMethodId,
+            getJourneyTypeFromUserSession(req.session.user, {
+              includeReauthentication: true,
+              includePasswordResetMfa: true,
+            })
+          );
+
+          if (!result.success) {
+            return handleSendMfaCodeError(result, res);
+          }
+
+          req.session.user.sentOtpMfaMethodIds.push(mfaMethodId);
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface UserSession {
   channel?: string;
   mfaMethodType?: string;
   activeMfaMethodId?: string;
+  sentOtpMfaMethodIds?: string[];
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What

- Previously, a user would be sent an OTP each time they selected an SMS MFA on the how do you want security codes screen, as long as it was not the last MFA selected.
- This commit fixes that issue by listing the MFA ID an OTP was sent to on the sentOtpMfaMethodIds array on a user's session if it has had an OTP sent to it in a given session.
- An MFA code will only be sent if the ID is not on this list and it is not the most recently selected MFA (mfaMethodId !== activeMfaMethodId).

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
2. Deploy to dev env with 2 MFAs set up on account. Choose a given SMS MFA once on the how do you want security codes screen, then your other MFA, then the first again. See that you only receive a code for your given SMS MFA once.

## Checklist


<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.
