### PR TITLE
AUT-4558: Reset password 2fa auth app missing validation

### DIFF
--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.ts
@@ -6,6 +6,7 @@ import {
 import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
+import { validateResetPassword2faAuthAppRequest } from "./reset-password-2fa-auth-app-validation.js";
 
 const router = express.Router();
 
@@ -20,6 +21,7 @@ router.post(
   PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
+  validateResetPassword2faAuthAppRequest(),
   resetPassword2FAAuthAppPost()
 );
 

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-validation.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-validation.ts
@@ -1,0 +1,19 @@
+import type { ValidationChainFunc } from "../../types.js";
+import { validateCode } from "../common/verify-code/verify-code-validation.js";
+import { validateBodyMiddleware } from "../../middleware/form-validation-middleware.js";
+
+export function validateResetPassword2faAuthAppRequest(): ValidationChainFunc {
+  return [
+    validateCode({
+      requiredKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.required",
+      maxLengthKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.invalidFormat",
+      minLengthKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.invalidFormat",
+      numbersOnlyKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.invalidFormat",
+    }),
+    validateBodyMiddleware("reset-password-2fa-auth-app/index.njk"),
+  ];
+}

--- a/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
+++ b/src/components/reset-password-2fa-auth-app/tests/__snapshots__/reset-password-2fa-auth-app-integration.test.ts.snap
@@ -10,3 +10,47 @@ Object {
   "taxonomyLevel5": "",
 }
 `;
+
+exports[`Integration::2fa auth app (in reset password flow) should return validation error when code entered contains letters 1`] = `
+Object {
+  "contentId": "943b41f4-8262-417f-8866-c0639319ccf0",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::2fa auth app (in reset password flow) should return validation error when code is less than 6 characters 1`] = `
+Object {
+  "contentId": "943b41f4-8262-417f-8866-c0639319ccf0",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::2fa auth app (in reset password flow) should return validation error when code is more than 6 characters 1`] = `
+Object {
+  "contentId": "943b41f4-8262-417f-8866-c0639319ccf0",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;
+
+exports[`Integration::2fa auth app (in reset password flow) should return validation error when code not entered 1`] = `
+Object {
+  "contentId": "943b41f4-8262-417f-8866-c0639319ccf0",
+  "taxonomyLevel1": "authentication",
+  "taxonomyLevel2": "account recovery",
+  "taxonomyLevel3": "",
+  "taxonomyLevel4": "",
+  "taxonomyLevel5": "",
+}
+`;

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-integration.test.ts
@@ -124,4 +124,82 @@ describe("Integration::2fa auth app (in reset password flow)", () => {
         .expect(302)
     );
   });
+
+  it("should return validation error when code not entered", async () => {
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains("Enter the code");
+        })
+        .expect(400)
+    );
+  });
+
+  it("should return validation error when code is less than 6 characters", async () => {
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "2",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
+  });
+
+  it("should return validation error when code is more than 6 characters", async () => {
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "1234567",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
+  });
+
+  it("should return validation error when code entered contains letters", async () => {
+    await request(app, (test) =>
+      test
+        .post(PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP)
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          code: "12ert-",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#code-error").text()).to.contains(
+            "Enter the code using only 6 digits"
+          );
+        })
+        .expect(400)
+    );
+  });
 });


### PR DESCRIPTION
## What

Add validation to the `reset-password-2fa-auth-app` routes to ensure that we can't send an empty code or a code with letters

## How to review

1. Code Review
2. Deploy to a dev environment and follow the ACs on the [ticket here ](https://govukverify.atlassian.net/browse/AUT-4558) to ensure that you get the correct errors

## Checklist

https://github.com/user-attachments/assets/c303282f-dc35-4c30-b184-cc2c072ba98d

- [x] A UCD review has been performed.
