### PR TITLE
Aut 4440/template viewer

### DIFF
--- a/journey-map/package.json
+++ b/journey-map/package.json
@@ -8,10 +8,11 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/index.ts --bundle --minify --sourcemap --target=chrome135,firefox137,safari18,edge135 --outfile=public/application.js",
+    "build-watch": "npm run build -- --watch=forever",
     "build-server": "tsc --project tsconfig.server.json",
     "start": "NODE_ENV=development tsx watch --clear-screen=false server/app.ts",
     "start-build": "node --enable-source-maps build/app.js",
-    "dev": "npm run build -- --watch=forever & npm run start; wait",
+    "dev": "npm run build-watch & npm run start; wait",
     "tsc": "tsc && tsc --project tsconfig.server.json --noEmit",
     "lint": "eslint src server && prettier src server --check",
     "lint-fix": "eslint --fix src server && prettier src server --write"

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -84,10 +84,16 @@ const setupStateClickHandlers = (): void => {
 
   const highlightState = (id: string, name: string): void => {
     // Open template on double-click if applicable
-    if ((currentHighlight === id) && (Date.now() - timeClicked < DOUBLE_CLICK_WINDOW_MILLIS)) {
+    if (
+      currentHighlight === id &&
+      Date.now() - timeClicked < DOUBLE_CLICK_WINDOW_MILLIS
+    ) {
       if (pages[name]) {
         const variant = Array.isArray(pages[name]) ? pages[name][0].name : "";
-        window.open(`/templates${name}?lng=en&pageVariant=${encodeURIComponent(variant)}`, "_blank");
+        window.open(
+          `/templates${name}?lng=en&pageVariant=${encodeURIComponent(variant)}`,
+          "_blank"
+        );
       }
     }
 

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -4,13 +4,16 @@ import type { Options } from "./mermaid.js";
 import { renderStateMachine } from "./mermaid.js";
 import type { AuthStateContext } from "di-auth/src/components/common/state-machine/state-machine.js";
 import { authStateMachine } from "di-auth/src/components/common/state-machine/state-machine.js";
+import { pages } from "di-auth/src/components/templates/pages.js";
 
 declare global {
   interface Window {
     // Used to define a click handler for use in the mermaid
-    onStateClick?: (name: string) => void;
+    onStateClick?: (id: string, name: string) => void;
   }
 }
+
+const DOUBLE_CLICK_WINDOW_MILLIS = 1000;
 
 const diagramElement = document.getElementById("diagram") as HTMLDivElement;
 const headerContent = document.getElementById(
@@ -76,26 +79,40 @@ const render = async (): Promise<void> => {
 };
 
 const setupStateClickHandlers = (): void => {
-  const highlightState = (state: string): void => {
+  let currentHighlight: string | undefined;
+  let timeClicked = 0;
+
+  const highlightState = (id: string, name: string): void => {
+    // Open template on double-click if applicable
+    if ((currentHighlight === id) && (Date.now() - timeClicked < DOUBLE_CLICK_WINDOW_MILLIS)) {
+      if (pages[name]) {
+        const variant = Array.isArray(pages[name]) ? pages[name][0].name : "";
+        window.open(`/templates${name}?lng=en&pageVariant=${encodeURIComponent(variant)}`, "_blank");
+      }
+    }
+
     // Remove existing highlights
     Array.from(document.getElementsByClassName("highlight")).forEach((edge) =>
       edge.classList.remove("highlight", "outgoingEdge", "incomingEdge")
     );
 
     // Add new highlights
-    Array.from(document.getElementsByClassName(`LS-${state}`)).forEach((edge) =>
+    Array.from(document.getElementsByClassName(`LS-${id}`)).forEach((edge) =>
       edge.classList.add("highlight", "outgoingEdge")
     );
-    Array.from(document.getElementsByClassName(`LE-${state}`)).forEach((edge) =>
+    Array.from(document.getElementsByClassName(`LE-${id}`)).forEach((edge) =>
       edge.classList.add("highlight", "incomingEdge")
     );
     Array.from(document.getElementsByClassName("node"))
-      .filter((node) => node.id.startsWith(`flowchart-${state}-`))
+      .filter((node) => node.id.startsWith(`flowchart-${id}-`))
       .forEach((node) => node.classList.add("highlight"));
+
+    currentHighlight = id;
+    timeClicked = Date.now();
   };
 
-  window.onStateClick = async (state: string): Promise<void> => {
-    highlightState(state);
+  window.onStateClick = async (id: string, name: string): Promise<void> => {
+    highlightState(id, name);
   };
 };
 

--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -4,6 +4,7 @@ import type {
   AuthStateMachine,
 } from "di-auth/src/components/common/state-machine/state-machine.js";
 import { authStateMachine } from "di-auth/src/components/common/state-machine/state-machine.js";
+import { pages } from "di-auth/src/components/templates/pages.js";
 
 export interface Options {
   includeOptional: boolean;
@@ -24,9 +25,15 @@ interface Transition {
 }
 
 const getMermaidHeader = (graphDirection: "TD" | "LR"): string =>
-  `graph ${graphDirection}`;
+  `graph ${graphDirection}
+    classDef page fill:#ae8,stroke:#000;`;
 
-const renderState = ({ name, id }: State): string => `    ${id}(${name})`;
+const renderState = ({ name, id }: State): string => {
+  if (pages[name]) {
+    return `    ${id}(${name}):::page`;
+  }
+  return `    ${id}(${name})`;
+}
 
 const renderTransition = ({
   source,
@@ -40,8 +47,8 @@ const renderTransition = ({
   return `    ${source}${arrow}${label}${target}`;
 };
 
-const renderClickHandler = ({ id }: State): string =>
-  `    click ${id} call onStateClick(${JSON.stringify(id)})`;
+const renderClickHandler = ({ id, name }: State): string =>
+  `    click ${id} call onStateClick(${JSON.stringify(id)},${JSON.stringify(name)})`;
 
 const getSingleTransitionTarget = (
   transition: TransitionDefinition<AuthStateContext, AnyEventObject>

--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -33,7 +33,7 @@ const renderState = ({ name, id }: State): string => {
     return `    ${id}(${name}):::page`;
   }
   return `    ${id}(${name})`;
-}
+};
 
 const renderTransition = ({
   source,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf dist node_modules logs.json",
     "clean-modules": "rm -rf node_modules",
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts && cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js dist/public/scripts && cp node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js dist/public/scripts && cp node_modules/@govuk-one-login/spinner/spinner-app.js dist/public/scripts && cp node_modules/@govuk-one-login/frontend-device-intelligence/build/esm/index.js dist/public/scripts/device-intelligence.js",
-    "dev": "yarn build-ts && concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\"",
+    "dev": "yarn build-ts && concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node,Journey Map\" -c \"yellow.bold,cyan.bold,green.bold,magenta.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\" \"npm run build-watch --prefix journey-map/\"",
     "dummy-server": "node dev-app.js | pino-pretty",
     "dummy-server-orchstub": "node dev-app-orchstub.js | pino-pretty",
     "depcheck": "depcheck",

--- a/src/app.ts
+++ b/src/app.ts
@@ -84,6 +84,7 @@ import { accountInterventionRouter } from "./components/account-intervention/pas
 import { permanentlyBlockedRouter } from "./components/account-intervention/permanently-blocked/permanently-blocked-router.js";
 import { temporarilyBlockedRouter } from "./components/account-intervention/temporarily-blocked/temporarily-blocked-router.js";
 import { resetPassword2FAAuthAppRouter } from "./components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-routes.js";
+import { templatesRouter } from "./components/templates/templates-routes.js";
 import { setGTM } from "./middleware/analytics-middleware.js";
 import { setCurrentUrlMiddleware } from "./middleware/current-url-middleware.js";
 import { getRedisConfig } from "./utils/redis.js";
@@ -155,7 +156,9 @@ function registerRoutes(app: express.Application) {
   app.use(mfaResetWithIpvRouter);
   app.use(ipvCallbackRouter);
 
+  // Development tools
   if (getAppEnv() !== APP_ENV_NAME.PROD && getAppEnv() !== APP_ENV_NAME.INT) {
+    app.use(templatesRouter);
     app.use(govukComponentRouter);
   }
 }

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -19,6 +19,7 @@
 @import "components/panel/panel";
 @import "components/phase-banner/phase-banner";
 @import "components/radios/radios";
+@import "components/select/select";
 @import "components/skip-link/skip-link";
 @import "components/summary-list/summary-list";
 @import "components/table/table";

--- a/src/components/templates/index.njk
+++ b/src/components/templates/index.njk
@@ -1,0 +1,71 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% set pageTitleName = "All templates" %}
+{% set rowClasses = "govuk-grid-column-full" %}
+
+{% if errorState %}
+    {% set errorText = 'Select a page and a context if appropriate.' %}
+{% endif %}
+
+{% block content %}
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Page</th>
+      <th scope="col" class="govuk-table__header">Variant</th>
+      <th scope="col" class="govuk-table__header">Error State</th>
+      <th scope="col" class="govuk-table__header">Submit</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+
+  {% for pageListItem in pageListItems %}
+  <form action="/templates" method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+    <input type="hidden" name="template" value="{{ pageListItem.path }}">
+
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">
+        {{ pageListItem.path }}
+      </th>
+      <td class="govuk-table__cell">
+        {% if pageListItem.variants | length %}
+          {{ govukSelect({
+            name: "pageVariant",
+            selected: pageListItem.variants[0].value,
+            items: pageListItem.variants
+          }) }}
+        {% else %}
+          <span class="govuk-body">Default</span>
+        {% endif %}
+      </td>
+      <td class="govuk-table__cell">
+        {{ govukCheckboxes({
+          name: "hasErrorState",
+          items: [
+            {
+              text: "Error",
+              value: "true"
+            }
+          ]
+        }) }}
+      </td>
+      <td class="govuk-table__cell">
+        <div style="display: flex; gap: 10px;">
+          <button name="language" value="en" class="govuk-button">En</button>
+          <button name="language" value="cy" class="govuk-button">Cy</button>
+        </div>
+      </td>
+    </tr>
+  </form>
+  {% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/src/components/templates/pages.ts
+++ b/src/components/templates/pages.ts
@@ -1,0 +1,83 @@
+import { PATH_NAMES } from "../../app.constants.js";
+
+interface Page {
+  template: string;
+  options?: Record<string, unknown>;
+}
+
+interface PageVariant extends Page {
+  name: string;
+}
+
+// Links to https://account.gov.uk
+const EXAMPLE_QR_CODE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACECAYAAABRRIOnAAAAAklEQVR4AewaftIAAAN6SURBVO3BQa5bRwADweZA979yx4ssuBrgQdK3nbAq/sLMvw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlxZuS8JNU3pGEG5WWhKbyRBJ+kso7DjPlMFMOM+XFh6l8UhJukvCEyk0SnkhCU7lR+aQkfNJhphxmymGmvPiyJDyh8g6VloSWhKbSVFoSvikJT6h802GmHGbKYaa8+I9TeSIJTeX/5DBTDjPlMFNe/OVUWhJuVG5UWhKayn/ZYaYcZsphprz4MpWfpNKS8EQSnlB5h8qf5DBTDjPlMFNefFgSflISmsoTSWgqLQk3SWgqN0n4kx1mymGmHGbKizep/E2S0FRuVFoSnlD5mxxmymGmHGbKizcloal8UhKayhMqLQktCTcqTeUmCTcqN0l4QuWTDjPlMFMOM+XFD0vCjUpTeUcSmkpLwk0SnlC5ScKf7DBTDjPlMFPiL3xREm5UbpLQVG6S0FRaEj5J5SYJNyotCU2lJeFG5R2HmXKYKYeZ8uLLVG6S0FSayk0SmkpLwhMqTyThRuWTVFoSPukwUw4z5TBTXrwpCTcqLQlPJKGpNJUblU9KQlO5ScKNSlP5nQ4z5TBTDjPlxQ9TuUlCU3lHEppKS0JTaUm4SUJTaSotCe9IQlP5pMNMOcyUw0x58WEqn5SEJ1SeUHmHyk0SbpJwo3KThKbyjsNMOcyUw0x58WVJuFFpKk8koSXhiSQ0labSknCThKbSktBUWhJaEppKS8InHWbKYaYcZsqLL1NpSbhJwhMqn5SEG5WWhJsk3CShqbQk3Kh80mGmHGbKYabEX/iLJeEJlZskNJWbJDSVJ5LQVH6nw0w5zJTDTHnxpiT8JJWm8o4kNJWWhKbyRBKayicloam84zBTDjPlMFNefJjKJyXhiSQ8ofJEEp5Q+SaVTzrMlMNMOcyUF1+WhCdUPkmlJeEJlZaEmyR8UhKeUHnHYaYcZsphprz4j0tCU2lJ+EkqT6i0JHzTYaYcZsphprz4n1NpSbhR+aYk3Ki0JHzSYaYcZsphprz4MpXfSeUmCTcqLQlPqLQk3Kj8ToeZcpgph5ny4sOS8JOS8EQS3qHSktBUblRuktBUftJhphxmymGmxF+Y+ddhphxmymGmHGbKYaYcZsphphxmymGmHGbKYaYcZsphphxmymGm/ANs8XkgbQ6z9gAAAABJRU5ErkJggg=="
+
+// TOOD: AUT-4440 Complete this list
+// TODO: AUT-4440 Some kind of UT to detect missing cases - e.g. filter PATH_NAMES by known 'non UI' paths
+// TODO: AUT-4439 Screenshot test across each of these pages
+// TODO: AUT-4441 Parameter validation for each template
+export const pages: Record<string, Page | PageVariant[]> = {
+  // Journey start
+  [PATH_NAMES.SIGN_IN_OR_CREATE]: { template: "sign-in-or-create/index.njk" },
+
+  // Sign in
+  [PATH_NAMES.ENTER_EMAIL_SIGN_IN]: { template: "enter-email/index-existing-account.njk" },
+  [PATH_NAMES.ENTER_PASSWORD]: { template: "enter-password/index.njk" },
+  [PATH_NAMES.ENTER_PASSWORD_ACCOUNT_EXISTS]: {
+    template: "enter-password/index-account-exists.njk",
+    options: { email: "example@account.gov.uk" },
+  },
+  [PATH_NAMES.ENTER_MFA]: {
+    template: "enter-mfa/index.njk",
+    options: {
+      phoneNumber: "123",
+      isAccountRecoveryPermitted: true,
+      hasMultipleMfaMethods: false,
+      mfaIssuePath: "#",
+    },
+  },
+
+  // Sign up
+  [PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT]: { template: "enter-email/index-create-account.njk" },
+  [PATH_NAMES.ACCOUNT_NOT_FOUND]: [{
+    name: "mandatory",
+    template: "account-not-found/index-mandatory.njk",
+    options: { email: "example@account.gov.uk" },
+   }, {
+    name: "optional",
+    template: "account-not-found/index-optional.njk",
+    options: { email: "example@account.gov.uk" },
+  }, {
+    name: "one login",
+    template: "account-not-found/index-one-login.njk",
+    options: { email: "example@account.gov.uk" },
+  }, {
+    name: "mobile",
+    template: "account-not-found/index-mobile.njk",
+    options: { email: "example@account.gov.uk" },
+   }],
+  [PATH_NAMES.CHECK_YOUR_EMAIL]: {
+    template: "check-your-email/index.njk",
+    options: {
+      email: "example@account.gov.uk",
+    },
+  },
+  [PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD]: { template: "create-password/index.njk" },
+  [PATH_NAMES.GET_SECURITY_CODES]: { template: "select-mfa-options/index.njk" },
+  [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER]: { template: "enter-phone-number/index.njk" },
+  [PATH_NAMES.CHECK_YOUR_PHONE]: {
+    template: "check-your-phone/index.njk",
+    options: {
+      phoneNumber: "123",
+      resendCodeLink: "#",
+    },
+  },
+  [PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP]: {
+    template: "setup-authenticator-app/index.njk",
+    options: {
+      qrCode: EXAMPLE_QR_CODE,
+      secretKeyFragmentArray: ["example-secret"],
+    },
+  },
+  [PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL]: { template: "account-created/index.njk" },
+};

--- a/src/components/templates/pages.ts
+++ b/src/components/templates/pages.ts
@@ -10,7 +10,8 @@ interface PageVariant extends Page {
 }
 
 // Links to https://account.gov.uk
-const EXAMPLE_QR_CODE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACECAYAAABRRIOnAAAAAklEQVR4AewaftIAAAN6SURBVO3BQa5bRwADweZA979yx4ssuBrgQdK3nbAq/sLMvw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlxZuS8JNU3pGEG5WWhKbyRBJ+kso7DjPlMFMOM+XFh6l8UhJukvCEyk0SnkhCU7lR+aQkfNJhphxmymGmvPiyJDyh8g6VloSWhKbSVFoSvikJT6h802GmHGbKYaa8+I9TeSIJTeX/5DBTDjPlMFNe/OVUWhJuVG5UWhKayn/ZYaYcZsphprz4MpWfpNKS8EQSnlB5h8qf5DBTDjPlMFNefFgSflISmsoTSWgqLQk3SWgqN0n4kx1mymGmHGbKizep/E2S0FRuVFoSnlD5mxxmymGmHGbKizcloal8UhKayhMqLQktCTcqTeUmCTcqN0l4QuWTDjPlMFMOM+XFD0vCjUpTeUcSmkpLwk0SnlC5ScKf7DBTDjPlMFPiL3xREm5UbpLQVG6S0FRaEj5J5SYJNyotCU2lJeFG5R2HmXKYKYeZ8uLLVG6S0FSayk0SmkpLwhMqTyThRuWTVFoSPukwUw4z5TBTXrwpCTcqLQlPJKGpNJUblU9KQlO5ScKNSlP5nQ4z5TBTDjPlxQ9TuUlCU3lHEppKS0JTaUm4SUJTaSotCe9IQlP5pMNMOcyUw0x58WEqn5SEJ1SeUHmHyk0SbpJwo3KThKbyjsNMOcyUw0x58WVJuFFpKk8koSXhiSQ0labSknCThKbSktBUWhJaEppKS8InHWbKYaYcZsqLL1NpSbhJwhMqn5SEG5WWhJsk3CShqbQk3Kh80mGmHGbKYabEX/iLJeEJlZskNJWbJDSVJ5LQVH6nw0w5zJTDTHnxpiT8JJWm8o4kNJWWhKbyRBKayicloam84zBTDjPlMFNefJjKJyXhiSQ8ofJEEp5Q+SaVTzrMlMNMOcyUF1+WhCdUPkmlJeEJlZaEmyR8UhKeUHnHYaYcZsphprz4j0tCU2lJ+EkqT6i0JHzTYaYcZsphprz4n1NpSbhR+aYk3Ki0JHzSYaYcZsphprz4MpXfSeUmCTcqLQlPqLQk3Kj8ToeZcpgph5ny4sOS8JOS8EQS3qHSktBUblRuktBUftJhphxmymGmxF+Y+ddhphxmymGmHGbKYaYcZsphphxmymGmHGbKYaYcZsphphxmymGm/ANs8XkgbQ6z9gAAAABJRU5ErkJggg=="
+const EXAMPLE_QR_CODE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACECAYAAABRRIOnAAAAAklEQVR4AewaftIAAAN6SURBVO3BQa5bRwADweZA979yx4ssuBrgQdK3nbAq/sLMvw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlxZuS8JNU3pGEG5WWhKbyRBJ+kso7DjPlMFMOM+XFh6l8UhJukvCEyk0SnkhCU7lR+aQkfNJhphxmymGmvPiyJDyh8g6VloSWhKbSVFoSvikJT6h802GmHGbKYaa8+I9TeSIJTeX/5DBTDjPlMFNe/OVUWhJuVG5UWhKayn/ZYaYcZsphprz4MpWfpNKS8EQSnlB5h8qf5DBTDjPlMFNefFgSflISmsoTSWgqLQk3SWgqN0n4kx1mymGmHGbKizep/E2S0FRuVFoSnlD5mxxmymGmHGbKizcloal8UhKayhMqLQktCTcqTeUmCTcqN0l4QuWTDjPlMFMOM+XFD0vCjUpTeUcSmkpLwk0SnlC5ScKf7DBTDjPlMFPiL3xREm5UbpLQVG6S0FRaEj5J5SYJNyotCU2lJeFG5R2HmXKYKYeZ8uLLVG6S0FSayk0SmkpLwhMqTyThRuWTVFoSPukwUw4z5TBTXrwpCTcqLQlPJKGpNJUblU9KQlO5ScKNSlP5nQ4z5TBTDjPlxQ9TuUlCU3lHEppKS0JTaUm4SUJTaSotCe9IQlP5pMNMOcyUw0x58WEqn5SEJ1SeUHmHyk0SbpJwo3KThKbyjsNMOcyUw0x58WVJuFFpKk8koSXhiSQ0labSknCThKbSktBUWhJaEppKS8InHWbKYaYcZsqLL1NpSbhJwhMqn5SEG5WWhJsk3CShqbQk3Kh80mGmHGbKYabEX/iLJeEJlZskNJWbJDSVJ5LQVH6nw0w5zJTDTHnxpiT8JJWm8o4kNJWWhKbyRBKayicloam84zBTDjPlMFNefJjKJyXhiSQ8ofJEEp5Q+SaVTzrMlMNMOcyUF1+WhCdUPkmlJeEJlZaEmyR8UhKeUHnHYaYcZsphprz4j0tCU2lJ+EkqT6i0JHzTYaYcZsphprz4n1NpSbhR+aYk3Ki0JHzSYaYcZsphprz4MpXfSeUmCTcqLQlPqLQk3Kj8ToeZcpgph5ny4sOS8JOS8EQS3qHSktBUblRuktBUftJhphxmymGmxF+Y+ddhphxmymGmHGbKYaYcZsphphxmymGmHGbKYaYcZsphphxmymGm/ANs8XkgbQ6z9gAAAABJRU5ErkJggg==";
 
 // TOOD: AUT-4440 Complete this list with all other pages, perhaps with a test to detect missing cases
 // TODO: AUT-4439 Screenshot test across each of these pages
@@ -18,7 +19,9 @@ const EXAMPLE_QR_CODE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACEC
 export const pages: Record<string, Page | PageVariant[]> = {
   // Sign in
   [PATH_NAMES.SIGN_IN_OR_CREATE]: { template: "sign-in-or-create/index.njk" },
-  [PATH_NAMES.ENTER_EMAIL_SIGN_IN]: { template: "enter-email/index-existing-account.njk" },
+  [PATH_NAMES.ENTER_EMAIL_SIGN_IN]: {
+    template: "enter-email/index-existing-account.njk",
+  },
   [PATH_NAMES.ENTER_PASSWORD]: { template: "enter-password/index.njk" },
   [PATH_NAMES.ENTER_PASSWORD_ACCOUNT_EXISTS]: {
     template: "enter-password/index-account-exists.njk",
@@ -45,44 +48,58 @@ export const pages: Record<string, Page | PageVariant[]> = {
     },
     {
       name: "uplift",
-      template: "enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk",
+      template:
+        "enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk",
       options: {
         isAccountRecoveryPermitted: true,
         hasMultipleMfaMethods: false,
         mfaIssuePath: "#",
       },
-    }
+    },
   ],
-  [PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS]: { template: "updated-terms-conditions/index.njk" },
+  [PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS]: {
+    template: "updated-terms-conditions/index.njk",
+  },
 
   // Sign up
-  [PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT]: { template: "enter-email/index-create-account.njk" },
-  [PATH_NAMES.ACCOUNT_NOT_FOUND]: [{
-    name: "mandatory",
-    template: "account-not-found/index-mandatory.njk",
-    options: { email: "example@account.gov.uk" },
-   }, {
-    name: "optional",
-    template: "account-not-found/index-optional.njk",
-    options: { email: "example@account.gov.uk" },
-  }, {
-    name: "one login",
-    template: "account-not-found/index-one-login.njk",
-    options: { email: "example@account.gov.uk" },
-  }, {
-    name: "mobile",
-    template: "account-not-found/index-mobile.njk",
-    options: { email: "example@account.gov.uk" },
-   }],
+  [PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT]: {
+    template: "enter-email/index-create-account.njk",
+  },
+  [PATH_NAMES.ACCOUNT_NOT_FOUND]: [
+    {
+      name: "mandatory",
+      template: "account-not-found/index-mandatory.njk",
+      options: { email: "example@account.gov.uk" },
+    },
+    {
+      name: "optional",
+      template: "account-not-found/index-optional.njk",
+      options: { email: "example@account.gov.uk" },
+    },
+    {
+      name: "one login",
+      template: "account-not-found/index-one-login.njk",
+      options: { email: "example@account.gov.uk" },
+    },
+    {
+      name: "mobile",
+      template: "account-not-found/index-mobile.njk",
+      options: { email: "example@account.gov.uk" },
+    },
+  ],
   [PATH_NAMES.CHECK_YOUR_EMAIL]: {
     template: "check-your-email/index.njk",
     options: {
       email: "example@account.gov.uk",
     },
   },
-  [PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD]: { template: "create-password/index.njk" },
+  [PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD]: {
+    template: "create-password/index.njk",
+  },
   [PATH_NAMES.GET_SECURITY_CODES]: { template: "select-mfa-options/index.njk" },
-  [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER]: { template: "enter-phone-number/index.njk" },
+  [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER]: {
+    template: "enter-phone-number/index.njk",
+  },
   [PATH_NAMES.CHECK_YOUR_PHONE]: {
     template: "check-your-phone/index.njk",
     options: {
@@ -97,24 +114,29 @@ export const pages: Record<string, Page | PageVariant[]> = {
       secretKeyFragmentArray: ["example-secret"],
     },
   },
-  [PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL]: { template: "account-created/index.njk" },
+  [PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL]: {
+    template: "account-created/index.njk",
+  },
 
   // Reset password
-  [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL]: [{
-    name: "unforced",
-    template: "reset-password-check-email/index.njk",
-    options: {
-      email: "example@account.gov.uk",
-      isForcedPasswordResetJourney: false,
+  [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL]: [
+    {
+      name: "unforced",
+      template: "reset-password-check-email/index.njk",
+      options: {
+        email: "example@account.gov.uk",
+        isForcedPasswordResetJourney: false,
+      },
     },
-  }, {
-    name: "forced",
-    template: "reset-password-check-email/index.njk",
-    options: {
-      email: "example@account.gov.uk",
-      isForcedPasswordResetJourney: true,
+    {
+      name: "forced",
+      template: "reset-password-check-email/index.njk",
+      options: {
+        email: "example@account.gov.uk",
+        isForcedPasswordResetJourney: true,
+      },
     },
-  }],
+  ],
   [PATH_NAMES.RESET_PASSWORD]: {
     template: "reset-password/index.njk",
     options: { isPasswordChangeRequired: false },
@@ -142,12 +164,12 @@ export const pages: Record<string, Page | PageVariant[]> = {
 
   // Account interventions
   [PATH_NAMES.PASSWORD_RESET_REQUIRED]: {
-    template: "account-intervention/password-reset-required/index.njk"
+    template: "account-intervention/password-reset-required/index.njk",
   },
   [PATH_NAMES.UNAVAILABLE_PERMANENT]: {
-    template: "account-intervention/permanently-blocked/index.njk"
+    template: "account-intervention/permanently-blocked/index.njk",
   },
   [PATH_NAMES.UNAVAILABLE_TEMPORARY]: {
-    template: "account-intervention/temporarily-blocked/index.njk"
+    template: "account-intervention/temporarily-blocked/index.njk",
   },
 };

--- a/src/components/templates/pages.ts
+++ b/src/components/templates/pages.ts
@@ -12,15 +12,12 @@ interface PageVariant extends Page {
 // Links to https://account.gov.uk
 const EXAMPLE_QR_CODE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIQAAACECAYAAABRRIOnAAAAAklEQVR4AewaftIAAAN6SURBVO3BQa5bRwADweZA979yx4ssuBrgQdK3nbAq/sLMvw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlMFMOM+UwUw4z5TBTDjPlxZuS8JNU3pGEG5WWhKbyRBJ+kso7DjPlMFMOM+XFh6l8UhJukvCEyk0SnkhCU7lR+aQkfNJhphxmymGmvPiyJDyh8g6VloSWhKbSVFoSvikJT6h802GmHGbKYaa8+I9TeSIJTeX/5DBTDjPlMFNe/OVUWhJuVG5UWhKayn/ZYaYcZsphprz4MpWfpNKS8EQSnlB5h8qf5DBTDjPlMFNefFgSflISmsoTSWgqLQk3SWgqN0n4kx1mymGmHGbKizep/E2S0FRuVFoSnlD5mxxmymGmHGbKizcloal8UhKayhMqLQktCTcqTeUmCTcqN0l4QuWTDjPlMFMOM+XFD0vCjUpTeUcSmkpLwk0SnlC5ScKf7DBTDjPlMFPiL3xREm5UbpLQVG6S0FRaEj5J5SYJNyotCU2lJeFG5R2HmXKYKYeZ8uLLVG6S0FSayk0SmkpLwhMqTyThRuWTVFoSPukwUw4z5TBTXrwpCTcqLQlPJKGpNJUblU9KQlO5ScKNSlP5nQ4z5TBTDjPlxQ9TuUlCU3lHEppKS0JTaUm4SUJTaSotCe9IQlP5pMNMOcyUw0x58WEqn5SEJ1SeUHmHyk0SbpJwo3KThKbyjsNMOcyUw0x58WVJuFFpKk8koSXhiSQ0labSknCThKbSktBUWhJaEppKS8InHWbKYaYcZsqLL1NpSbhJwhMqn5SEG5WWhJsk3CShqbQk3Kh80mGmHGbKYabEX/iLJeEJlZskNJWbJDSVJ5LQVH6nw0w5zJTDTHnxpiT8JJWm8o4kNJWWhKbyRBKayicloam84zBTDjPlMFNefJjKJyXhiSQ8ofJEEp5Q+SaVTzrMlMNMOcyUF1+WhCdUPkmlJeEJlZaEmyR8UhKeUHnHYaYcZsphprz4j0tCU2lJ+EkqT6i0JHzTYaYcZsphprz4n1NpSbhR+aYk3Ki0JHzSYaYcZsphprz4MpXfSeUmCTcqLQlPqLQk3Kj8ToeZcpgph5ny4sOS8JOS8EQS3qHSktBUblRuktBUftJhphxmymGmxF+Y+ddhphxmymGmHGbKYaYcZsphphxmymGmHGbKYaYcZsphphxmymGm/ANs8XkgbQ6z9gAAAABJRU5ErkJggg=="
 
-// TOOD: AUT-4440 Complete this list
-// TODO: AUT-4440 Some kind of UT to detect missing cases - e.g. filter PATH_NAMES by known 'non UI' paths
+// TOOD: AUT-4440 Complete this list with all other pages, perhaps with a test to detect missing cases
 // TODO: AUT-4439 Screenshot test across each of these pages
 // TODO: AUT-4441 Parameter validation for each template
 export const pages: Record<string, Page | PageVariant[]> = {
-  // Journey start
-  [PATH_NAMES.SIGN_IN_OR_CREATE]: { template: "sign-in-or-create/index.njk" },
-
   // Sign in
+  [PATH_NAMES.SIGN_IN_OR_CREATE]: { template: "sign-in-or-create/index.njk" },
   [PATH_NAMES.ENTER_EMAIL_SIGN_IN]: { template: "enter-email/index-existing-account.njk" },
   [PATH_NAMES.ENTER_PASSWORD]: { template: "enter-password/index.njk" },
   [PATH_NAMES.ENTER_PASSWORD_ACCOUNT_EXISTS]: {
@@ -36,6 +33,27 @@ export const pages: Record<string, Page | PageVariant[]> = {
       mfaIssuePath: "#",
     },
   },
+  [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE]: [
+    {
+      name: "default",
+      template: "enter-authenticator-app-code/index.njk",
+      options: {
+        isAccountRecoveryPermitted: true,
+        hasMultipleMfaMethods: false,
+        mfaIssuePath: "#",
+      },
+    },
+    {
+      name: "uplift",
+      template: "enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk",
+      options: {
+        isAccountRecoveryPermitted: true,
+        hasMultipleMfaMethods: false,
+        mfaIssuePath: "#",
+      },
+    }
+  ],
+  [PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS]: { template: "updated-terms-conditions/index.njk" },
 
   // Sign up
   [PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT]: { template: "enter-email/index-create-account.njk" },
@@ -80,4 +98,56 @@ export const pages: Record<string, Page | PageVariant[]> = {
     },
   },
   [PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL]: { template: "account-created/index.njk" },
+
+  // Reset password
+  [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL]: [{
+    name: "unforced",
+    template: "reset-password-check-email/index.njk",
+    options: {
+      email: "example@account.gov.uk",
+      isForcedPasswordResetJourney: false,
+    },
+  }, {
+    name: "forced",
+    template: "reset-password-check-email/index.njk",
+    options: {
+      email: "example@account.gov.uk",
+      isForcedPasswordResetJourney: true,
+    },
+  }],
+  [PATH_NAMES.RESET_PASSWORD]: {
+    template: "reset-password/index.njk",
+    options: { isPasswordChangeRequired: false },
+  },
+  [PATH_NAMES.RESET_PASSWORD_2FA_SMS]: {
+    template: "reset-password-2fa-sms/index.njk",
+    options: {
+      phoneNumber: "123",
+      resendCodeLink: "",
+      hasMultipleMfaMethods: false,
+      chooseMfaMethodHref: "#",
+    },
+  },
+  [PATH_NAMES.RESET_PASSWORD_2FA_AUTH_APP]: {
+    template: "reset-password-2fa-auth-app/index.njk",
+    options: {
+      hasMultipleMfaMethods: false,
+      chooseMfaMethodHref: "#",
+    },
+  },
+  [PATH_NAMES.RESET_PASSWORD_REQUIRED]: {
+    template: "reset-password/index.njk",
+    options: { isPasswordChangeRequired: true },
+  },
+
+  // Account interventions
+  [PATH_NAMES.PASSWORD_RESET_REQUIRED]: {
+    template: "account-intervention/password-reset-required/index.njk"
+  },
+  [PATH_NAMES.UNAVAILABLE_PERMANENT]: {
+    template: "account-intervention/permanently-blocked/index.njk"
+  },
+  [PATH_NAMES.UNAVAILABLE_TEMPORARY]: {
+    template: "account-intervention/temporarily-blocked/index.njk"
+  },
 };

--- a/src/components/templates/templates-controller.ts
+++ b/src/components/templates/templates-controller.ts
@@ -13,25 +13,25 @@ interface PageListItem {
   variants: RadioOption[];
 }
 
-const getPageListItems = (): PageListItem[] => {
-  return Object.entries(pages).map(([path, page]) => ({
+const pageListItems: PageListItem[] = Object.entries(pages)
+  .map(([path, page]) => ({
     path,
     variants: Array.isArray(page)
       ? page.map(({ name }) => ({ text: name, value: name }))
       : [],
-  })).sort((a, b) => a.path.localeCompare(b.path));
+  }))
+  .sort((a, b) => a.path.localeCompare(b.path));
+
+export const allTemplatesGet: RequestHandler = (req, res) => {
+  return res.render("templates/index.njk", { pageListItems });
 };
 
-export const allTemplatesGet: RequestHandler = async (req, res) => {
-  res.render("templates/index.njk", { pageListItems: getPageListItems() });
-};
-
-export const allTemplatesPost: RequestHandler = async (req, res) => {
+export const allTemplatesPost: RequestHandler = (req, res) => {
   const templateId = req.body.template;
 
   if (!pages[templateId]) {
     return res.render("templates/index.njk", {
-      pageListItems: getPageListItems(),
+      pageListItems,
       errorState: true,
     });
   }
@@ -45,7 +45,7 @@ export const allTemplatesPost: RequestHandler = async (req, res) => {
   return res.redirect(`/templates${templateId}?${query}`);
 };
 
-export const templatesDisplayGet: RequestHandler = async (req, res) => {
+export const templatesDisplayGet: RequestHandler = (req, res) => {
   const path = `/${req.params.templateId}`;
   const pageVariant = req.query.pageVariant;
 
@@ -54,7 +54,9 @@ export const templatesDisplayGet: RequestHandler = async (req, res) => {
     : pages[path];
 
   if (!page) {
-    logger.error(`Could not find template for ${path} (${pageVariant || "no variant"})`);
+    logger.error(
+      `Could not find template for ${path} (${pageVariant || "no variant"})`
+    );
     res.status(404);
     return res.render("common/errors/404.njk");
   }

--- a/src/components/templates/templates-controller.ts
+++ b/src/components/templates/templates-controller.ts
@@ -1,0 +1,74 @@
+import type { RequestHandler } from "express";
+import querystring from "querystring";
+import { pages } from "./pages.js";
+import { logger } from "../../utils/logger.js";
+
+interface RadioOption {
+  text: string;
+  value: string;
+}
+
+interface PageListItem {
+  path: string;
+  variants: RadioOption[];
+}
+
+const getPageListItems = (): PageListItem[] => {
+  return Object.entries(pages).map(([path, page]) => ({
+    path,
+    variants: Array.isArray(page)
+      ? page.map(({ name }) => ({ text: name, value: name }))
+      : [],
+  })).sort((a, b) => a.path.localeCompare(b.path));
+};
+
+export const allTemplatesGet: RequestHandler = async (req, res) => {
+  res.render("templates/index.njk", { pageListItems: getPageListItems() });
+};
+
+export const allTemplatesPost: RequestHandler = async (req, res) => {
+  const templateId = req.body.template;
+
+  if (!pages[templateId]) {
+    return res.render("templates/index.njk", {
+      pageListItems: getPageListItems(),
+      errorState: true,
+    });
+  }
+
+  const query = querystring.stringify({
+    lng: req.body.language,
+    pageVariant: req.body.pageVariant,
+    pageErrorState: req.body.hasErrorState,
+  });
+
+  return res.redirect(`/templates${templateId}?${query}`);
+};
+
+export const templatesDisplayGet: RequestHandler = async (req, res) => {
+  const path = `/${req.params.templateId}`;
+  const pageVariant = req.query.pageVariant;
+
+  const page = Array.isArray(pages[path])
+    ? pages[path].find(({ name }) => name === pageVariant)
+    : pages[path];
+
+  if (!page) {
+    logger.error(`Could not find template for ${path} (${pageVariant || "no variant"})`);
+    res.status(404);
+    return res.render("common/errors/404.njk");
+  }
+
+  const renderOptions = {
+    ...page.options,
+  };
+
+  if (req.query.pageErrorState) {
+    renderOptions.errors = {
+      exampleError: { text: "An example error occurred" },
+    };
+    renderOptions.errorList = Object.values(renderOptions.errors);
+  }
+
+  return res.render(page.template, renderOptions);
+};

--- a/src/components/templates/templates-routes.ts
+++ b/src/components/templates/templates-routes.ts
@@ -1,0 +1,10 @@
+import * as express from "express";
+import { allTemplatesPost, allTemplatesGet, templatesDisplayGet } from "./templates-controller.js";
+
+const router = express.Router();
+
+router.post("/templates", allTemplatesPost);
+router.get("/templates", allTemplatesGet);
+router.get("/templates/:templateId", templatesDisplayGet);
+
+export { router as templatesRouter };

--- a/src/components/templates/templates-routes.ts
+++ b/src/components/templates/templates-routes.ts
@@ -1,5 +1,9 @@
 import * as express from "express";
-import { allTemplatesPost, allTemplatesGet, templatesDisplayGet } from "./templates-controller.js";
+import {
+  allTemplatesPost,
+  allTemplatesGet,
+  templatesDisplayGet,
+} from "./templates-controller.js";
 
 const router = express.Router();
 


### PR DESCRIPTION
## What

Add template viewer to auth frontend in non-prod environments. Currently only includes main (non optional) journey states, but can be easily extended.

This allows you to see a list of pages in the app:

<img width="3274" height="2136" alt="image" src="https://github.com/user-attachments/assets/61e66bb7-634e-47a1-a0cf-54c810eb155f" />

Selecting one allows you to preview that page outside of a journey:

<img width="3274" height="2136" alt="image" src="https://github.com/user-attachments/assets/80bdc41e-614e-475d-9984-caebbb85214b" />

The journey map is also updated so that double-clicking on a page state (in green) opens up a preview of that page:

<img width="3274" height="2136" alt="image" src="https://github.com/user-attachments/assets/ead955e6-e4f9-4025-9411-4f5f5f9e1d7c" />

## How to review

1. Code Review
1. Test locally with `yarn dev` and visiting both https://localhost:3000/templates and https://localhost:3000/journey-map
1. [Optional] Deploy to a dev environment and test there
