### PR TITLE
BAU: Use string instead of env variable in smart agent api url for integration tests

### DIFF
--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -37,7 +37,7 @@ describe("Integration:: contact us - public user", () => {
     );
 
     app = await createApp();
-    smartAgentApiUrl = process.env.SMARTAGENT_API_URL;
+    smartAgentApiUrl = "http://smartagentmockurl";
 
     await request(
       app,


### PR DESCRIPTION
## What

Use a string instead of relying on the env variables for the `smartAgentApiUrl` inside `contact-us-controller-integration.test.ts` to prevent failing tests locally if you don't have correct env variables

## How to review

1. Code Review
