### PR TITLE
BAU: Revise state machine interface

### DIFF
--- a/custom-lint-rules/no-res-locals-write.js
+++ b/custom-lint-rules/no-res-locals-write.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export default {
   meta: {
     type: "problem",

--- a/src/components/account-created/account-created-controller.ts
+++ b/src/components/account-created/account-created-controller.ts
@@ -16,7 +16,6 @@ export async function accountCreatedPost(
 ): Promise<void> {
   const nextPath = await getNextPathAndUpdateJourney(
     req,
-    req.path,
     USER_JOURNEY_EVENTS.ACCOUNT_CREATED,
     res.locals.sessionId
   );

--- a/src/components/account-created/account-created-controller.ts
+++ b/src/components/account-created/account-created-controller.ts
@@ -17,7 +17,7 @@ export async function accountCreatedPost(
   const nextPath = await getNextPathAndUpdateJourney(
     req,
     res,
-    USER_JOURNEY_EVENTS.ACCOUNT_CREATED,
+    USER_JOURNEY_EVENTS.ACCOUNT_CREATED
   );
 
   res.redirect(nextPath);

--- a/src/components/account-created/account-created-controller.ts
+++ b/src/components/account-created/account-created-controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 export function accountCreatedGet(req: Request, res: Response): void {
   const { serviceType, name } = req.session.client;

--- a/src/components/account-created/account-created-controller.ts
+++ b/src/components/account-created/account-created-controller.ts
@@ -16,8 +16,8 @@ export async function accountCreatedPost(
 ): Promise<void> {
   const nextPath = await getNextPathAndUpdateJourney(
     req,
+    res,
     USER_JOURNEY_EVENTS.ACCOUNT_CREATED,
-    res.locals.sessionId
   );
 
   res.redirect(nextPath);

--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -4,9 +4,7 @@ import type { ExpressRouteFunc } from "../../types.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";
 import { sendNotificationService } from "../common/send-notification/send-notification-service.js";
 import { BadRequestError } from "../../utils/error.js";
-import {
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import xss from "xss";
@@ -62,7 +60,7 @@ export function accountNotFoundPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
+        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE
       )
     );
   };

--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -61,7 +61,6 @@ export function accountNotFoundPost(
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
         null,
         sessionId

--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -6,8 +6,8 @@ import { sendNotificationService } from "../common/send-notification/send-notifi
 import { BadRequestError } from "../../utils/error.js";
 import {
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import xss from "xss";
 import { getServiceSignInLink } from "../../config.js";

--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -61,9 +61,8 @@ export function accountNotFoundPost(
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
-        null,
-        sessionId
       )
     );
   };

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -33,7 +33,7 @@ export async function changeSecurityCodesConfirmationPost(
   const nextPath = await getNextPathAndUpdateJourney(
     req,
     res,
-    USER_JOURNEY_EVENTS.CHANGE_SECURITY_CODES_COMPLETED,
+    USER_JOURNEY_EVENTS.CHANGE_SECURITY_CODES_COMPLETED
   );
   res.redirect(nextPath);
 }

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -32,7 +32,6 @@ export async function changeSecurityCodesConfirmationPost(
   req.session.user.accountRecoveryVerifiedMfaType = null;
   const nextPath = await getNextPathAndUpdateJourney(
     req,
-    req.path,
     USER_JOURNEY_EVENTS.CHANGE_SECURITY_CODES_COMPLETED,
     null,
     res.locals.sessionId

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { MFA_METHOD_TYPE } from "../../../app.constants.js";
 import type { ExpressRouteFunc } from "../../../types.js";
 import { USER_JOURNEY_EVENTS } from "../../common/state-machine/state-machine.js";
-import { getNextPathAndUpdateJourney } from "../../common/constants.js";
+import { getNextPathAndUpdateJourney } from "src/components/common/state-machine/state-machine-executor.js";
 import { getDefaultSmsMfaMethod } from "../../../utils/mfa.js";
 
 export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from "express";
 import { MFA_METHOD_TYPE } from "../../../app.constants.js";
 import type { ExpressRouteFunc } from "../../../types.js";
 import { USER_JOURNEY_EVENTS } from "../../common/state-machine/state-machine.js";
-import { getNextPathAndUpdateJourney } from "src/components/common/state-machine/state-machine-executor.js";
+import { getNextPathAndUpdateJourney } from "../../common/state-machine/state-machine-executor.js";
 import { getDefaultSmsMfaMethod } from "../../../utils/mfa.js";
 
 export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -32,9 +32,8 @@ export async function changeSecurityCodesConfirmationPost(
   req.session.user.accountRecoveryVerifiedMfaType = null;
   const nextPath = await getNextPathAndUpdateJourney(
     req,
+    res,
     USER_JOURNEY_EVENTS.CHANGE_SECURITY_CODES_COMPLETED,
-    null,
-    res.locals.sessionId
   );
   res.redirect(nextPath);
 }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -9,9 +9,9 @@ import {
   APP_ENV_NAME,
 } from "../../app.constants.js";
 import {
-  getNextPathAndUpdateJourney,
   ERROR_CODES,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError, QueryParamsError } from "../../utils/error.js";
 import type { ApiResponseResult, ExpressRouteFunc } from "../../types.js";
 import type { CookieConsentServiceInterface } from "../common/cookie-consent/types.js";

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -135,6 +135,7 @@ export function authorizeGet(
 
     let redirectPath = await getNextPathAndUpdateJourney(
       req,
+      res,
       nextStateEvent,
       {
         requiresUplift: isUpliftRequired(req),
@@ -143,7 +144,6 @@ export function authorizeGet(
         mfaMethodType: startAuthResponse.data.user.mfaMethodType,
         isReauthenticationRequired: isReauth(req),
       },
-      sessionId
     );
 
     const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -2,7 +2,6 @@ import type { Request, Response } from "express";
 import {
   COOKIE_CONSENT,
   COOKIES_PREFERENCES_SET,
-  PATH_NAMES,
   ERROR_LOG_LEVEL,
   COOKIES_CHANNEL,
   CHANNEL,

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -8,9 +8,7 @@ import {
   CHANNEL,
   APP_ENV_NAME,
 } from "../../app.constants.js";
-import {
-  ERROR_CODES,
-} from "../common/constants.js";
+import { ERROR_CODES } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError, QueryParamsError } from "../../utils/error.js";
 import type { ApiResponseResult, ExpressRouteFunc } from "../../types.js";
@@ -143,7 +141,7 @@ export function authorizeGet(
         prompt: req.session.client.prompt,
         mfaMethodType: startAuthResponse.data.user.mfaMethodType,
         isReauthenticationRequired: isReauth(req),
-      },
+      }
     );
 
     const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -135,7 +135,6 @@ export function authorizeGet(
 
     let redirectPath = await getNextPathAndUpdateJourney(
       req,
-      PATH_NAMES.AUTHORIZE,
       nextStateEvent,
       {
         requiresUplift: isUpliftRequired(req),

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -117,7 +117,6 @@ export const checkYourPhonePost = (
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -9,9 +9,9 @@ import type { ExpressRouteFunc } from "../../types.js";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
   pathWithQueryParam,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";
 import { sendNotificationService } from "../common/send-notification/send-notification-service.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -117,12 +117,12 @@ export const checkYourPhonePost = (
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
           isAccountRecoveryJourney: accountRecoveryEnabledJourney,
         },
-        res.locals.sessionId
       )
     );
   };

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -122,7 +122,7 @@ export const checkYourPhonePost = (
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
           isAccountRecoveryJourney: accountRecoveryEnabledJourney,
-        },
+        }
       )
     );
   };

--- a/src/components/common/account-recovery/tests/account-recovery-helper.test.ts
+++ b/src/components/common/account-recovery/tests/account-recovery-helper.test.ts
@@ -59,7 +59,7 @@ const TEST_ERROR_CODE = "TestErrorCode";
 export const fakeAccountRecoveryService = (
   accountRecoveryPermitted: boolean,
   success = true
-) => {
+): AccountRecoveryInterface => {
   return {
     accountRecovery: sinon.fake.returns({
       success,

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -1,7 +1,7 @@
 import { PATH_NAMES } from "../../app.constants.js";
 import type { AuthStateContext } from "./state-machine/state-machine.js";
 import { getNextState } from "./state-machine/state-machine.js";
-import type { Request } from "express";
+import type { Request, Response } from "express";
 
 export const SECURITY_CODE_ERROR = "actionType";
 
@@ -184,10 +184,12 @@ export async function saveSessionState(req: Request): Promise<void> {
 
 export async function getNextPathAndUpdateJourney(
   req: Request,
+  res: Response,
   event: string,
   ctx?: AuthStateContext,
-  sessionId?: string
 ): Promise<string> {
+  const sessionId = res.locals.sessionId;
+
   const nextState = getNextState(req.path, event, ctx);
 
   req.session.user.journey = {

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -184,12 +184,11 @@ export async function saveSessionState(req: Request): Promise<void> {
 
 export async function getNextPathAndUpdateJourney(
   req: Request,
-  path: string,
   event: string,
   ctx?: AuthStateContext,
   sessionId?: string
 ): Promise<string> {
-  const nextState = getNextState(path, event, ctx);
+  const nextState = getNextState(req.path, event, ctx);
 
   req.session.user.journey = {
     nextPath: nextState.value,
@@ -207,7 +206,7 @@ export async function getNextPathAndUpdateJourney(
 
   if (!nextState) {
     throw Error(
-      `Invalid user journey. No transition found from ${path} with event ${event} with sessionId ${sessionId}`
+      `Invalid user journey. No transition found from ${req.path} with event ${event} with sessionId ${sessionId}`
     );
   }
 

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -1,7 +1,5 @@
 import { PATH_NAMES } from "../../app.constants.js";
-import type { AuthStateContext } from "./state-machine/state-machine.js";
-import { getNextState } from "./state-machine/state-machine.js";
-import type { Request, Response } from "express";
+import type { Request } from "express";
 
 export const SECURITY_CODE_ERROR = "actionType";
 
@@ -180,39 +178,6 @@ export async function saveSessionState(req: Request): Promise<void> {
       }
     });
   });
-}
-
-export async function getNextPathAndUpdateJourney(
-  req: Request,
-  res: Response,
-  event: string,
-  ctx?: AuthStateContext,
-): Promise<string> {
-  const sessionId = res.locals.sessionId;
-
-  const nextState = getNextState(req.path, event, ctx);
-
-  req.session.user.journey = {
-    nextPath: nextState.value,
-    optionalPaths:
-      Object.keys(nextState.meta).length > 0
-        ? nextState.meta["AUTH." + nextState.value].optionalPaths
-        : [],
-  };
-
-  await saveSessionState(req);
-
-  req.log.info(
-    `User journey transitioned from ${req.path} to ${nextState.value} with session id ${sessionId}`
-  );
-
-  if (!nextState) {
-    throw Error(
-      `Invalid user journey. No transition found from ${req.path} with event ${event} with sessionId ${sessionId}`
-    );
-  }
-
-  return nextState.value;
 }
 
 export const JOURNEY_TYPE = {

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -97,13 +97,13 @@ export function sendMfaGeneric(
     if (!isResendCodeRequest) {
       redirectPath = await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.VERIFY_MFA,
         {
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
           isIdentityRequired: req.session.user.isIdentityRequired,
         },
-        sessionId
       );
     }
 

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -5,10 +5,7 @@ import type {
   ExpressRouteFunc,
 } from "../../../types.js";
 import type { MfaServiceInterface } from "./types.js";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../constants.js";
 import { getNextPathAndUpdateJourney } from "../state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine.js";
@@ -103,7 +100,7 @@ export function sendMfaGeneric(
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
           isIdentityRequired: req.session.user.isIdentityRequired,
-        },
+        }
       );
     }
 

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -8,8 +8,8 @@ import type { MfaServiceInterface } from "./types.js";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../constants.js";
+import { getNextPathAndUpdateJourney } from "../state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine.js";
 import { PATH_NAMES } from "../../../app.constants.js";

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -97,7 +97,6 @@ export function sendMfaGeneric(
     if (!isResendCodeRequest) {
       redirectPath = await getNextPathAndUpdateJourney(
         req,
-        PATH_NAMES.ENTER_MFA,
         USER_JOURNEY_EVENTS.VERIFY_MFA,
         {
           isLatestTermsAndConditionsAccepted:

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -11,17 +11,22 @@ interface AuthState extends State<AuthStateContext> {
       optionalPaths?: string[];
     };
   };
-};
+}
 
 export async function getNextPathAndUpdateJourney(
   req: Request,
   res: Response,
   event: string,
-  ctx?: AuthStateContext,
+  ctx?: AuthStateContext
 ): Promise<string> {
   const sessionId = res.locals.sessionId;
+  const currentState = req.path;
 
-  const nextState = authStateMachine.transition(req.path, event, ctx) as AuthState;
+  const nextState = authStateMachine.transition(
+    currentState,
+    event,
+    ctx
+  ) as AuthState;
 
   req.session.user.journey = {
     nextPath: nextState.value,

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -32,7 +32,8 @@ export async function getNextPathAndUpdateJourney(
     nextPath: nextState.value,
     optionalPaths:
       Object.keys(nextState.meta).length > 0
-        ? nextState.meta["AUTH." + nextState.value].optionalPaths
+        ? nextState.meta[`${authStateMachine.id}.${nextState.value}`]
+            .optionalPaths
         : [],
   };
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -1,0 +1,47 @@
+import type { Request, Response } from "express";
+import { authStateMachine, type AuthStateContext } from "./state-machine.js";
+import { saveSessionState } from "../constants.js";
+import type { State } from "xstate";
+
+// Extend the state interface to be more precise
+interface AuthState extends State<AuthStateContext> {
+  value: string;
+  meta: {
+    [id: string]: {
+      optionalPaths?: string[];
+    };
+  };
+};
+
+export async function getNextPathAndUpdateJourney(
+  req: Request,
+  res: Response,
+  event: string,
+  ctx?: AuthStateContext,
+): Promise<string> {
+  const sessionId = res.locals.sessionId;
+
+  const nextState = authStateMachine.transition(req.path, event, ctx) as AuthState;
+
+  req.session.user.journey = {
+    nextPath: nextState.value,
+    optionalPaths:
+      Object.keys(nextState.meta).length > 0
+        ? nextState.meta["AUTH." + nextState.value].optionalPaths
+        : [],
+  };
+
+  await saveSessionState(req);
+
+  req.log.info(
+    `User journey transitioned from ${req.path} to ${nextState.value} with session id ${sessionId}`
+  );
+
+  if (!nextState) {
+    throw Error(
+      `Invalid user journey. No transition found from ${req.path} with event ${event} with sessionId ${sessionId}`
+    );
+  }
+
+  return nextState.value;
+}

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -380,6 +380,11 @@ const authStateMachine = createMachine<AuthStateContext>(
           ],
         },
       },
+      [PATH_NAMES.RESEND_MFA_CODE]: {
+        on: {
+          [USER_JOURNEY_EVENTS.VERIFY_MFA]: [PATH_NAMES.ENTER_MFA],
+        },
+      },
       [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE]: {
         on: {
           [USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED]: [

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -1,3 +1,4 @@
+import type { State } from "xstate";
 import { createMachine } from "xstate";
 import {
   MFA_METHOD_TYPE,
@@ -726,6 +727,22 @@ const authStateMachine = createMachine<AuthStateContext>(
   }
 );
 
+// Extend the state interface to be more precise
+interface AuthState extends State<AuthStateContext> {
+  value: string;
+  meta: {
+    [id: string]: {
+      optionalPaths?: string[];
+    };
+  };
+}
+
+const getNextState = (
+  stateId: string,
+  event: string,
+  ctx?: AuthStateContext
+): AuthState => authStateMachine.transition(stateId, event, ctx) as AuthState;
+
 export type AuthStateMachine = typeof authStateMachine;
 
-export { USER_JOURNEY_EVENTS, authStateMachine };
+export { getNextState, USER_JOURNEY_EVENTS, authStateMachine };

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -1,4 +1,3 @@
-import type { EventType, StateValue } from "xstate";
 import { createMachine } from "xstate";
 import {
   MFA_METHOD_TYPE,
@@ -727,19 +726,6 @@ const authStateMachine = createMachine<AuthStateContext>(
   }
 );
 
-function getNextState(
-  from: StateValue,
-  to: any,
-  ctx?: AuthStateContext
-): { value: string; events: EventType[]; meta: any } {
-  const t = authStateMachine.transition(from, to, ctx);
-  return {
-    value: t.value as string,
-    events: t.nextEvents,
-    meta: t.meta,
-  };
-}
-
 export type AuthStateMachine = typeof authStateMachine;
 
-export { getNextState, USER_JOURNEY_EVENTS, authStateMachine };
+export { USER_JOURNEY_EVENTS, authStateMachine };

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -178,7 +178,6 @@ export function verifyCodePost(
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         nextEvent,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -1,8 +1,5 @@
 import type { Request, Response } from "express";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../constants.js";
 import { getNextPathAndUpdateJourney } from "../state-machine/state-machine-executor.js";
 import {
   formatValidationError,
@@ -176,21 +173,16 @@ export function verifyCodePost(
     }
 
     res.redirect(
-      await getNextPathAndUpdateJourney(
-        req,
-        res,
-        nextEvent,
-        {
-          isIdentityRequired: req.session.user.isIdentityRequired,
-          isLatestTermsAndConditionsAccepted:
-            req.session.user.isLatestTermsAndConditionsAccepted,
-          mfaMethodType: req.session.user.enterEmailMfaType,
-          isPasswordChangeRequired: req.session.user.isPasswordChangeRequired,
-          isOnForcedPasswordResetJourney:
-            req.path === PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL &&
-            req.session.user.withinForcedPasswordResetJourney,
-        },
-      )
+      await getNextPathAndUpdateJourney(req, res, nextEvent, {
+        isIdentityRequired: req.session.user.isIdentityRequired,
+        isLatestTermsAndConditionsAccepted:
+          req.session.user.isLatestTermsAndConditionsAccepted,
+        mfaMethodType: req.session.user.enterEmailMfaType,
+        isPasswordChangeRequired: req.session.user.isPasswordChangeRequired,
+        isOnForcedPasswordResetJourney:
+          req.path === PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL &&
+          req.session.user.withinForcedPasswordResetJourney,
+      })
     );
   };
 }

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -178,6 +178,7 @@ export function verifyCodePost(
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         nextEvent,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
@@ -189,7 +190,6 @@ export function verifyCodePost(
             req.path === PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL &&
             req.session.user.withinForcedPasswordResetJourney,
         },
-        res.locals.sessionId
       )
     );
   };

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -2,8 +2,8 @@ import type { Request, Response } from "express";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../constants.js";
+import { getNextPathAndUpdateJourney } from "../state-machine/state-machine-executor.js";
 import {
   formatValidationError,
   renderBadRequest,

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -43,7 +43,6 @@ export function createPasswordPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           requiresTwoFactorAuth: true,

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -6,8 +6,8 @@ import { BadRequestError } from "../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import {
   ERROR_CODES,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import {
   formatValidationError,
   renderBadRequest,

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -4,9 +4,7 @@ import { createPasswordService } from "./create-password-service.js";
 import type { CreatePasswordServiceInterface } from "./types.js";
 import { BadRequestError } from "../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
-import {
-  ERROR_CODES,
-} from "../common/constants.js";
+import { ERROR_CODES } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import {
   formatValidationError,
@@ -47,7 +45,7 @@ export function createPasswordPost(
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           requiresTwoFactorAuth: true,
-        },
+        }
       )
     );
   };

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -43,11 +43,11 @@ export function createPasswordPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           requiresTwoFactorAuth: true,
         },
-        res.locals.sessionId
       )
     );
   };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -117,13 +117,13 @@ export const enterAuthenticatorAppCodePost = (
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
         },
-        res.locals.sessionId
       )
     );
   };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -117,7 +117,6 @@ export const enterAuthenticatorAppCodePost = (
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -7,8 +7,8 @@ import type {
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import {
   getCodeEnteredWrongBlockDurationInMinutes,
   supportReauthentication,

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -4,10 +4,7 @@ import type {
   DefaultApiResponse,
   ExpressRouteFunc,
 } from "../../types.js";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import {
   getCodeEnteredWrongBlockDurationInMinutes,
@@ -123,7 +120,7 @@ export const enterAuthenticatorAppCodePost = (
           isIdentityRequired: req.session.user.isIdentityRequired,
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
-        },
+        }
       )
     );
   };

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -11,10 +11,7 @@ import type {
   LockoutInformation,
 } from "./types.js";
 import type { SecurityCodeErrorType } from "../common/constants.js";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../utils/error.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";
