### PR TITLE
Revert "BAU: Keep enterEmailMfaType for ZDD"

### DIFF
--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -26,9 +26,7 @@ export async function getNextPathAndUpdateJourney(
       !!req.session.user?.withinForcedPasswordResetJourney,
     isPasswordChangeRequired: !!req.session.user?.isPasswordChangeRequired,
     isPasswordResetJourney: !!req.session.user?.isPasswordResetJourney,
-    // TODO: Consolidate to just mfaMethodType in follow-up PR
-    mfaMethodType:
-      req.session.user?.mfaMethodType ?? req.session.user?.enterEmailMfaType,
+    mfaMethodType: req.session.user?.mfaMethodType,
   };
 
   const nextState = getNextState(currentState, event, context);

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -99,8 +99,6 @@ async function getExistingUserAndPopulateSessionData(
     setUpAuthAppLocks(req, result.data.lockoutInformation);
   }
 
-  // TODO: Delete this in follow-up PR
-  req.session.user.enterEmailMfaType = result.data.mfaMethodType;
   req.session.user.mfaMethodType = result.data.mfaMethodType;
   req.session.user.mfaMethods = upsertDefaultSmsMfaMethod(
     req.session.user.mfaMethods,

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,8 +81,6 @@ export interface UserSession {
   isAccountRecoveryJourney?: boolean;
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
-  // TODO: Delete this in follow-up PR
-  enterEmailMfaType?: string;
   withinForcedPasswordResetJourney?: boolean;
   passwordResetTime?: number;
   isPasswordResetJourney?: boolean;


### PR DESCRIPTION
This reverts commit cc290ca790781e5bf4693288339709f7d1c18aa3.

## What

Remove `enterEmailMfaType`, superseded by `mfaMethodType`.

See also https://github.com/govuk-one-login/authentication-frontend/pull/2969