### PR TITLE
AUT-4473: Incorrect SMS MFA lockout screen when requesting new code sign in journey

### DIFF
--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -34,12 +34,12 @@ function handleErrors(
   res: Response<any, Record<string, any>>,
   req: Request
 ) {
-  const path = getErrorPathByCode(mfaFailResponse.data.code);
+  const pathWithQueryParams = getErrorPathByCode(mfaFailResponse.data.code);
 
-  if (path && isResendCodeRequest) {
-    return path.includes("?")
-      ? res.redirect(path + "&isResendCodeRequest=true")
-      : res.redirect(path + "?isResendCodeRequest=true");
+  if (pathWithQueryParams && isResendCodeRequest) {
+    return pathWithQueryParams.includes("?")
+      ? res.redirect(pathWithQueryParams + "&isResendCodeRequest=true")
+      : res.redirect(pathWithQueryParams + "?isResendCodeRequest=true");
   }
 
   if (isReauth(req)) {
@@ -55,8 +55,8 @@ function handleErrors(
     }
   }
 
-  if (path && !isResendCodeRequest) {
-    res.redirect(path);
+  if (pathWithQueryParams && !isResendCodeRequest) {
+    res.redirect(pathWithQueryParams);
   }
 
   throw new BadRequestError(

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -21,6 +21,9 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
     res.render("security-code-error/index-security-code-entered-exceeded.njk", {
       newCodeLink: newCodeLink,
       isAuthApp: false,
+      show2HrScreen:
+        req.session.user.isSignInJourney &&
+        !req.session.user.isAccountRecoveryJourney,
     });
   } else if (isLocked(req.session.user.codeRequestLock)) {
     const newCodeLink = req.query?.isResendCodeRequest

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
@@ -58,6 +58,41 @@ describe("resend mfa controller", () => {
         "security-code-error/index-wait.njk"
       );
     });
+
+    [
+      {
+        isSignInJourney: true,
+        isAccountRecoveryJourney: false,
+        expectedShow2HrScreen: true,
+      },
+      {
+        isSignInJourney: false,
+        isAccountRecoveryJourney: true,
+        expectedShow2HrScreen: false,
+      },
+      {
+        isSignInJourney: true,
+        isAccountRecoveryJourney: true,
+        expectedShow2HrScreen: false,
+      },
+    ].forEach((i) => {
+      it(`should render correct lockout when isSignInJourney is ${i.isSignInJourney} and isAccountRecoveryJourney is ${i.isAccountRecoveryJourney}`, () => {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        req.session.user.wrongCodeEnteredLock = tomorrow.toUTCString();
+        req.session.user.isSignInJourney = i.isSignInJourney;
+        req.session.user.isAccountRecoveryJourney = i.isAccountRecoveryJourney;
+
+        resendMfaCodeGet(req as Request, res as Response);
+
+        expect(res.render).to.have.calledWithMatch(
+          "security-code-error/index-security-code-entered-exceeded.njk",
+          sinon.match({
+            show2HrScreen: i.expectedShow2HrScreen,
+          })
+        );
+      });
+    });
   });
 
   describe("resendMfaCodePost", () => {


### PR DESCRIPTION
## What

Show the 2 hour lockout screen when `isLocked(req.session.user.wrongCodeEnteredLock)` is true

## How to review

1. Code Review
2. Deploy to dev env and test the fix works (follow [steps on ticket](https://govukverify.atlassian.net/browse/AUT-4473) and check that the 2 hour lockout screen is shown instead of 15 minute) 


## Checklist

https://github.com/user-attachments/assets/ea097be9-8581-41a3-92a2-a769f2c0b132

- [x] A UCD review has been performed.