@@ -66,7 +63,7 @@ export async function enterEmailCreateRequestGet(
     await getNextPathAndUpdateJourney(
       req,
       res,
-      USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT,
+      USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT
     )
   );
 }
@@ -172,13 +169,7 @@ export function enterEmailPost(
       ? USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS
       : USER_JOURNEY_EVENTS.ACCOUNT_NOT_FOUND;
 
-    return res.redirect(
-      await getNextPathAndUpdateJourney(
-        req,
-        res,
-        nextState,
-      )
-    );
+    return res.redirect(await getNextPathAndUpdateJourney(req, res, nextState));
   };
 }
 
@@ -208,7 +199,7 @@ export function enterEmailCreatePost(
         await getNextPathAndUpdateJourney(
           req,
           res,
-          USER_JOURNEY_EVENTS.ACCOUNT_FOUND_CREATE,
+          USER_JOURNEY_EVENTS.ACCOUNT_FOUND_CREATE
         )
       );
     }
@@ -253,7 +244,7 @@ export function enterEmailCreatePost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
+        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE
       )
     );
   };

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -65,9 +65,8 @@ export async function enterEmailCreateRequestGet(
   return res.redirect(
     await getNextPathAndUpdateJourney(
       req,
+      res,
       USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT,
-      null,
-      res.locals.sessionId
     )
   );
 }
