### PR TITLE
AUT-4686: Common journey states

### DIFF
--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -161,11 +161,9 @@ form textarea.hidden {
 }
 #diagramSvg .highlight.incomingEdge {
   stroke-width: 3px;
-  filter: drop-shadow(1px 0 0 cyan) drop-shadow(-1px 0 0 cyan)
-    drop-shadow(0 1px 0 cyan) drop-shadow(0 -1px 0 cyan);
+  filter: drop-shadow(1px 0 0 #66ddff) drop-shadow(-1px 0 0 #66ddff)
+    drop-shadow(0 1px 0 #66ddff) drop-shadow(0 -1px 0 #66ddff);
 }
-#diagramSvg .highlight.node .label-container {
+#diagramSvg .highlight.node path {
   stroke-width: 3px;
-  filter: drop-shadow(1px 0 0 #ffdd00) drop-shadow(-1px 0 0 #ffdd00)
-    drop-shadow(0 1px 0 #ffdd00) drop-shadow(0 -1px 0 #ffdd00);
 }

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -136,6 +136,13 @@ const setupStateClickHandlers = (): void => {
       })
       .forEach((node) => node.classList.add("highlight"));
 
+    Array.from(document.querySelectorAll(`[data-source="${id}"]`)).forEach(
+      (label) => label.classList.add("highlight", "outgoingEdge")
+    );
+    Array.from(document.querySelectorAll(`[data-target="${id}"]`)).forEach(
+      (label) => label.classList.add("highlight", "incomingEdge")
+    );
+
     currentHighlight = id;
     timeClicked = Date.now();
   };

--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -42,7 +42,8 @@ const renderTransition = ({
   condition,
   optional,
 }: Transition): string => {
-  const label = event ? `|${event}<br/>${condition ?? ""}|` : "";
+  const label =
+    event || condition ? `|${event ?? ""}<br/>${condition ?? ""}|` : "";
   const arrow = optional ? "-.->" : "-->";
   return `    ${source}${arrow}${label}${target}`;
 };

--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -42,8 +42,11 @@ const renderTransition = ({
   condition,
   optional,
 }: Transition): string => {
+  const lineBreak = event && condition ? "<br/>" : "";
   const label =
-    event || condition ? `|${event ?? ""}<br/>${condition ?? ""}|` : "";
+    event || condition
+      ? `|<span data-source="${source}" data-target="${target}">${event ?? ""}${lineBreak}${condition ?? ""}</span>|`
+      : "";
   const arrow = optional ? "-.->" : "-->";
   return `    ${source}${arrow}${label}${target}`;
 };


### PR DESCRIPTION
## What

- Added common state for 'sign-in end', abstracting away the need to distinguish T&Cs accepted in each final auth step
- Added common state for 'password verified', ensuring both variants map the same paths
- Some styling tweaks to highlighted states and labels

<img width="5034" height="1246" alt="image" src="https://github.com/user-attachments/assets/403312c5-11c4-452c-8b47-8cdbb030ff08" />

Although this adds more states to the map, it reduces the total number of elements as it eliminates a bunch of parallel state transitions.

A more sophisticated approach here could instead use a 'sub-journey', completely abstracting the common states.

## How to review

1. Code Review
1. Marvel at journey map locally
1. Ensure integration tests pass
