### PR TITLE
BAU: Ignore @govuk-one-login/frontend-analytics versions >= 4.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
         versions: ["> 20"]
       - dependency-name: "@types/node"
         versions: ["> 20"]
+      - dependency-name: "@govuk-one-login/frontend-analytics"
+        versions: [">=4.0.1"]
     groups:
       npm-pino-dependencies:
         patterns:


### PR DESCRIPTION


## What

Ignore @govuk-one-login/frontend-analytics versions >= 4.0.1

This version caused acceptance tests to fail in staging.  Different tests failed on different test runs.

Can be removed when the issue has been resolved.

See:

Test-frontend-pipeline:0b1303b3-0043-4927-b3d5-f6a7cb981dc0
Test-frontend-pipeline:1f75db58-a043-40ca-a177-b8ba99375064

## How to review

1. Code Review

## Related PRs

#2938 
#2940 
#2941 