@@ -176,9 +175,8 @@ export function enterEmailPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         nextState,
-        null,
-        sessionId
       )
     );
   };
@@ -209,9 +207,8 @@ export function enterEmailCreatePost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
+          res,
           USER_JOURNEY_EVENTS.ACCOUNT_FOUND_CREATE,
-          null,
-          sessionId
         )
       );
     }
@@ -255,9 +252,8 @@ export function enterEmailCreatePost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
-        null,
-        sessionId
       )
     );
   };

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -14,8 +14,8 @@ import type { SecurityCodeErrorType } from "../common/constants.js";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../utils/error.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";
 import { sendNotificationService } from "../common/send-notification/send-notification-service.js";

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -65,7 +65,6 @@ export async function enterEmailCreateRequestGet(
   return res.redirect(
     await getNextPathAndUpdateJourney(
       req,
-      req.path,
       USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT,
       null,
       res.locals.sessionId
@@ -177,7 +176,6 @@ export function enterEmailPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         nextState,
         null,
         sessionId
@@ -211,7 +209,6 @@ export function enterEmailCreatePost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
-          req.path,
           USER_JOURNEY_EVENTS.ACCOUNT_FOUND_CREATE,
           null,
           sessionId
@@ -258,7 +255,6 @@ export function enterEmailCreatePost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
         null,
         sessionId

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -12,8 +12,8 @@ import { mfaService } from "../common/mfa/mfa-service.js";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { ReauthJourneyError } from "../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -9,10 +9,7 @@ import { enterPasswordService } from "./enter-password-service.js";
 import type { EnterPasswordServiceInterface } from "./types.js";
 import type { MfaServiceInterface } from "../common/mfa/types.js";
 import { mfaService } from "../common/mfa/mfa-service.js";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { ReauthJourneyError } from "../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
@@ -185,7 +182,7 @@ export function enterPasswordPost(
       clientSessionId,
       persistentSessionId,
       req,
-      res,
+      res
     );
     if (interventionRedirect) {
       return res.redirect(interventionRedirect);
@@ -231,7 +228,7 @@ export function enterPasswordPost(
           mfaMethodType: userLogin.data.mfaMethodType,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
           isPasswordChangeRequired: isPasswordChangeRequired,
-        },
+        }
       )
     );
   };
