### PR TITLE
BAU: State machine auto context

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -138,7 +138,6 @@ export function authorizeGet(
       nextStateEvent,
       {
         requiresUplift: isUpliftRequired(req),
-        isIdentityRequired: req.session.user.isIdentityRequired,
         prompt: req.session.client.prompt,
         mfaMethodType: startAuthResponse.data.user.mfaMethodType,
         isReauthenticationRequired: isReauth(req),

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -57,7 +57,7 @@ const getNextStateEvent = (req: Request): string => {
       return USER_JOURNEY_EVENTS.UPLIFT;
     }
     if (req.session.client?.prompt === OIDC_PROMPT.LOGIN) {
-      return USER_JOURNEY_EVENTS.LOGIN;
+      return USER_JOURNEY_EVENTS.PROMPT_LOGIN;
     }
     return USER_JOURNEY_EVENTS.SILENT_LOGIN;
   }
@@ -155,7 +155,7 @@ export function authorizeGet(
     let redirectPath = await getNextPathAndUpdateJourney(
       req,
       res,
-      nextStateEvent,
+      nextStateEvent
     );
 
     const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -156,9 +156,6 @@ export function authorizeGet(
       req,
       res,
       nextStateEvent,
-      {
-        mfaMethodType: startAuthResponse.data.user.mfaMethodType,
-      }
     );
 
     const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);
@@ -251,6 +248,7 @@ function setSessionDataFromAuthResponse(
   req.session.user.isAuthenticated = startAuthResponse.data.user.authenticated;
   req.session.user.isUpliftRequired =
     startAuthResponse.data.user.upliftRequired;
+  req.session.user.mfaMethodType = startAuthResponse.data.user.mfaMethodType;
   if (startAuthResponse.data.featureFlags) {
     req.session.user.featureFlags = startAuthResponse.data.featureFlags;
   }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -137,7 +137,6 @@ export function authorizeGet(
       res,
       nextStateEvent,
       {
-        prompt: req.session.client.prompt,
         mfaMethodType: startAuthResponse.data.user.mfaMethodType,
         isReauthenticationRequired: isReauth(req),
       }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -36,7 +36,7 @@ import {
 } from "../../config.js";
 import { logger } from "../../utils/logger.js";
 import type { Claims } from "./claims-config.js";
-import { isReauth, isUpliftRequired } from "../../utils/request.js";
+import { isReauth } from "../../utils/request.js";
 import { LocalDecryptionService } from "./local-decryption-service.js";
 
 const decryptionService =
@@ -137,7 +137,6 @@ export function authorizeGet(
       res,
       nextStateEvent,
       {
-        requiresUplift: isUpliftRequired(req),
         prompt: req.session.client.prompt,
         mfaMethodType: startAuthResponse.data.user.mfaMethodType,
         isReauthenticationRequired: isReauth(req),

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -92,12 +92,9 @@ export const checkYourPhonePost = (
       throw new BadRequestError(result.data.message, result.data.code);
     }
 
-    const accountRecoveryEnabledJourney =
-      isAccountRecoveryJourneyAndPermitted(req);
-
     let notificationType = NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION;
 
-    if (accountRecoveryEnabledJourney) {
+    if (isAccountRecoveryJourneyAndPermitted(req)) {
       req.session.user.accountRecoveryVerifiedMfaType = MFA_METHOD_TYPE.SMS;
       notificationType =
         NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION;
@@ -119,9 +116,6 @@ export const checkYourPhonePost = (
         req,
         res,
         USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
-        {
-          isAccountRecoveryJourney: accountRecoveryEnabledJourney,
-        }
       )
     );
   };

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -115,7 +115,7 @@ export const checkYourPhonePost = (
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
+        USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED
       )
     );
   };

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -120,7 +120,6 @@ export const checkYourPhonePost = (
         res,
         USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
         {
-          isIdentityRequired: req.session.user.isIdentityRequired,
           isAccountRecoveryJourney: accountRecoveryEnabledJourney,
         }
       )

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -95,7 +95,7 @@ export function sendMfaGeneric(
       redirectPath = await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.VERIFY_MFA,
+        USER_JOURNEY_EVENTS.VERIFY_MFA
       );
     }
 

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -97,8 +97,6 @@ export function sendMfaGeneric(
         res,
         USER_JOURNEY_EVENTS.VERIFY_MFA,
         {
-          isLatestTermsAndConditionsAccepted:
-            req.session.user.isLatestTermsAndConditionsAccepted,
           isIdentityRequired: req.session.user.isIdentityRequired,
         }
       );

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -96,9 +96,6 @@ export function sendMfaGeneric(
         req,
         res,
         USER_JOURNEY_EVENTS.VERIFY_MFA,
-        {
-          isIdentityRequired: req.session.user.isIdentityRequired,
-        }
       );
     }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -5,6 +5,7 @@ import {
   type AuthStateContext,
 } from "./state-machine.js";
 import { saveSessionState } from "../constants.js";
+import { isAccountRecoveryJourneyAndPermitted } from "../../../utils/request.js";
 
 export async function getNextPathAndUpdateJourney(
   req: Request,
@@ -16,8 +17,12 @@ export async function getNextPathAndUpdateJourney(
   const currentState = req.path;
 
   const context = {
+    isAccountRecoveryJourney: isAccountRecoveryJourneyAndPermitted(req),
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
+    isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
+    isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
+    isOnForcedPasswordResetJourney: !!req.session.user?.withinForcedPasswordResetJourney,
     ...ctx,
   }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -9,7 +9,7 @@ import { saveSessionState } from "../constants.js";
 export async function getNextPathAndUpdateJourney(
   req: Request,
   res: Response,
-  event: string,
+  event: string
 ): Promise<string> {
   const sessionId = res.locals.sessionId;
   const currentState = req.path;
@@ -18,13 +18,15 @@ export async function getNextPathAndUpdateJourney(
     isAccountPartCreated: !!req.session.user?.isAccountPartCreated,
     isAccountRecoveryJourney: !!req.session.user?.isAccountRecoveryJourney,
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
-    isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
+    isLatestTermsAndConditionsAccepted:
+      !!req.session.user?.isLatestTermsAndConditionsAccepted,
     isMfaRequired: !!req.session.user?.isMfaRequired,
-    isOnForcedPasswordResetJourney: !!req.session.user?.withinForcedPasswordResetJourney,
+    isOnForcedPasswordResetJourney:
+      !!req.session.user?.withinForcedPasswordResetJourney,
     isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
     isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
     mfaMethodType: req.session.user?.mfaMethodType,
-  }
+  };
 
   const nextState = getNextState(currentState, event, context);
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -26,7 +26,9 @@ export async function getNextPathAndUpdateJourney(
       !!req.session.user?.withinForcedPasswordResetJourney,
     isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
     isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
-    mfaMethodType: req.session.user?.mfaMethodType,
+    // TODO: Consolidate to just mfaMethodType in follow-up PR
+    mfaMethodType:
+      req.session.user?.mfaMethodType ?? req.session.user?.enterEmailMfaType,
   };
 
   const nextState = getNextState(currentState, event, context);

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -23,6 +23,7 @@ export async function getNextPathAndUpdateJourney(
     isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
     isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
     isOnForcedPasswordResetJourney: !!req.session.user?.withinForcedPasswordResetJourney,
+    mfaMethodType: req.session.user?.mfaMethodType,
     ...ctx,
   }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -5,27 +5,25 @@ import {
   type AuthStateContext,
 } from "./state-machine.js";
 import { saveSessionState } from "../constants.js";
-import { isAccountRecoveryJourneyAndPermitted } from "../../../utils/request.js";
 
 export async function getNextPathAndUpdateJourney(
   req: Request,
   res: Response,
   event: string,
-  ctx?: AuthStateContext
 ): Promise<string> {
   const sessionId = res.locals.sessionId;
   const currentState = req.path;
 
-  const context = {
-    isAccountRecoveryJourney: isAccountRecoveryJourneyAndPermitted(req),
+  const context: AuthStateContext = {
+    isAccountPartCreated: !!req.session.user?.isAccountPartCreated,
+    isAccountRecoveryJourney: !!req.session.user?.isAccountRecoveryJourney,
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
     isMfaRequired: !!req.session.user?.isMfaRequired,
+    isOnForcedPasswordResetJourney: !!req.session.user?.withinForcedPasswordResetJourney,
     isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
     isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
-    isOnForcedPasswordResetJourney: !!req.session.user?.withinForcedPasswordResetJourney,
     mfaMethodType: req.session.user?.mfaMethodType,
-    ...ctx,
   }
 
   const nextState = getNextState(currentState, event, context);

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -20,6 +20,7 @@ export async function getNextPathAndUpdateJourney(
     isAccountRecoveryJourney: isAccountRecoveryJourneyAndPermitted(req),
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
+    isMfaRequired: !!req.session.user?.isMfaRequired,
     isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
     isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
     isOnForcedPasswordResetJourney: !!req.session.user?.withinForcedPasswordResetJourney,

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -19,6 +19,7 @@ export async function getNextPathAndUpdateJourney(
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
     isUpliftRequired: !!req.session.user?.isUpliftRequired,
+    prompt: req.session.client?.prompt,
     ...ctx,
   }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -16,7 +16,8 @@ export async function getNextPathAndUpdateJourney(
   const currentState = req.path;
 
   const context = {
-    isLatestTermsAndConditionsAccepted: req.session.user?.isLatestTermsAndConditionsAccepted,
+    isIdentityRequired: !!req.session.user?.isIdentityRequired,
+    isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
     ...ctx,
   }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -20,7 +20,7 @@ export async function getNextPathAndUpdateJourney(
     isAccountRecoveryJourney: !!req.session.user?.isAccountRecoveryJourney,
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted:
-      !!req.session.user?.isLatestTermsAndConditionsAccepted,
+      req.session.user?.isLatestTermsAndConditionsAccepted ?? true,
     isMfaRequired: !!req.session.user?.isMfaRequired,
     isOnForcedPasswordResetJourney:
       !!req.session.user?.withinForcedPasswordResetJourney,

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -18,6 +18,7 @@ export async function getNextPathAndUpdateJourney(
   const context = {
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
+    isUpliftRequired: !!req.session.user?.isUpliftRequired,
     ...ctx,
   }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -18,8 +18,6 @@ export async function getNextPathAndUpdateJourney(
   const context = {
     isIdentityRequired: !!req.session.user?.isIdentityRequired,
     isLatestTermsAndConditionsAccepted: !!req.session.user?.isLatestTermsAndConditionsAccepted,
-    isUpliftRequired: !!req.session.user?.isUpliftRequired,
-    prompt: req.session.client?.prompt,
     ...ctx,
   }
 

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -13,6 +13,7 @@ export async function getNextPathAndUpdateJourney(
 ): Promise<string> {
   const sessionId = res.locals.sessionId;
   const currentState = req.path;
+  const sessionState = req.session.user?.journey?.nextPath;
 
   const context: AuthStateContext = {
     isAccountPartCreated: !!req.session.user?.isAccountPartCreated,
@@ -42,7 +43,16 @@ export async function getNextPathAndUpdateJourney(
   await saveSessionState(req);
 
   req.log.info(
-    `User journey transitioned from ${currentState} to ${nextState.value} with session id ${sessionId}`
+    {
+      transition: {
+        from: currentState,
+        to: nextState.value,
+        event: event,
+        sessionState,
+      },
+      sessionId,
+    },
+    `User journey transition`
   );
 
   // If an invalid/unexpected event is supplied Stately will return the same state, likely indicating a bug

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -15,7 +15,12 @@ export async function getNextPathAndUpdateJourney(
   const sessionId = res.locals.sessionId;
   const currentState = req.path;
 
-  const nextState = getNextState(currentState, event, ctx);
+  const context = {
+    isLatestTermsAndConditionsAccepted: req.session.user?.isLatestTermsAndConditionsAccepted,
+    ...ctx,
+  }
+
+  const nextState = getNextState(currentState, event, context);
 
   req.session.user.journey = {
     nextPath: nextState.value,

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -68,25 +68,22 @@ const USER_JOURNEY_EVENTS = {
   SELECT_AUTH_APP_MFA_METHOD: "SELECT_AUTH_APP_MFA_METHOD",
 };
 
-const defaultContext = {
-  isLatestTermsAndConditionsAccepted: true,
-  isMfaRequired: false,
-  isIdentityRequired: false,
-  mfaMethodType: MFA_METHOD_TYPE.SMS,
-  isMfaMethodVerified: true,
-  isPasswordChangeRequired: false,
-  isAccountRecoveryJourney: false,
-  isPasswordResetJourney: false,
-  isOnForcedPasswordResetJourney: false,
-};
-
-export type AuthStateContext = Partial<typeof defaultContext>;
+export interface AuthStateContext {
+  isAccountPartCreated: boolean;
+  isAccountRecoveryJourney: boolean;
+  isIdentityRequired: boolean;
+  isLatestTermsAndConditionsAccepted: boolean;
+  isMfaRequired: boolean;
+  isOnForcedPasswordResetJourney: boolean;
+  isPasswordChangeRequired: boolean;
+  isPasswordResetJourney: boolean;
+  mfaMethodType: MFA_METHOD_TYPE | undefined;
+}
 
 const authStateMachine = createMachine<AuthStateContext>(
   {
     id: "AUTH",
     initial: PATH_NAMES.AUTHORIZE,
-    context: defaultContext,
     states: {
       [PATH_NAMES.AUTHORIZE]: {
         on: {
@@ -657,7 +654,7 @@ const authStateMachine = createMachine<AuthStateContext>(
         context.isLatestTermsAndConditionsAccepted === false,
       isMfaRequired: (context) =>
         context.isMfaRequired === true,
-      isAccountPartCreated: (context) => context.isMfaMethodVerified === false,
+      isAccountPartCreated: (context) => context.isAccountPartCreated === true,
       isIdentityRequired: (context) => context.isIdentityRequired === true,
       hasAuthAppMfa: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -68,7 +68,7 @@ const USER_JOURNEY_EVENTS = {
 
 const defaultContext = {
   isLatestTermsAndConditionsAccepted: true,
-  requiresUplift: false,
+  isUpliftRequired: false,
   requiresTwoFactorAuth: false,
   isIdentityRequired: false,
   prompt: OIDC_PROMPT.NONE,
@@ -675,11 +675,11 @@ const authStateMachine = createMachine<AuthStateContext>(
     guards: {
       needsLatestTermsAndConditions: (context) =>
         context.isLatestTermsAndConditionsAccepted === false,
-      requiresUplift: (context) => context.requiresUplift === true,
+      requiresUplift: (context) => context.isUpliftRequired === true,
       isReauthenticationRequired: (context) =>
         !!context.isReauthenticationRequired,
       requiresAuthAppUplift: (context) =>
-        context.requiresUplift === true &&
+        context.isUpliftRequired === true &&
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,
       requiresTwoFactorAuth: (context) =>
         context.requiresTwoFactorAuth === true,

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -69,7 +69,7 @@ const USER_JOURNEY_EVENTS = {
 const defaultContext = {
   isLatestTermsAndConditionsAccepted: true,
   isUpliftRequired: false,
-  requiresTwoFactorAuth: false,
+  isMfaRequired: false,
   isIdentityRequired: false,
   prompt: OIDC_PROMPT.NONE,
   mfaMethodType: MFA_METHOD_TYPE.SMS,
@@ -343,7 +343,7 @@ const authStateMachine = createMachine<AuthStateContext>(
             target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
             cond: "requiresMFAAuthAppCode",
           },
-          { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
+          { target: [PATH_NAMES.ENTER_MFA], cond: "isMfaRequired" },
           { target: [INTERMEDIATE_STATES.SIGN_IN_END] },
         ],
       },
@@ -498,7 +498,6 @@ const authStateMachine = createMachine<AuthStateContext>(
               target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
               cond: "requiresMFAAuthAppCode",
             },
-            { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             { target: [INTERMEDIATE_STATES.SIGN_IN_END] },
           ],
         },
@@ -521,7 +520,6 @@ const authStateMachine = createMachine<AuthStateContext>(
               target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
               cond: "requiresMFAAuthAppCode",
             },
-            { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             { target: [INTERMEDIATE_STATES.SIGN_IN_END] },
           ],
         },
@@ -681,14 +679,14 @@ const authStateMachine = createMachine<AuthStateContext>(
       requiresAuthAppUplift: (context) =>
         context.isUpliftRequired === true &&
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,
-      requiresTwoFactorAuth: (context) =>
-        context.requiresTwoFactorAuth === true,
+      isMfaRequired: (context) =>
+        context.isMfaRequired === true,
       isAccountPartCreated: (context) => context.isMfaMethodVerified === false,
       isIdentityRequired: (context) => context.isIdentityRequired === true,
       requiresLogin: (context) => context.prompt === OIDC_PROMPT.LOGIN,
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
-        context.requiresTwoFactorAuth === true,
+        context.isMfaRequired === true,
       requiresResetPasswordMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.isOnForcedPasswordResetJourney !== true,
@@ -699,11 +697,11 @@ const authStateMachine = createMachine<AuthStateContext>(
       is2FASMSPasswordChangeRequired: (context) =>
         context.isPasswordChangeRequired === true &&
         context.mfaMethodType === MFA_METHOD_TYPE.SMS &&
-        context.requiresTwoFactorAuth === true,
+        context.isMfaRequired === true,
       is2FAAuthAppPasswordChangeRequired: (context) =>
         context.isPasswordChangeRequired === true &&
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
-        context.requiresTwoFactorAuth === true,
+        context.isMfaRequired === true,
       isAccountRecoveryJourney: (context) => !!context.isAccountRecoveryJourney,
       isPasswordResetJourney: (context) => !!context.isPasswordResetJourney,
     },

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -395,9 +395,6 @@ const authStateMachine = createMachine<AuthStateContext>(
       },
       [PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL]: {
         on: {
-          [USER_JOURNEY_EVENTS.PASSWORD_RESET_INTERVENTION]: [
-            PATH_NAMES.PASSWORD_RESET_REQUIRED,
-          ],
           [USER_JOURNEY_EVENTS.RESET_PASSWORD_CODE_VERIFIED]: [
             {
               target: [PATH_NAMES.RESET_PASSWORD_2FA_SMS],

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -1,74 +1,69 @@
 import { expect } from "chai";
 import { describe } from "mocha";
 import { getNextState, USER_JOURNEY_EVENTS } from "../state-machine.js";
-import {
-  MFA_METHOD_TYPE,
-  OIDC_PROMPT,
-  PATH_NAMES,
-} from "../../../../app.constants.js";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../../app.constants.js";
+
+const DEFAULT_CONTEXT = {
+  isAccountPartCreated: false,
+  isAccountRecoveryJourney: false,
+  isIdentityRequired: false,
+  isLatestTermsAndConditionsAccepted: true,
+  isMfaRequired: true,
+  isOnForcedPasswordResetJourney: false,
+  isPasswordChangeRequired: false,
+  isPasswordResetJourney: false,
+  mfaMethodType: MFA_METHOD_TYPE.SMS,
+};
 
 describe("state-machine", () => {
-  describe(`getNextState - ${PATH_NAMES.AUTHORIZE} on ${USER_JOURNEY_EVENTS.EXISTING_SESSION}`, () => {
+  describe(`getNextState - ${PATH_NAMES.AUTHORIZE}`, () => {
     it(`should move from ${PATH_NAMES.AUTHORIZE} to ${PATH_NAMES.AUTH_CODE}`, () => {
       const nextState = getNextState(
         PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.EXISTING_SESSION,
-        {}
+        USER_JOURNEY_EVENTS.SILENT_LOGIN,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
     });
     it(`should move from ${PATH_NAMES.AUTHORIZE} to ${PATH_NAMES.ENTER_PASSWORD} for prompt login`, () => {
       const nextState = getNextState(
         PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.EXISTING_SESSION,
-        {
-          prompt: OIDC_PROMPT.LOGIN,
-        }
+        USER_JOURNEY_EVENTS.PROMPT_LOGIN,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
     });
     it(`should move from ${PATH_NAMES.AUTHORIZE} to ${PATH_NAMES.UPLIFT_JOURNEY} for uplift`, () => {
       const nextState = getNextState(
         PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.EXISTING_SESSION,
-        {
-          requiresUplift: true,
-        }
+        USER_JOURNEY_EVENTS.UPLIFT,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.UPLIFT_JOURNEY);
     });
     it(`should move from ${PATH_NAMES.AUTHORIZE} to ${PATH_NAMES.ENTER_EMAIL_SIGN_IN} for reauth`, () => {
       const nextState = getNextState(
         PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.EXISTING_SESSION,
-        {
-          isReauthenticationRequired: true,
-        }
+        USER_JOURNEY_EVENTS.REAUTH,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
     });
-  });
-
-  describe(`getNextState - ${PATH_NAMES.AUTHORIZE} on ${USER_JOURNEY_EVENTS.NO_EXISTING_SESSION}`, () => {
-    describe("where isIdentityRequired", () => {
-      it(`should move from ${PATH_NAMES.AUTHORIZE} to ${PATH_NAMES.SIGN_IN_OR_CREATE}`, () => {
-        const nextState = getNextState(
-          PATH_NAMES.AUTHORIZE,
-          USER_JOURNEY_EVENTS.NO_EXISTING_SESSION,
-          {
-            isIdentityRequired: true,
-          }
-        );
-
-        expect(nextState.value).to.equal(PATH_NAMES.SIGN_IN_OR_CREATE);
-      });
+    it(`should move from ${PATH_NAMES.AUTHORIZE} to ${PATH_NAMES.SIGN_IN_OR_CREATE}`, () => {
+      const nextState = getNextState(
+        PATH_NAMES.AUTHORIZE,
+        USER_JOURNEY_EVENTS.NO_EXISTING_SESSION,
+        DEFAULT_CONTEXT
+      );
+      expect(nextState.value).to.equal(PATH_NAMES.SIGN_IN_OR_CREATE);
     });
   });
   describe("getNextState - login journey (2fa)", () => {
     it("should move from sign or create to enter email when user event is sign in", () => {
       const nextState = getNextState(
         PATH_NAMES.SIGN_IN_OR_CREATE,
-        USER_JOURNEY_EVENTS.SIGN_IN
+        USER_JOURNEY_EVENTS.SIGN_IN,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
     });
@@ -76,7 +71,8 @@ describe("state-machine", () => {
     it("should move from enter email to enter password when user event is validate credentials", () => {
       const nextState = getNextState(
         PATH_NAMES.ENTER_EMAIL_SIGN_IN,
-        USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS
+        USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
     });
@@ -85,7 +81,7 @@ describe("state-machine", () => {
       const nextState = getNextState(
         PATH_NAMES.ENTER_PASSWORD,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
-        { requiresTwoFactorAuth: true }
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_MFA);
     });
@@ -93,7 +89,8 @@ describe("state-machine", () => {
     it("should move from mfa code verified state to auth code when user event is mfa code verified", () => {
       const nextState = getNextState(
         PATH_NAMES.ENTER_MFA,
-        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED
+        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
     });
@@ -103,7 +100,8 @@ describe("state-machine", () => {
     it("should move from sign or create to enter email when user event is sign in", () => {
       const nextState = getNextState(
         PATH_NAMES.SIGN_IN_OR_CREATE,
-        USER_JOURNEY_EVENTS.SIGN_IN
+        USER_JOURNEY_EVENTS.SIGN_IN,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
     });
@@ -111,7 +109,8 @@ describe("state-machine", () => {
     it("should move from enter email to enter password when user event is validate credentials", () => {
       const nextState = getNextState(
         PATH_NAMES.ENTER_EMAIL_SIGN_IN,
-        USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS
+        USER_JOURNEY_EVENTS.VALIDATE_CREDENTIALS,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
     });
@@ -120,7 +119,7 @@ describe("state-machine", () => {
       const nextState = getNextState(
         PATH_NAMES.ENTER_PASSWORD,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
-        { requiresTwoFactorAuth: false }
+        { ...DEFAULT_CONTEXT, isMfaRequired: false }
       );
       expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
     });
@@ -129,7 +128,8 @@ describe("state-machine", () => {
     it("should move from sign or create to enter email when user event is create account", () => {
       const nextState = getNextState(
         PATH_NAMES.SIGN_IN_OR_CREATE,
-        USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT
+        USER_JOURNEY_EVENTS.CREATE_NEW_ACCOUNT,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT);
     });
@@ -137,7 +137,8 @@ describe("state-machine", () => {
     it("should move from enter email to check your email when email verification code sent event", () => {
       const nextState = getNextState(
         PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT,
-        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE
+        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.CHECK_YOUR_EMAIL);
     });
@@ -145,7 +146,8 @@ describe("state-machine", () => {
     it("should move from check your email to create password when email verified code event", () => {
       const nextState = getNextState(
         PATH_NAMES.CHECK_YOUR_EMAIL,
-        USER_JOURNEY_EVENTS.EMAIL_CODE_VERIFIED
+        USER_JOURNEY_EVENTS.EMAIL_CODE_VERIFIED,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD);
     });
@@ -153,7 +155,8 @@ describe("state-machine", () => {
     it("should move from create password to get security codes when password created event", () => {
       const nextState = getNextState(
         PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD,
-        USER_JOURNEY_EVENTS.PASSWORD_CREATED
+        USER_JOURNEY_EVENTS.PASSWORD_CREATED,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.GET_SECURITY_CODES);
     });
@@ -161,7 +164,8 @@ describe("state-machine", () => {
     it("should move from check your phone to account confirmation when phone number verified event", () => {
       const nextState = getNextState(
         PATH_NAMES.CHECK_YOUR_PHONE,
-        USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED
+        USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL);
     });
@@ -169,34 +173,8 @@ describe("state-machine", () => {
     it("should move from account created to auth code when user successfully has created an account", () => {
       const nextState = getNextState(
         PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL,
-        USER_JOURNEY_EVENTS.ACCOUNT_CREATED
-      );
-      expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
-    });
-
-    it("should move from authorize to sign or create when reauthentication is requested and the user is already logged in", () => {
-      const nextState = getNextState(
-        PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.EXISTING_SESSION,
-        { isReauthenticationRequired: true }
-      );
-      expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
-    });
-
-    it("should move from authorize to sign or create when reauthentication is requested and the user is not logged in", () => {
-      const nextState = getNextState(
-        PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.NO_EXISTING_SESSION,
-        { isReauthenticationRequired: true }
-      );
-      expect(nextState.value).to.equal(PATH_NAMES.ENTER_EMAIL_SIGN_IN);
-    });
-
-    it("should move from authorize to auth code create when the user is already logged in", () => {
-      const nextState = getNextState(
-        PATH_NAMES.AUTHORIZE,
-        USER_JOURNEY_EVENTS.EXISTING_SESSION,
-        {}
+        USER_JOURNEY_EVENTS.ACCOUNT_CREATED,
+        DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.AUTH_CODE);
     });
@@ -206,49 +184,33 @@ describe("state-machine", () => {
     [
       {
         context: {
-          requiresTwoFactorAuth: true,
-          isMfaMethodVerified: false,
+          isMfaRequired: true,
+          isAccountPartCreated: true,
           mfaMethodType: MFA_METHOD_TYPE.SMS,
         },
         destination: PATH_NAMES.GET_SECURITY_CODES,
       },
       {
         context: {
-          requiresTwoFactorAuth: true,
-          mfaMethodType: MFA_METHOD_TYPE.SMS,
-          isLatestTermsAndConditionsAccepted: false,
-        },
-        destination: PATH_NAMES.ENTER_MFA,
-      },
-      {
-        context: {
-          requiresTwoFactorAuth: true,
-          mfaMethodType: MFA_METHOD_TYPE.AUTH_APP,
-          isLatestTermsAndConditionsAccepted: false,
-        },
-        destination: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
-      },
-      {
-        context: {
-          requiresTwoFactorAuth: false,
+          isMfaRequired: false,
           isLatestTermsAndConditionsAccepted: false,
         },
         destination: PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS,
       },
       {
-        context: { requiresTwoFactorAuth: false, isMfaMethodVerified: false },
+        context: { isMfaRequired: false, isAccountPartCreated: true },
         destination: PATH_NAMES.GET_SECURITY_CODES,
       },
       {
         context: {
-          requiresTwoFactorAuth: false,
+          isMfaRequired: false,
           mfaMethodType: MFA_METHOD_TYPE.SMS,
         },
         destination: PATH_NAMES.AUTH_CODE,
       },
       {
         context: {
-          requiresTwoFactorAuth: false,
+          isMfaRequired: false,
           mfaMethodType: MFA_METHOD_TYPE.AUTH_APP,
         },
         destination: PATH_NAMES.AUTH_CODE,
@@ -258,7 +220,7 @@ describe("state-machine", () => {
         const nextState = getNextState(
           PATH_NAMES.RESET_PASSWORD,
           USER_JOURNEY_EVENTS.PASSWORD_CREATED,
-          test.context
+          { ...DEFAULT_CONTEXT, ...test.context }
         );
         expect(nextState.value).to.equal(test.destination);
       });

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -175,10 +175,6 @@ export function verifyCodePost(
     res.redirect(
       await getNextPathAndUpdateJourney(req, res, nextEvent, {
         mfaMethodType: req.session.user.enterEmailMfaType,
-        isPasswordChangeRequired: req.session.user.isPasswordChangeRequired,
-        isOnForcedPasswordResetJourney:
-          req.path === PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL &&
-          req.session.user.withinForcedPasswordResetJourney,
       })
     );
   };

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -173,9 +173,7 @@ export function verifyCodePost(
     }
 
     res.redirect(
-      await getNextPathAndUpdateJourney(req, res, nextEvent, {
-        mfaMethodType: req.session.user.enterEmailMfaType,
-      })
+      await getNextPathAndUpdateJourney(req, res, nextEvent)
     );
   };
 }

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -175,8 +175,6 @@ export function verifyCodePost(
     res.redirect(
       await getNextPathAndUpdateJourney(req, res, nextEvent, {
         isIdentityRequired: req.session.user.isIdentityRequired,
-        isLatestTermsAndConditionsAccepted:
-          req.session.user.isLatestTermsAndConditionsAccepted,
         mfaMethodType: req.session.user.enterEmailMfaType,
         isPasswordChangeRequired: req.session.user.isPasswordChangeRequired,
         isOnForcedPasswordResetJourney:

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -174,7 +174,6 @@ export function verifyCodePost(
 
     res.redirect(
       await getNextPathAndUpdateJourney(req, res, nextEvent, {
-        isIdentityRequired: req.session.user.isIdentityRequired,
         mfaMethodType: req.session.user.enterEmailMfaType,
         isPasswordChangeRequired: req.session.user.isPasswordChangeRequired,
         isOnForcedPasswordResetJourney:

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -9,11 +9,7 @@ import { BadRequestError } from "../../../utils/error.js";
 import type { VerifyCodeInterface } from "./types.js";
 import type { ExpressRouteFunc } from "../../../types.js";
 import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine.js";
-import {
-  JOURNEY_TYPE,
-  NOTIFICATION_TYPE,
-  PATH_NAMES,
-} from "../../../app.constants.js";
+import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../../app.constants.js";
 import { supportAccountInterventions } from "../../../config.js";
 import type { AccountInterventionsInterface } from "../../account-intervention/types.js";
 import { isSuspendedWithoutUserActions } from "../../../utils/interventions.js";
@@ -172,8 +168,6 @@ export function verifyCodePost(
       if (possibleEarlyReturn) return;
     }
 
-    res.redirect(
-      await getNextPathAndUpdateJourney(req, res, nextEvent)
-    );
+    res.redirect(await getNextPathAndUpdateJourney(req, res, nextEvent));
   };
 }

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -43,9 +43,6 @@ export function createPasswordPost(
         req,
         res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
-        {
-          requiresTwoFactorAuth: true,
-        }
       )
     );
   };

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -42,7 +42,7 @@ export function createPasswordPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.PASSWORD_CREATED,
+        USER_JOURNEY_EVENTS.PASSWORD_CREATED
       )
     );
   };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -118,8 +118,6 @@ export const enterAuthenticatorAppCodePost = (
         USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
-          isLatestTermsAndConditionsAccepted:
-            req.session.user.isLatestTermsAndConditionsAccepted,
         }
       )
     );

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -116,9 +116,6 @@ export const enterAuthenticatorAppCodePost = (
         req,
         res,
         USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
-        {
-          isIdentityRequired: req.session.user.isIdentityRequired,
-        }
       )
     );
   };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -115,7 +115,7 @@ export const enterAuthenticatorAppCodePost = (
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
+        USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED
       )
     );
   };

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -99,6 +99,8 @@ async function getExistingUserAndPopulateSessionData(
     setUpAuthAppLocks(req, result.data.lockoutInformation);
   }
 
+  // TODO: Delete this in follow-up PR
+  req.session.user.enterEmailMfaType = result.data.mfaMethodType;
   req.session.user.mfaMethodType = result.data.mfaMethodType;
   req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
     req.session.user.mfaMethods,

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -99,7 +99,7 @@ async function getExistingUserAndPopulateSessionData(
     setUpAuthAppLocks(req, result.data.lockoutInformation);
   }
 
-  req.session.user.enterEmailMfaType = result.data.mfaMethodType;
+  req.session.user.mfaMethodType = result.data.mfaMethodType;
   req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
     req.session.user.mfaMethods,
     { redactedPhoneNumber: result.data.phoneNumberLastThree }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -221,7 +221,7 @@ export function enterPasswordPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
+        USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED
       )
     );
   };

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -222,7 +222,8 @@ export function enterPasswordPost(
         res,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
         {
-          requiresTwoFactorAuth: userLogin.data.mfaRequired,
+          // TODO: Store this on session and move into state-machine-executor
+          isMfaRequired: userLogin.data.mfaRequired,
           mfaMethodType: userLogin.data.mfaMethodType,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
           isPasswordChangeRequired: isPasswordChangeRequired,

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -222,8 +222,6 @@ export function enterPasswordPost(
         res,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
         {
-          isLatestTermsAndConditionsAccepted:
-            req.session.user.isLatestTermsAndConditionsAccepted,
           requiresTwoFactorAuth: userLogin.data.mfaRequired,
           mfaMethodType: userLogin.data.mfaMethodType,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -224,7 +224,6 @@ export function enterPasswordPost(
         {
           // TODO: Store this on session and move into state-machine-executor
           isMfaRequired: userLogin.data.mfaRequired,
-          mfaMethodType: userLogin.data.mfaMethodType,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
         }
       )

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -168,6 +168,7 @@ export function enterPasswordPost(
     req.session.user.activeMfaMethodId = userLogin.data.mfaMethods.find(
       (method: MfaMethod) => method.priority === MfaMethodPriority.DEFAULT
     )?.id;
+    req.session.user.isMfaRequired = userLogin.data.mfaRequired;
     req.session.user.isAccountPartCreated = !userLogin.data.mfaMethodVerified;
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
@@ -222,8 +223,6 @@ export function enterPasswordPost(
         res,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
         {
-          // TODO: Store this on session and move into state-machine-executor
-          isMfaRequired: userLogin.data.mfaRequired,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
         }
       )

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -222,9 +222,6 @@ export function enterPasswordPost(
         req,
         res,
         USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED,
-        {
-          isMfaMethodVerified: userLogin.data.mfaMethodVerified,
-        }
       )
     );
   };

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -226,7 +226,6 @@ export function enterPasswordPost(
           isMfaRequired: userLogin.data.mfaRequired,
           mfaMethodType: userLogin.data.mfaMethodType,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
-          isPasswordChangeRequired: isPasswordChangeRequired,
         }
       )
     );

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -13,6 +13,7 @@ import type { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import esmock from "esmock";
 import { buildMfaMethods } from "../../../../test/helpers/mfa-helper.js";
+import type { UserLoginResponse } from "../types.js";
 
 describe("Integration::enter password", () => {
   let token: string | string[];
@@ -120,17 +121,21 @@ describe("Integration::enter password", () => {
       .expect(400);
   });
 
-  it("should redirect to /auth-code when password is correct (VTR Cm)", async () => {
+  it("should redirect to /auth-code when password is correct (VTR Cl)", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
+        mfaRequired: false,
+        mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
           phoneNumber: "07123456789",
           redactedPhoneNumber: "789",
         }),
-      });
+        mfaMethodVerified: true,
+        passwordChangeRequired: false,
+      } as UserLoginResponse);
 
     await request(app)
       .post(ENDPOINT)
@@ -144,6 +149,35 @@ describe("Integration::enter password", () => {
       .expect(302);
   });
 
+  it("should redirect to /enter-code when password is correct (VTR Cl.Cm)", async () => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.LOG_IN_USER)
+      .once()
+      .reply(200, {
+        mfaRequired: true,
+        mfaMethodType: "SMS",
+        mfaMethods: buildMfaMethods({
+          id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
+          phoneNumber: "07123456789",
+          redactedPhoneNumber: "789",
+        }),
+        mfaMethodVerified: true,
+        passwordChangeRequired: false,
+      } as UserLoginResponse);
+    nock(baseApi).post("/mfa").once().reply(204);
+
+    await request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "password",
+      })
+      .expect("Location", PATH_NAMES.ENTER_MFA)
+      .expect(302);
+  });
+
   it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is not required", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
@@ -151,13 +185,14 @@ describe("Integration::enter password", () => {
       .reply(200, {
         mfaRequired: false,
         mfaMethodType: "SMS",
-        passwordChangeRequired: true,
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
           phoneNumber: "07123456789",
           redactedPhoneNumber: "789",
         }),
-      });
+        mfaMethodVerified: true,
+        passwordChangeRequired: true,
+      } as UserLoginResponse);
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 
@@ -180,13 +215,14 @@ describe("Integration::enter password", () => {
       .reply(200, {
         mfaRequired: true,
         mfaMethodType: "SMS",
-        passwordChangeRequired: true,
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
           phoneNumber: "07123456789",
           redactedPhoneNumber: "789",
         }),
-      });
+        mfaMethodVerified: true,
+        passwordChangeRequired: true,
+      } as UserLoginResponse);
 
     setupAccountInterventionsResponse(baseApi, noInterventions);
 

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -9,6 +9,7 @@ import type { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import esmock from "esmock";
 import { buildMfaMethods } from "../../../../test/helpers/mfa-helper.js";
+import type { UserLoginResponse } from "../types.js";
 
 const REDIRECT_URI = "https://rp.host/redirect";
 
@@ -124,17 +125,21 @@ describe("Integration::enter password", () => {
       .expect(400);
   });
 
-  it("should redirect to /auth-code when password is correct (VTR Cm)", async () => {
+  it("should redirect to /auth-code when password is correct (VTR Cl)", async () => {
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
+        mfaRequired: false,
+        mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
           phoneNumber: "07123456789",
           redactedPhoneNumber: "789",
         }),
-      });
+        mfaMethodVerified: true,
+        passwordChangeRequired: false,
+      } as UserLoginResponse);
 
     await request(app)
       .post(ENDPOINT)
@@ -145,6 +150,35 @@ describe("Integration::enter password", () => {
         password: "password",
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
+      .expect(302);
+  });
+
+  it("should redirect to /enter-code when password is correct (VTR Cl.Cm)", async () => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.LOG_IN_USER)
+      .once()
+      .reply(200, {
+        mfaRequired: true,
+        mfaMethodType: "SMS",
+        mfaMethods: buildMfaMethods({
+          id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
+          phoneNumber: "07123456789",
+          redactedPhoneNumber: "789",
+        }),
+        mfaMethodVerified: true,
+        passwordChangeRequired: false,
+      } as UserLoginResponse);
+    nock(baseApi).post("/mfa").once().reply(204);
+
+    await request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "password",
+      })
+      .expect("Location", PATH_NAMES.ENTER_MFA)
       .expect(302);
   });
 

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -84,7 +84,6 @@ export function howDoYouWantSecurityCodesPost(
           req,
           res,
           USER_JOURNEY_EVENTS.SELECT_SMS_MFA_METHOD,
-          { isPasswordResetJourney }
         )
       );
     }
@@ -96,7 +95,6 @@ export function howDoYouWantSecurityCodesPost(
           req,
           res,
           USER_JOURNEY_EVENTS.SELECT_AUTH_APP_MFA_METHOD,
-          { isPasswordResetJourney }
         )
       );
     }

--- a/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
+++ b/src/components/how-do-you-want-security-codes/how-do-you-want-security-codes-controller.ts
@@ -37,7 +37,7 @@ export function howDoYouWantSecurityCodesPost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const mfaMethodId = req.body["mfa-method-id"];
-    const { email, isPasswordResetJourney, mfaMethods } = req.session.user;
+    const { email, mfaMethods } = req.session.user;
     const selectedMethod = mfaMethods.find(
       (method: MfaMethod) => method.id === mfaMethodId
     );
@@ -83,7 +83,7 @@ export function howDoYouWantSecurityCodesPost(
         await getNextPathAndUpdateJourney(
           req,
           res,
-          USER_JOURNEY_EVENTS.SELECT_SMS_MFA_METHOD,
+          USER_JOURNEY_EVENTS.SELECT_SMS_MFA_METHOD
         )
       );
     }
@@ -94,7 +94,7 @@ export function howDoYouWantSecurityCodesPost(
         await getNextPathAndUpdateJourney(
           req,
           res,
-          USER_JOURNEY_EVENTS.SELECT_AUTH_APP_MFA_METHOD,
+          USER_JOURNEY_EVENTS.SELECT_AUTH_APP_MFA_METHOD
         )
       );
     }

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -116,9 +116,6 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
         req,
         res,
         USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
-        {
-          isAccountRecoveryJourney: accountRecoveryJourney,
-        }
       )
     );
   };

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -115,7 +115,7 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
+        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE
       )
     );
   };

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -92,9 +92,6 @@ export function resetPassword2FAAuthAppPost(
         req,
         res,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
-        {
-          isIdentityRequired: req.session.user.isIdentityRequired,
-        }
       )
     );
   };

--- a/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
+++ b/src/components/reset-password-2fa-auth-app/reset-password-2fa-auth-app-controller.ts
@@ -91,7 +91,7 @@ export function resetPassword2FAAuthAppPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
+        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED
       )
     );
   };

--- a/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
+++ b/src/components/reset-password-2fa-auth-app/tests/reset-password-2fa-auth-app-controller.test.ts
@@ -89,7 +89,7 @@ describe("reset password 2fa auth app controller", () => {
           success: true,
         }),
       } as unknown as VerifyMfaCodeInterface;
-      req.session.user.enterEmailMfaType = "AUTH-APP";
+      req.session.user.mfaMethodType = "AUTH-APP";
       req.body.code = "123456";
 
       await resetPassword2FAAuthAppPost(fakeService)(
@@ -109,7 +109,7 @@ describe("reset password 2fa auth app controller", () => {
           },
         }),
       } as unknown as VerifyMfaCodeInterface;
-      req.session.user.enterEmailMfaType = "AUTH-APP";
+      req.session.user.mfaMethodType = "AUTH-APP";
       req.body.code = "123456";
 
       await resetPassword2FAAuthAppPost(fakeService)(

--- a/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
+++ b/src/components/reset-password-2fa-sms/tests/reset-password-2fa-sms-controller.test.ts
@@ -140,7 +140,7 @@ describe("reset password 2fa SMS controller", () => {
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
-      req.session.user.enterEmailMfaType = "SMS";
+      req.session.user.mfaMethodType = "SMS";
       req.body.code = "123456";
 
       await resetPassword2FASmsPost(fakeService)(
@@ -163,7 +163,7 @@ describe("reset password 2fa SMS controller", () => {
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
-      req.session.user.enterEmailMfaType = "SMS";
+      req.session.user.mfaMethodType = "SMS";
       req.body.code = "123456";
 
       await resetPassword2FASmsPost(fakeService)(

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -68,8 +68,7 @@ export function resetPasswordCheckEmailGet(
         (method: MfaMethod) => method.priority === MfaMethodPriority.DEFAULT
       )?.id;
       req.session.user.mfaMethods = result.data.mfaMethods;
-
-      req.session.user.enterEmailMfaType = result.data.mfaMethodType;
+      req.session.user.mfaMethodType = result.data.mfaMethodType;
     }
 
     if (!requestCode || result.success) {

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-auth-app-2fa-integration.test.ts
@@ -41,7 +41,7 @@ describe("Integration::reset password check email ", () => {
                 PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL
               ),
             };
-            req.session.user.enterEmailMfaType = "AUTH_APP";
+            req.session.user.mfaMethodType = "AUTH_APP";
             next();
           }),
         },

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -68,7 +68,7 @@ describe("reset password check email controller", () => {
         res as Response
       );
 
-      expect(req.session.user.enterEmailMfaType).to.eq("SMS");
+      expect(req.session.user.mfaMethodType).to.eq("SMS");
       expect(req.session.user.mfaMethods).to.deep.eq(expectedMfaMethods);
       expect(req.session.user.activeMfaMethodId).to.equal(
         TEST_DEFAULT_MFA_METHOD_ID
@@ -284,7 +284,7 @@ describe("reset password check email controller", () => {
       const fakeService = fakeVerifyCodeServiceHelper(true);
       const fakeInterventionsService =
         accountInterventionsFakeHelper(noInterventions);
-      req.session.user.enterEmailMfaType = "SMS";
+      req.session.user.mfaMethodType = "SMS";
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
         req as Request,
         res as Response
@@ -299,7 +299,7 @@ describe("reset password check email controller", () => {
       const fakeService = fakeVerifyCodeServiceHelper(true);
       const fakeInterventionsService =
         accountInterventionsFakeHelper(noInterventions);
-      req.session.user.enterEmailMfaType = "AUTH_APP";
+      req.session.user.mfaMethodType = "AUTH_APP";
       await resetPasswordCheckEmailPost(fakeService, fakeInterventionsService)(
         req as Request,
         res as Response
@@ -350,9 +350,9 @@ describe("reset password check email controller", () => {
     });
 
     ["AUTH_APP", "SMS"].forEach((method) => {
-      it(`should redirect to /reset-password without calling the account interventions service when session.user.withinForcedPasswordResetJourney === true and enterEmailMfaType == ${method}`, async () => {
+      it(`should redirect to /reset-password without calling the account interventions service when session.user.withinForcedPasswordResetJourney === true and mfaMethodType == ${method}`, async () => {
         req.session.user.withinForcedPasswordResetJourney = true;
-        req.session.user.enterEmailMfaType = method;
+        req.session.user.mfaMethodType = method;
 
         const fakeInterventionsService =
           accountInterventionsFakeHelper(noInterventions);

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -45,7 +45,7 @@ describe("Integration::reset password check email ", () => {
               }),
               activeMfaMethodId: "test-id",
             };
-            req.session.user.enterEmailMfaType = "SMS";
+            req.session.user.mfaMethodType = "SMS";
             next();
           }),
         },

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -109,7 +109,6 @@ export function resetPasswordPost(
         res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
-          requiresTwoFactorAuth: false,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         }

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -92,8 +92,6 @@ export function resetPasswordPost(
     }
 
     req.session.user.mfaMethodType = loginResponse.data.mfaMethodType;
-    req.session.user.isAccountPartCreated =
-      !loginResponse.data.mfaMethodVerified;
     req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
       req.session.user.mfaMethods,
       { redactedPhoneNumber: loginResponse.data.redactedPhoneNumber }

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -111,8 +111,6 @@ export function resetPasswordPost(
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
           requiresTwoFactorAuth: false,
-          isLatestTermsAndConditionsAccepted:
-            req.session.user.isLatestTermsAndConditionsAccepted,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         }

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -109,7 +109,6 @@ export function resetPasswordPost(
         res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
-          isIdentityRequired: req.session.user.isIdentityRequired,
           requiresTwoFactorAuth: false,
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -92,7 +92,8 @@ export function resetPasswordPost(
     }
 
     req.session.user.mfaMethodType = loginResponse.data.mfaMethodType;
-    req.session.user.isAccountPartCreated = !loginResponse.data.mfaMethodVerified;
+    req.session.user.isAccountPartCreated =
+      !loginResponse.data.mfaMethodVerified;
     req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
       req.session.user.mfaMethods,
       { redactedPhoneNumber: loginResponse.data.redactedPhoneNumber }
@@ -109,7 +110,7 @@ export function resetPasswordPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.PASSWORD_CREATED,
+        USER_JOURNEY_EVENTS.PASSWORD_CREATED
       )
     );
   };

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -91,6 +91,7 @@ export function resetPasswordPost(
       );
     }
 
+    req.session.user.mfaMethodType = loginResponse.data.mfaMethodType;
     req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
       req.session.user.mfaMethods,
       { redactedPhoneNumber: loginResponse.data.redactedPhoneNumber }
@@ -109,7 +110,6 @@ export function resetPasswordPost(
         res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
-          mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         }
       )

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -92,6 +92,7 @@ export function resetPasswordPost(
     }
 
     req.session.user.mfaMethodType = loginResponse.data.mfaMethodType;
+    req.session.user.isAccountPartCreated = !loginResponse.data.mfaMethodVerified;
     req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
       req.session.user.mfaMethods,
       { redactedPhoneNumber: loginResponse.data.redactedPhoneNumber }
@@ -109,9 +110,6 @@ export function resetPasswordPost(
         req,
         res,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
-        {
-          isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
-        }
       )
     );
   };

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -12,6 +12,7 @@ import type { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import { buildMfaMethods } from "../../../../test/helpers/mfa-helper.js";
 import esmock from "esmock";
+import type { UserLoginResponse } from "../../enter-password/types.js";
 
 describe("Integration::reset password (in 6 digit code flow)", () => {
   let token: string | string[];
@@ -266,8 +267,20 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
 
   it("should redirect to /auth-code when valid password entered", async () => {
     nock(baseApi).post("/reset-password").once().reply(204);
-    nock(baseApi).post("/login").once().reply(200);
-    nock(baseApi).post("/mfa").once().reply(204);
+    nock(baseApi)
+      .post("/login")
+      .once()
+      .reply(200, {
+        mfaRequired: true,
+        mfaMethodType: "SMS",
+        mfaMethods: buildMfaMethods({
+          id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
+          phoneNumber: "07123456789",
+          redactedPhoneNumber: "789",
+        }),
+        mfaMethodVerified: true,
+        passwordChangeRequired: false,
+      } as UserLoginResponse);
 
     await request(app)
       .post(ENDPOINT)

--- a/src/components/reset-password/tests/reset-password-required-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-required-integration.test.ts
@@ -12,6 +12,7 @@ import type { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import { buildMfaMethods } from "../../../../test/helpers/mfa-helper.js";
 import esmock from "esmock";
+import type { UserLoginResponse } from "../../enter-password/types.js";
 
 describe("Integration::reset password required", () => {
   let token: string | string[];
@@ -223,8 +224,20 @@ describe("Integration::reset password required", () => {
 
   it("should redirect to /auth-code when valid password entered", async () => {
     nock(baseApi).post("/reset-password").once().reply(204);
-    nock(baseApi).post("/login").once().reply(200);
-    nock(baseApi).post("/mfa").once().reply(204);
+    nock(baseApi)
+      .post("/login")
+      .once()
+      .reply(200, {
+        mfaRequired: true,
+        mfaMethodType: "SMS",
+        mfaMethods: buildMfaMethods({
+          id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
+          phoneNumber: "07123456789",
+          redactedPhoneNumber: "789",
+        }),
+        mfaMethodVerified: true,
+        passwordChangeRequired: false,
+      } as UserLoginResponse);
 
     await request(app)
       .post(ENDPOINT)

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -127,7 +127,7 @@ export function setupAuthenticatorAppPost(
       await getNextPathAndUpdateJourney(
         req,
         res,
-        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
+        USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED
       )
     );
   };

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -132,7 +132,6 @@ export function setupAuthenticatorAppPost(
         res,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
-          isIdentityRequired: req.session.user.isIdentityRequired,
           isAccountRecoveryJourney: accountRecoveryEnabledJourney,
         }
       )

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -103,12 +103,9 @@ export function setupAuthenticatorAppPost(
       req.session.user.mfaMethods
     );
 
-    const accountRecoveryEnabledJourney =
-      isAccountRecoveryJourneyAndPermitted(req);
-
     let notificationType = NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION;
 
-    if (accountRecoveryEnabledJourney) {
+    if (isAccountRecoveryJourneyAndPermitted(req)) {
       req.session.user.accountRecoveryVerifiedMfaType =
         MFA_METHOD_TYPE.AUTH_APP;
       notificationType =
@@ -131,9 +128,6 @@ export function setupAuthenticatorAppPost(
         req,
         res,
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
-        {
-          isAccountRecoveryJourney: accountRecoveryEnabledJourney,
-        }
       )
     );
   };

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -55,7 +55,7 @@ export function updatedTermsConditionsPost(
         await getNextPathAndUpdateJourney(
           req,
           res,
-          USER_JOURNEY_EVENTS.TERMS_AND_CONDITIONS_ACCEPTED,
+          USER_JOURNEY_EVENTS.TERMS_AND_CONDITIONS_ACCEPTED
         )
       );
     }

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -56,9 +56,6 @@ export function updatedTermsConditionsPost(
           req,
           res,
           USER_JOURNEY_EVENTS.TERMS_AND_CONDITIONS_ACCEPTED,
-          {
-            isIdentityRequired: req.session.user.isIdentityRequired,
-          }
         )
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,8 @@ export interface UserSession {
   isAccountRecoveryJourney?: boolean;
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
+  // TODO: Delete this in follow-up PR
+  enterEmailMfaType?: string;
   withinForcedPasswordResetJourney?: boolean;
   passwordResetTime?: number;
   isPasswordResetJourney?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,7 @@ export interface UserSession {
   isVerifyEmailCodeResendRequired?: boolean;
   channel?: string;
   mfaMethodType?: string;
+  isMfaRequired?: boolean;
   activeMfaMethodId?: string;
   sentOtpMfaMethodIds?: string[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,6 @@ export interface UserSession {
   isAccountRecoveryJourney?: boolean;
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
-  enterEmailMfaType?: string;
   withinForcedPasswordResetJourney?: boolean;
   passwordResetTime?: number;
   isPasswordResetJourney?: boolean;


### PR DESCRIPTION
## What

Compute state machine context from current session instead of passing in bespoke parameters at each call-site. This should make it easier to reason about the state machine and use existing conditions elsewhere.

Also:
- Refine logging to make it easier to analyse journeys
- Remove some impossible transitions

New journey map:

<img width="5110" height="1552" alt="image" src="https://github.com/user-attachments/assets/3ab0c91e-b26a-45c8-9801-be44b26da403" />

## How to review

1. Code Review
1. Ensure all acceptance tests still pass

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2962