### PR TITLE
BAU: Improve logging context

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,7 +3,7 @@ import express from "express";
 import "express-async-errors";
 import cookieParser from "cookie-parser";
 import type serveStatic from "serve-static";
-import { logger, loggerMiddleware } from "./utils/logger.js";
+import { addRequestContext, logger, loggerMiddleware } from "./utils/logger.js";
 import { sanitizeRequestMiddleware } from "./middleware/sanitize-request-middleware.js";
 import * as i18nextMiddleware from "i18next-http-middleware";
 import * as path from "path";
@@ -282,6 +282,14 @@ async function createApp(): Promise<express.Application> {
     app.use(setCurrentUrlMiddleware);
   }
   app.use(getAnalyticsPropertiesMiddleware);
+
+  // Attach context to request logs
+  app.use((req, res, next) => {
+    req.log = req.log.child({
+      ...addRequestContext(req, res),
+    });
+    next();
+  });
 
   registerRoutes(app);
 

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -35,7 +35,6 @@ import {
   getAppEnv,
   getLocalEncryptionKey,
 } from "../../config.js";
-import { logger } from "../../utils/logger.js";
 import type { Claims } from "./claims-config.js";
 import { isReauth, isUpliftRequired } from "../../utils/request.js";
 import { LocalDecryptionService } from "./local-decryption-service.js";