@@ -244,7 +241,7 @@ export function enterPasswordPost(
     clientSessionId: string,
     persistentSessionId: string,
     req: Request,
-    res: Response,
+    res: Response
   ): Promise<string | null> {
     if (!isPasswordChangeRequired || !supportAccountInterventions()) {
       return null;
@@ -267,7 +264,7 @@ export function enterPasswordPost(
       return await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.COMMON_PASSWORD_AND_AIS_STATUS,
+        USER_JOURNEY_EVENTS.COMMON_PASSWORD_AND_AIS_STATUS
       );
     }
 

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -184,7 +184,8 @@ export function enterPasswordPost(
       email,
       clientSessionId,
       persistentSessionId,
-      req
+      req,
+      res,
     );
     if (interventionRedirect) {
       return res.redirect(interventionRedirect);
@@ -221,6 +222,7 @@ export function enterPasswordPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
         {
           isLatestTermsAndConditionsAccepted:
@@ -230,7 +232,6 @@ export function enterPasswordPost(
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
           isPasswordChangeRequired: isPasswordChangeRequired,
         },
-        sessionId
       )
     );
   };
@@ -242,7 +243,8 @@ export function enterPasswordPost(
     email: string,
     clientSessionId: string,
     persistentSessionId: string,
-    req: Request
+    req: Request,
+    res: Response,
   ): Promise<string | null> {
     if (!isPasswordChangeRequired || !supportAccountInterventions()) {
       return null;
@@ -264,9 +266,8 @@ export function enterPasswordPost(
     ) {
       return await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.COMMON_PASSWORD_AND_AIS_STATUS,
-        null,
-        sessionId
       );
     }
 

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -221,7 +221,6 @@ export function enterPasswordPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
         {
           isLatestTermsAndConditionsAccepted:
@@ -265,7 +264,6 @@ export function enterPasswordPost(
     ) {
       return await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.COMMON_PASSWORD_AND_AIS_STATUS,
         null,
         sessionId

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -6,8 +6,8 @@ import type { SecurityCodeErrorType } from "../common/constants.js";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../utils/error.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";
 import { sendNotificationService } from "../common/send-notification/send-notification-service.js";

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -3,10 +3,7 @@ import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants.js";
 import type { ExpressRouteFunc } from "../../types.js";
 import { redactPhoneNumber } from "../../utils/strings.js";
 import type { SecurityCodeErrorType } from "../common/constants.js";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../utils/error.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";
@@ -92,7 +89,7 @@ export function enterPhoneNumberPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.VERIFY_PHONE_NUMBER,
+        USER_JOURNEY_EVENTS.VERIFY_PHONE_NUMBER
       )
     );
   };

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -91,9 +91,8 @@ export function enterPhoneNumberPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.VERIFY_PHONE_NUMBER,
-        null,
-        sessionId
       )
     );
   };

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -91,7 +91,6 @@ export function enterPhoneNumberPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.VERIFY_PHONE_NUMBER,
         null,
         sessionId

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -82,7 +82,6 @@ export function howDoYouWantSecurityCodesPost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
-          req.path,
           USER_JOURNEY_EVENTS.SELECT_SMS_MFA_METHOD,
           { isPasswordResetJourney },
           res.locals.sessionId
