### PR TITLE
BAU: Local running without AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Clones the repository to the `<your_folder_name>` directory.
 
 ## Running the app
 
-There are two different ways to run the app on a local machine:
+There are three different ways to run the app on a local machine:
 
-- Everything running in Docker
-- The frontend app running in a local node instance, with supporting services running in Docker
+- Full stack running locally in Docker
+- The frontend and stubs running in Docker, with AWS connections
+- The frontend app running in a local node instance, with supporting services running in Docker and AWS connections
+
+To run the full stack locally in Docker, see `local-running` in the `authentication-api` repo.
 
 Before you can run the frontend app against the backend you will need to configure some environment variables.
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -231,16 +231,22 @@ async function createApp(): Promise<express.Application> {
     next();
   });
 
+  // Use in-memory sessions when running locally
+  const sessionStore =
+    getAppEnv() === APP_ENV_NAME.LOCAL
+      ? undefined
+      : getSessionStore(await getRedisConfig());
+
   app.use(
     session({
       name: SESSION_COOKIE_NAME,
-      store: getSessionStore(await getRedisConfig()),
+      store: sessionStore,
       saveUninitialized: false,
       secret: getSessionSecret(),
       unset: "destroy",
       resave: false,
       cookie: getSessionCookieOptions(
-        isProduction,
+        getAppEnv() !== APP_ENV_NAME.LOCAL,
         getSessionExpiry(),
         getSessionSecret()
       ),

--- a/src/components/authorize/kms-decryption-service.ts
+++ b/src/components/authorize/kms-decryption-service.ts
@@ -4,11 +4,11 @@ import type {
   DecryptCommandOutput,
 } from "@aws-sdk/client-kms";
 import { EncryptionAlgorithmSpec, KMS } from "@aws-sdk/client-kms";
-import type { KmsDecryptionServiceInterface } from "./types.js";
+import type { DecryptionServiceInterface } from "./types.js";
 import { getAwsRegion, getKmsKeyId } from "../../config.js";
 import { DecryptionError } from "../../utils/error.js";
 import { base64DecodeToUint8Array } from "../../utils/encoding.js";
-export class KmsDecryptionService implements KmsDecryptionServiceInterface {
+export class KmsDecryptionService implements DecryptionServiceInterface {
   private kmsClient: KMS;
   private readonly encryptionAlgorithm: EncryptionAlgorithmSpec;
   private readonly kmsKeyId: string;

--- a/src/components/authorize/local-decryption-service.ts
+++ b/src/components/authorize/local-decryption-service.ts
@@ -1,0 +1,13 @@
+import * as jose from "jose";
+import type { DecryptionServiceInterface } from "./types.js";
+import { getLocalEncryptionKey } from "../../config.js";
+
+const decoder = new TextDecoder();
+
+export class LocalDecryptionService implements DecryptionServiceInterface {
+  async decrypt(serializedJwe: string): Promise<string> {
+    const key = await jose.importPKCS8(getLocalEncryptionKey(), "RSA_OAEP_256");
+    const result = await jose.compactDecrypt(serializedJwe, key);
+    return decoder.decode(result.plaintext);
+  }
+}

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -52,7 +52,7 @@ export interface AuthorizeServiceInterface {
   ) => Promise<ApiResponseResult<StartAuthResponse>>;
 }
 
-export interface KmsDecryptionServiceInterface {
+export interface DecryptionServiceInterface {
   decrypt(serializedJwe: string): Promise<string>;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -47,6 +47,10 @@ export function getKmsKeyId(): string {
   return process.env.ENCRYPTION_KEY_ID;
 }
 
+export function getLocalEncryptionKey(): string {
+  return process.env.LOCAL_ENCRYPTION_KEY;
+}
+
 export function getVitalSignsIntervalSeconds(): number {
   return Number(process.env.VITAL_SIGNS_INTERVAL_SECONDS) || 10;
 }


### PR DESCRIPTION
## What

Changes to run authentication-frontend locally (without AWS dependencies).
- Use the default in-memory session store (removes dependency on Redis and SSM)
- Use an encryption key defined in an environment variable for decryption (removes dependency on KMS)

## How to review

1. Code Review
1. Run full local stack from authentication-api

## Checklist

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.

## Related PRs

- https://github.com/govuk-one-login/authentication-stubs/pull/405
- TBD
