### PR TITLE
BAU: Increase minimum number of ECS tasks in staging from 9 to 12

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -466,7 +466,7 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
       frontendApiBaseUrl: https://auth.staging.account.gov.uk/
-      frontendAutoScalingMinCount: 9
+      frontendAutoScalingMinCount: 12
       frontendAutoScalingMaxCount: 240
       frontendTaskDefinitionCpu: 1024
       frontendTaskDefinitionMemory: 2048


### PR DESCRIPTION
## What

Increase minimum number of ECS tasks in staging from 9 to 12

During the last performance test the event loop was satured during ramp up, so adding more initial capacity to deal with the required load for the next test.

## How to review

1. Code Review