@@ -95,7 +94,6 @@ export function howDoYouWantSecurityCodesPost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
-          req.path,
           USER_JOURNEY_EVENTS.SELECT_AUTH_APP_MFA_METHOD,
           { isPasswordResetJourney },
           res.locals.sessionId

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants.js";
 import type { ExpressRouteFunc, MfaMethod } from "../../types.js";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import type { MfaServiceInterface } from "../common/mfa/types.js";
 import { mfaService } from "../common/mfa/mfa-service.js";

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -82,9 +82,9 @@ export function howDoYouWantSecurityCodesPost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
+          res,
           USER_JOURNEY_EVENTS.SELECT_SMS_MFA_METHOD,
           { isPasswordResetJourney },
-          res.locals.sessionId
         )
       );
     }
@@ -94,9 +94,9 @@ export function howDoYouWantSecurityCodesPost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
+          res,
           USER_JOURNEY_EVENTS.SELECT_AUTH_APP_MFA_METHOD,
           { isPasswordResetJourney },
-          res.locals.sessionId
         )
       );
     }

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -84,7 +84,7 @@ export function howDoYouWantSecurityCodesPost(
           req,
           res,
           USER_JOURNEY_EVENTS.SELECT_SMS_MFA_METHOD,
-          { isPasswordResetJourney },
+          { isPasswordResetJourney }
         )
       );
     }