@@ -96,7 +95,7 @@ export function authorizeGet(
     }
 
     if (claims.govuk_signin_journey_id !== clientSessionId) {
-      logger.warn(
+      req.log.warn(
         `clientSessionId in claims (${claims.govuk_signin_journey_id}) does not match one found in cookie (${clientSessionId})`
       );
     }
@@ -137,7 +136,7 @@ export function authorizeGet(
       req.session.user.reauthenticate &&
       startAuthResponse.data.user.isBlockedForReauth
     ) {
-      logger.info(
+      req.log.info(
         `Start response indicates user with session ${res.locals.sessionId} is blocked for reauth, redirecting back to orchestration`
       );
       return res.redirect(
@@ -147,8 +146,8 @@ export function authorizeGet(
 
     req.session.user.isAccountCreationJourney = undefined;
 
-    logger.info(`Reauth claim length ${claims.reauthenticate?.length}`);
-    logger.info(`Support for reauth is enabled ${supportReauthentication()}`);
+    req.log.info(`Reauth claim length ${claims.reauthenticate?.length}`);
+    req.log.info(`Support for reauth is enabled ${supportReauthentication()}`);
 
     const nextStateEvent = getNextStateEvent(req);
 
@@ -236,7 +235,7 @@ function setSessionDataFromClaims(req: Request, claims: Claims) {
   req.session.user.channel = isValidChannel(claims.channel)
     ? claims.channel
     : getDefaultChannel();
-  logger.info(`Channel is set to: ${req.session.user.channel}`);
+  req.log.info(`Channel is set to: ${req.session.user.channel}`);
 }
 
 function setSessionDataFromAuthResponse(

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -10,7 +10,6 @@ import type { AccountInterventionsInterface } from "../account-intervention/type
 import { accountInterventionService } from "../account-intervention/account-intervention-service.js";
 import { getNewCodePath } from "../security-code-error/security-code-error-controller.js";
 import { isLocked } from "../../utils/lock-helper.js";
-import { logger } from "../../utils/logger.js";
 import type { CheckEmailFraudBlockInterface } from "../check-email-fraud-block/types.js";
 import { checkEmailFraudBlockService } from "../check-email-fraud-block/check-email-fraud-block-service.js";
 const TEMPLATE_NAME = "check-your-email/index.njk";
@@ -52,11 +51,11 @@ export const checkYourEmailPost = (
           persistentSessionId,
           req
         );
-      logger.info(
+      req.log.info(
         `checkEmailFraudResponse: ${checkEmailFraudResponse.data.isBlockedStatus}`
       );
     } catch (e) {
-      logger.error("Error checking email fraud block", e);
+      req.log.error("Error checking email fraud block", e);
     }
     const verifyCodeRequest = verifyCodePost(
       service,

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -140,12 +140,12 @@ export function contactUsGet(req: Request, res: Response): void {
 
   if (req.query.fromURL) {
     fromURL = validateReferer(req.query.fromURL as string, serviceDomain);
-    logger.info(`fromURL query param received with value ${fromURL}`);
+    req.log.info(`fromURL query param received with value ${fromURL}`);
   }
 
   if (req.query.referer) {
     referer = validateReferer(req.query.referer as string, serviceDomain);
-    logger.info(`referer with referer query param ${referer}`);
+    req.log.info(`referer with referer query param ${referer}`);
   }
 
   if (req.headers?.referer?.includes(REFERER)) {
@@ -154,9 +154,9 @@ export function contactUsGet(req: Request, res: Response): void {
         new URL(req.get(REFERER)).searchParams.get(REFERER),
         serviceDomain
       );
-      logger.info(`referer with referer header param ${referer}`);
+      req.log.info(`referer with referer header param ${referer}`);
     } catch {
-      logger.warn(
+      req.log.warn(
         `unable to parse referer with referer param ${req.get(REFERER)}`
       );
     }
@@ -571,8 +571,8 @@ export function contactUsQuestionsFormPostToSmartAgent(
           : undefined,
     });
 
-    logger.info(
-      `Support ticket submitted to SmartAgent with id ${ticketIdentifier} for session ${res.locals.sessionId}`
+    req.log.info(
+      `Support ticket submitted to SmartAgent with id ${ticketIdentifier}`
     );
     return res.redirect(PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS);
   };

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -30,10 +30,12 @@ import type {
   RequestGet,
   ResponseRedirect,
 } from "../../../types.js";
+import { logger } from "../../../utils/logger.js";
 import { getServiceDomain, getSupportLinkUrl } from "../../../config.js";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
 import { mockResponse } from "mock-req-res";
 import type { ContactForm } from "../types.js";
+
 describe("contact us controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
@@ -49,6 +51,7 @@ describe("contact us controller", () => {
       query: {},
       headers: {},
       get: sandbox.fake() as unknown as RequestGet,
+      log: logger,
     };
     res = {
       render: sandbox.fake(),

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -14,6 +14,8 @@ import {
   CONTACT_US_COUNTRY_MAX_LENGTH,
 } from "../../../app.constants.js";
 import type { RequestGet, ResponseRedirect } from "../../../types.js";
+import { logger } from "../../../utils/logger.js";
+
 describe("contact us questions controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
@@ -30,6 +32,7 @@ describe("contact us questions controller", () => {
       get: sandbox.fake() as unknown as RequestGet,
       headers: {},
       t: sandbox.fake(),
+      log: logger,
     };
     res = {
       render: sandbox.fake(),

--- a/src/components/ipv-callback/ipv-callback-controller.ts
+++ b/src/components/ipv-callback/ipv-callback-controller.ts
@@ -5,7 +5,6 @@ import {
   isReverificationResultFailedResponse,
   REVERIFICATION_ERROR_CODE,
 } from "./types.js";
-import { logger } from "../../utils/logger.js";
 import { reverificationResultService } from "./reverification-result-service.js";
 import { BadRequestError } from "../../utils/error.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
@@ -64,7 +63,7 @@ export function ipvCallbackGet(
       state
     );
 
-    logger.info(
+    req.log.info(
       `Reverification result for session id ${res.locals.sessionId} is success: ${result.success}`
     );
 

--- a/src/components/templates/templates-controller.ts
+++ b/src/components/templates/templates-controller.ts
@@ -1,7 +1,6 @@
 import type { RequestHandler } from "express";
 import querystring from "querystring";
 import { pages } from "./pages.js";
-import { logger } from "../../utils/logger.js";
 import { PATH_NAMES } from "../../app.constants.js";
 
 interface RadioOption {
@@ -55,7 +54,7 @@ export const templatesDisplayGet: RequestHandler = (req, res) => {
     : pages[path];
 
   if (!page) {
-    logger.error(
+    req.log.error(
       `Could not find template for ${path} (${pageVariant || "no variant"})`
     );
     res.status(404);

--- a/src/middleware/account-interventions-middleware.ts
+++ b/src/middleware/account-interventions-middleware.ts
@@ -4,7 +4,6 @@ import { USER_JOURNEY_EVENTS } from "../components/common/state-machine/state-ma
 import { accountInterventionService } from "../components/account-intervention/account-intervention-service.js";
 import type { ExpressRouteFunc } from "../types.js";
 import { supportAccountInterventions } from "../config.js";
-import { logger } from "../utils/logger.js";
 import {
   isSuspendedWithoutUserActions,
   passwordHasBeenResetMoreRecentlyThanInterventionApplied,
@@ -56,7 +55,7 @@ export function accountInterventionsMiddleware(
             )
           );
         } else {
-          logger.info(
+          req.log.info(
             `User reset password since intervention applied. Skipping intervention. User reset password timestamp: ${req.session.user.passwordResetTime} intervention applied at timestamp: ${accountInterventionsResponse.data.appliedAt}`
           );
         }

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -7,7 +7,6 @@ import {
   ERROR_MESSAGES,
   PATH_NAMES,
 } from "../app.constants.js";
-import { logger } from "../utils/logger.js";
 import type { MfaMethod } from "../types.js";
 import { MfaMethodPriority } from "../types.js";
 
@@ -82,7 +81,7 @@ export function requiredSessionFieldsMiddleware(
   next: NextFunction
 ): void {
   if (!req.session?.user?.email) {
-    logger.info("required session field 'email' is missing");
+    req.log.info("required session field 'email' is missing");
     return handleSessionError(req, res, next);
   } else {
     return next();

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -17,7 +17,6 @@ import { HTTP_STATUS_CODES } from "../app.constants.js";
 import { ApiError } from "./error.js";
 import type { Request } from "express";
 import { createPersonalDataHeaders } from "@govuk-one-login/frontend-passthrough-headers";
-import { logger } from "./logger.js";
 import { Agent } from "https";
 
 type CustomAxiosRequestHeaders = Partial<AxiosRequestHeaders>;
@@ -57,7 +56,7 @@ function getSecurityHeaders(path: string, req: Request, baseUrl?: string) {
     url = new URL(path, basePath).toString();
     personalDataHeaders = createPersonalDataHeaders(url, req);
   } catch (err) {
-    logger.warn(
+    req.log.warn(
       `Called with ${url}. Failed to set security headers due to: ${err instanceof Error ? err.message : "Unknown error"}`
     );
   }

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,0 +1,39 @@
+import { expect } from "chai";
+import { redactQueryParams } from "./logger";
+
+describe("redactQueryParams", () => {
+  [
+    {
+      input: undefined,
+      output: undefined,
+    },
+    {
+      input: "malformed",
+      output: "malformed",
+    },
+    {
+      input: "/authorize",
+      output: "/authorize",
+    },
+    {
+      input: "/authorize?safe=value",
+      output: "/authorize?safe=value",
+    },
+    {
+      input: "/authorize?code=secret_code&safe=value&request=long_request",
+      output: "/authorize?code=hidden&safe=value&request=hidden",
+    },
+    {
+      input: "/authorize?code=secret_code&safe=value&request=long_request",
+      output: "/authorize?code=hidden&safe=value&request=hidden",
+    },
+  ].forEach(({ input, output }) => {
+    it(`should correctly map ${input}`, () => {
+      // Act
+      const actual = redactQueryParams(input);
+
+      // Assert
+      expect(actual).to.equal(output);
+    });
+  });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,6 +3,8 @@ import { pinoHttp } from "pino-http";
 import { getLogLevel } from "../config.js";
 import type { Request, Response } from "express";
 
+// Global logger for use outside of a request context
+// Per-request logging should use req.log instead so it is populated with request context
 const logger = pino({
   name: "di-auth",
   level: getLogLevel(),
@@ -41,7 +43,7 @@ export function getRefererFrom(referer: string): string {
 export const addRequestContext = (
   req: Request,
   res: Response,
-  val?: object,
+  val?: object
 ): object => ({
   ...val,
   clientId: res.locals.clientId,


### PR DESCRIPTION
## What

- Add useful log context to request logger
- Use request logger where possible
- Redact sensitive/large query params (i.e. JAR payloads and auth codes)

### Response logging

#### Before
```
{
  "level": 30,
  "time": 1757954030841,
  "pid": 6,
  "hostname": "<ECS task>",
  "name": "di-auth",
  "req": {
    "id": 12345,
    "method": "GET",
    "url": "/enter-password",
    "from": "/enter-email"
  },
  "res": {
    "status": 200,
    "sessionId": "<session id>",
    "clientSessionId": "<journey id>",
    "persistentSessionId": "<persistent session id>",
    "languageFromCookie": "EN",
    "clientId": "<client id>"
  },
  "timeTaken": 5,
  "msg": "request completed with status code of: 200"
}
```

#### After
Standard properties are lifted to top level and client session id => journey id:
```
{
  "level": 30,
  "time": 1757954030841,
  "pid": 6,
  "hostname": "<ECS task>",
  "name": "di-auth",
  "req": {
    "id": 12345,
    "method": "GET",
    "url": "/enter-password",
    "from": "/enter-email"
  },
  "res": {
    "status": 200,
    "languageFromCookie": "EN"
  },
  "timeTaken": 5,
  "clientId": "<client id>",
  "govuk_journey_id": "<journey id>",
  "persistentSessionId": "<persistent session id>",
  "sessionId": "<session id>",
  "msg": "request completed with status code of: 200"
}
```

#### After (/authorize)
Request in the Authorize URL is redacted
```
{
  "level": 30,
  "time": 1757954030841,
  "pid": 6,
  "hostname": "<ECS task>",
  "name": "di-auth",
  "req": {
    "id": 1,
    "method": "GET",
    "url": "/authorize?request=hidden&response_type=code&client_id=orchestrationAuth",
    "from": "/"
  },
  "res": {
    "status": 302,
    "languageFromCookie": "EN"
  },
  "timeTaken": 5,
  "govuk_journey_id": "<journey id>",
  "persistentSessionId": "<persistent session id>",
  "sessionId": "<session id>",
  "msg": "request completed with status code of: 302"
}
```

### Other request logs

#### Before
```
{
  "level": 20,
  "time": 1757954631106,
  "pid": 6,
  "hostname": "<ECS task>",
  "name": "di-auth",
  "req": {
    "id": 1895616,
    "method": "POST",
    "url": "/enter-password",
    "from": "/enter-email"
  },
  "msg": "Session was successfully saved after setting the user journey."
}
```

#### After
Standard properties are included at top level
```
{
  "level": 20,
  "time": 1757954631106,
  "pid": 6,
  "hostname": "<ECS task>",
  "name": "di-auth",
  "req": {
    "id": 1895616,
    "method": "POST",
    "url": "/enter-password",
    "from": "/enter-email"
  },
  "clientId": "<client id>",
  "govuk_journey_id": "<journey id>",
  "persistentSessionId": "<persistent session id>",
  "sessionId": "<session id>",
  "msg": "Session was successfully saved after setting the user journey."
}
```

## How to review

1. Code Review
1. Run locally and observe log structures

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change.