@@ -96,7 +96,7 @@ export function howDoYouWantSecurityCodesPost(
           req,
           res,
           USER_JOURNEY_EVENTS.SELECT_AUTH_APP_MFA_METHOD,
-          { isPasswordResetJourney },
+          { isPasswordResetJourney }
         )
       );
     }

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -80,16 +80,15 @@ export function ipvCallbackGet(
       }
 
       return res.redirect(
-        await getNextPathAndUpdateJourney(req, event, {}, sessionId)
+        await getNextPathAndUpdateJourney(req, res, event)
       );
     }
 
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.IPV_REVERIFICATION_COMPLETED,
-        {},
-        sessionId
       )
     );
   };
@@ -123,11 +122,10 @@ export async function cannotChangeSecurityCodesPost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
+          res,
           req.session.user.mfaMethodType === MFA_METHOD_TYPE.SMS
             ? USER_JOURNEY_EVENTS.VERIFY_MFA
             : USER_JOURNEY_EVENTS.VERIFY_AUTH_APP_CODE,
-          {},
-          sessionId
         )
       );
   }

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -8,7 +8,7 @@ import {
 import { logger } from "../../utils/logger.js";
 import { reverificationResultService } from "./reverification-result-service.js";
 import { BadRequestError } from "../../utils/error.js";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import {
   CANNOT_CHANGE_HOW_GET_SECURITY_CODES_ACTION,

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -79,16 +79,14 @@ export function ipvCallbackGet(
         throw new Error(result.data.failure_code);
       }
 
-      return res.redirect(
-        await getNextPathAndUpdateJourney(req, res, event)
-      );
+      return res.redirect(await getNextPathAndUpdateJourney(req, res, event));
     }
 
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.IPV_REVERIFICATION_COMPLETED,
+        USER_JOURNEY_EVENTS.IPV_REVERIFICATION_COMPLETED
       )
     );
   };
@@ -125,7 +123,7 @@ export async function cannotChangeSecurityCodesPost(
           res,
           req.session.user.mfaMethodType === MFA_METHOD_TYPE.SMS
             ? USER_JOURNEY_EVENTS.VERIFY_MFA
-            : USER_JOURNEY_EVENTS.VERIFY_AUTH_APP_CODE,
+            : USER_JOURNEY_EVENTS.VERIFY_AUTH_APP_CODE
         )
       );
   }

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -109,7 +109,6 @@ export async function cannotChangeSecurityCodesPost(
   req: Request,
   res: Response
 ): Promise<void> {
-  const { sessionId } = res.locals;
   const cannotChangeHowGetSecurityCodeAction =
     req.body.cannotChangeHowGetSecurityCodeAction;
 

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -80,14 +80,13 @@ export function ipvCallbackGet(
       }
 
       return res.redirect(
-        await getNextPathAndUpdateJourney(req, req.path, event, {}, sessionId)
+        await getNextPathAndUpdateJourney(req, event, {}, sessionId)
       );
     }
 
     res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.IPV_REVERIFICATION_COMPLETED,
         {},
         sessionId
@@ -124,7 +123,6 @@ export async function cannotChangeSecurityCodesPost(
       return res.redirect(
         await getNextPathAndUpdateJourney(
           req,
-          req.path,
           req.session.user.mfaMethodType === MFA_METHOD_TYPE.SMS
             ? USER_JOURNEY_EVENTS.VERIFY_MFA
             : USER_JOURNEY_EVENTS.VERIFY_AUTH_APP_CODE,

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -3,7 +3,7 @@ import { mfaResetAuthorizeService } from "./mfa-reset-authorize-service.js";
 import type { ExpressRouteFunc } from "../../types.js";
 import type { Request, Response } from "express";
 import { BadRequestError } from "../../utils/error.js";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants.js";
 export function mfaResetWithIpvGet(

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -22,7 +22,6 @@ export function mfaResetWithIpvGet(
     if (res.locals.isApp) {
       const redirectPath = await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.MFA_RESET_ATTEMPTED_VIA_AUTH_APP,
         {},
         res.locals.sessionId
@@ -51,7 +50,6 @@ export function mfaResetWithIpvGet(
 
     await getNextPathAndUpdateJourney(
       req,
-      req.path,
       USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT,
       null,
       sessionId

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -23,7 +23,7 @@ export function mfaResetWithIpvGet(
       const redirectPath = await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.MFA_RESET_ATTEMPTED_VIA_AUTH_APP,
+        USER_JOURNEY_EVENTS.MFA_RESET_ATTEMPTED_VIA_AUTH_APP
       );
       return res.redirect(redirectPath);
     }
@@ -50,7 +50,7 @@ export function mfaResetWithIpvGet(
     await getNextPathAndUpdateJourney(
       req,
       res,
-      USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT,
+      USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT
     );
 
     const ipvCoreURL = result.data.authorize_url;

--- a/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
+++ b/src/components/mfa-reset-with-ipv/mfa-reset-with-ipv-controller.ts
@@ -22,9 +22,8 @@ export function mfaResetWithIpvGet(
     if (res.locals.isApp) {
       const redirectPath = await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.MFA_RESET_ATTEMPTED_VIA_AUTH_APP,
-        {},
-        res.locals.sessionId
       );
       return res.redirect(redirectPath);
     }
@@ -50,9 +49,8 @@ export function mfaResetWithIpvGet(
 
     await getNextPathAndUpdateJourney(
       req,
+      res,
       USER_JOURNEY_EVENTS.IPV_REVERIFICATION_INIT,
-      null,
-      sessionId
     );
 
     const ipvCoreURL = result.data.authorize_url;

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -3,8 +3,8 @@ import type { ExpressRouteFunc } from "../../types.js";
 import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants.js";
 import {
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import type { SendNotificationServiceInterface } from "../common/send-notification/types.js";

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -90,9 +90,8 @@ export function resendEmailCodePost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
-        {},
-        sessionId
       )
     );
   };
@@ -118,11 +117,11 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
         {
           isAccountRecoveryJourney: accountRecoveryJourney,
         },
-        sessionId
       )
     );
   };

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -1,9 +1,7 @@
 import type { Request, Response } from "express";
 import type { ExpressRouteFunc } from "../../types.js";
 import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants.js";
-import {
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { BadRequestError } from "../../utils/error.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
@@ -91,7 +89,7 @@ export function resendEmailCodePost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
+        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE
       )
     );
   };
@@ -121,7 +119,7 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
         {
           isAccountRecoveryJourney: accountRecoveryJourney,
-        },
+        }
       )
     );
   };

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -97,7 +97,6 @@ export function resendEmailCodePost(
 
 export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const { sessionId } = res.locals;
     const accountRecoveryJourney = isAccountRecoveryJourney(req);
     if (isLocked(req.session.user.codeRequestLock)) {
       const newCodeLink = req.query?.isResendCodeRequest

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -90,7 +90,6 @@ export function resendEmailCodePost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
         {},
         sessionId
@@ -119,7 +118,6 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
         {
           isAccountRecoveryJourney: accountRecoveryJourney,

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -93,11 +93,11 @@ export function resetPassword2FAAuthAppPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
         },
-        res.locals.sessionId
       )
     );
   };

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -3,8 +3,8 @@ import type { ExpressRouteFunc } from "src/types.js";
 import {
   ERROR_CODES,
   getErrorPathByCode,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import type { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types.js";
 import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service.js";

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -93,7 +93,6 @@ export function resetPassword2FAAuthAppPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -1,9 +1,6 @@
 import type { Request, Response } from "express";
 import type { ExpressRouteFunc } from "src/types.js";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-} from "../common/constants.js";
+import { ERROR_CODES, getErrorPathByCode } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import type { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types.js";
@@ -97,7 +94,7 @@ export function resetPassword2FAAuthAppPost(
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
-        },
+        }
       )
     );
   };

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -108,7 +108,6 @@ export function resetPasswordPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
@@ -131,7 +130,6 @@ export async function resetPasswordRequestGet(
   return res.redirect(
     await getNextPathAndUpdateJourney(
       req,
-      req.path,
       USER_JOURNEY_EVENTS.PASSWORD_RESET_REQUESTED,
       null,
       res.locals.sessionId

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -6,9 +6,7 @@ import {
   formatValidationError,
   renderBadRequest,
 } from "../../utils/validation.js";
-import {
-  ERROR_CODES,
-} from "../common/constants.js";
+import { ERROR_CODES } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import { BadRequestError } from "../../utils/error.js";
@@ -117,7 +115,7 @@ export function resetPasswordPost(
             req.session.user.isLatestTermsAndConditionsAccepted,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
-        },
+        }
       )
     );
   };
@@ -131,7 +129,7 @@ export async function resetPasswordRequestGet(
     await getNextPathAndUpdateJourney(
       req,
       res,
-      USER_JOURNEY_EVENTS.PASSWORD_RESET_REQUESTED,
+      USER_JOURNEY_EVENTS.PASSWORD_RESET_REQUESTED
     )
   );
 }

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -8,8 +8,8 @@ import {
 } from "../../utils/validation.js";
 import {
   ERROR_CODES,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import { BadRequestError } from "../../utils/error.js";
 import type { EnterPasswordServiceInterface } from "../enter-password/types.js";

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -108,6 +108,7 @@ export function resetPasswordPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
@@ -117,7 +118,6 @@ export function resetPasswordPost(
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         },
-        res.locals.sessionId
       )
     );
   };
@@ -130,9 +130,8 @@ export async function resetPasswordRequestGet(
   return res.redirect(
     await getNextPathAndUpdateJourney(
       req,
+      res,
       USER_JOURNEY_EVENTS.PASSWORD_RESET_REQUESTED,
-      null,
-      res.locals.sessionId
     )
   );
 }

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import { generateMfaSecret } from "../../utils/mfa.js";
 import { MFA_METHOD_TYPE } from "../../app.constants.js";

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -33,7 +33,6 @@ export async function getSecurityCodesPost(
   res.redirect(
     await getNextPathAndUpdateJourney(
       req,
-      req.path,
       isAuthApp
         ? USER_JOURNEY_EVENTS.MFA_OPTION_AUTH_APP_SELECTED
         : USER_JOURNEY_EVENTS.MFA_OPTION_SMS_SELECTED,

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -33,11 +33,10 @@ export async function getSecurityCodesPost(
   res.redirect(
     await getNextPathAndUpdateJourney(
       req,
+      res,
       isAuthApp
         ? USER_JOURNEY_EVENTS.MFA_OPTION_AUTH_APP_SELECTED
         : USER_JOURNEY_EVENTS.MFA_OPTION_SMS_SELECTED,
-      null,
-      res.locals.sessionId
     )
   );
 }

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -36,7 +36,7 @@ export async function getSecurityCodesPost(
       res,
       isAuthApp
         ? USER_JOURNEY_EVENTS.MFA_OPTION_AUTH_APP_SELECTED
-        : USER_JOURNEY_EVENTS.MFA_OPTION_SMS_SELECTED,
+        : USER_JOURNEY_EVENTS.MFA_OPTION_SMS_SELECTED
     )
   );
 }

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -131,12 +131,12 @@ export function setupAuthenticatorAppPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
+        res,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
           isAccountRecoveryJourney: accountRecoveryEnabledJourney,
         },
-        sessionId
       )
     );
   };

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -131,7 +131,6 @@ export function setupAuthenticatorAppPost(
     return res.redirect(
       await getNextPathAndUpdateJourney(
         req,
-        req.path,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -3,8 +3,8 @@ import QRCode from "qrcode";
 import type { ExpressRouteFunc } from "../../types.js";
 import {
   ERROR_CODES,
-  getNextPathAndUpdateJourney,
 } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import {
   generateQRCodeValue,

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -1,9 +1,7 @@
 import type { Request, Response } from "express";
 import QRCode from "qrcode";
 import type { ExpressRouteFunc } from "../../types.js";
-import {
-  ERROR_CODES,
-} from "../common/constants.js";
+import { ERROR_CODES } from "../common/constants.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import {
@@ -136,7 +134,7 @@ export function setupAuthenticatorAppPost(
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
           isAccountRecoveryJourney: accountRecoveryEnabledJourney,
-        },
+        }
       )
     );
   };

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 export async function signInOrCreateGet(
   req: Request,

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -29,11 +29,10 @@ export async function signInOrCreatePost(
   res.redirect(
     await getNextPathAndUpdateJourney(
       req,
+      res,
       req.body.optionSelected === "create"
         ? USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT
         : USER_JOURNEY_EVENTS.SIGN_IN,
-      null,
-      res.locals.sessionId
     )
   );
 }

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -29,7 +29,6 @@ export async function signInOrCreatePost(
   res.redirect(
     await getNextPathAndUpdateJourney(
       req,
-      req.path,
       req.body.optionSelected === "create"
         ? USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT
         : USER_JOURNEY_EVENTS.SIGN_IN,

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -32,7 +32,7 @@ export async function signInOrCreatePost(
       res,
       req.body.optionSelected === "create"
         ? USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT
-        : USER_JOURNEY_EVENTS.SIGN_IN,
+        : USER_JOURNEY_EVENTS.SIGN_IN
     )
   );
 }

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -54,7 +54,6 @@ export function updatedTermsConditionsPost(
       res.redirect(
         await getNextPathAndUpdateJourney(
           req,
-          req.path,
           USER_JOURNEY_EVENTS.TERMS_AND_CONDITIONS_ACCEPTED,
           {
             isIdentityRequired: req.session.user.isIdentityRequired,

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -6,7 +6,7 @@ import type { UpdateProfileServiceInterface } from "../common/update-profile/typ
 import { UpdateType } from "../common/update-profile/types.js";
 import { updateProfileService } from "../common/update-profile/update-profile-service.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
-import { getNextPathAndUpdateJourney } from "../common/constants.js";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 export function updatedTermsConditionsGet(req: Request, res: Response): void {
   res.render("updated-terms-conditions/index.njk");
 }

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -54,11 +54,11 @@ export function updatedTermsConditionsPost(
       res.redirect(
         await getNextPathAndUpdateJourney(
           req,
+          res,
           USER_JOURNEY_EVENTS.TERMS_AND_CONDITIONS_ACCEPTED,
           {
             isIdentityRequired: req.session.user.isIdentityRequired,
           },
-          sessionId
         )
       );
     }

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -58,7 +58,7 @@ export function updatedTermsConditionsPost(
           USER_JOURNEY_EVENTS.TERMS_AND_CONDITIONS_ACCEPTED,
           {
             isIdentityRequired: req.session.user.isIdentityRequired,
-          },
+          }
         )
       );
     }

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -34,7 +34,6 @@ export function accountInterventionsMiddleware(
         return res.redirect(
           await getNextPathAndUpdateJourney(
             req,
-            req.path,
             USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION
           )
         );
@@ -51,7 +50,6 @@ export function accountInterventionsMiddleware(
           return res.redirect(
             await getNextPathAndUpdateJourney(
               req,
-              req.path,
               USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION
             )
           );
@@ -67,7 +65,6 @@ export function accountInterventionsMiddleware(
         return res.redirect(
           await getNextPathAndUpdateJourney(
             req,
-            req.path,
             USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
           )
         );

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import { getNextPathAndUpdateJourney } from "src/components/common/state-machine/state-machine-executor.js";
+import { getNextPathAndUpdateJourney } from "../components/common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../components/common/state-machine/state-machine.js";
 import { accountInterventionService } from "../components/account-intervention/account-intervention-service.js";
 import type { ExpressRouteFunc } from "../types.js";

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -1,5 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
-import { getNextPathAndUpdateJourney } from "../components/common/constants.js";
+import { getNextPathAndUpdateJourney } from "src/components/common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../components/common/state-machine/state-machine.js";
 import { accountInterventionService } from "../components/account-intervention/account-intervention-service.js";
 import type { ExpressRouteFunc } from "../types.js";

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -34,6 +34,7 @@ export function accountInterventionsMiddleware(
         return res.redirect(
           await getNextPathAndUpdateJourney(
             req,
+            res,
             USER_JOURNEY_EVENTS.PERMANENTLY_BLOCKED_INTERVENTION
           )
         );
@@ -50,6 +51,7 @@ export function accountInterventionsMiddleware(
           return res.redirect(
             await getNextPathAndUpdateJourney(
               req,
+              res,
               USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION
             )
           );
@@ -65,6 +67,7 @@ export function accountInterventionsMiddleware(
         return res.redirect(
           await getNextPathAndUpdateJourney(
             req,
+            res,
             USER_JOURNEY_EVENTS.TEMPORARILY_BLOCKED_INTERVENTION
           )
         );


### PR DESCRIPTION
## What

- Removed `path` argument - using `req.path` simplifies logic and avoids 'hidden' transitions
- Added `res` argument - mirrors `req`, and provides access to locals
- Removed `sessionId` argument - can read from locals
- Extracted state machine executor from misleadingly named `constants.ts`

Largely these are innocuous changes. There is one case where we were passing a path that didn't match the request (see comment).

The aim of these changes is to give us more flexibility in the state machine execution without needing to update all the call-sites. A couple of examples:
- Automatically generating the `ctx` argument based on the session/locals, rather than needing to know what context to pass in to each step
- Executing additional actions when passing through states (e.g. sending an MFA code)

## How to review

1. Code Review
1. Ensure integration tests all still pass
