### PR TITLE
BAU: Fix 'macOS' typo

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1211,7 +1211,7 @@
       },
       "section2": {
         "header": "Cael mynydiad i’ch GOV.UK One Login",
-        "paragraph1": "Rydych yn gyfrifol am wneud yr holl drefniadau i chi gael mynediad i’ch GOV.UK One Login. Mae hyn yn cynnwys darparu eich dyfais eich hun, system weithredu, porwr a chysylltiad rhyngrwyd. Dylech ddefnyddio dyfais sy’n defnyddio system weithredu Windows, OS, iOS neu Android. Rydym yn argymell eich bod yn defnyddio un o’r porwyr canlynol:",
+        "paragraph1": "Rydych yn gyfrifol am wneud yr holl drefniadau i chi gael mynediad i’ch GOV.UK One Login. Mae hyn yn cynnwys darparu eich dyfais eich hun, system weithredu, porwr a chysylltiad rhyngrwyd. Dylech ddefnyddio dyfais sy’n defnyddio system weithredu Windows, macOS, iOS neu Android. Rydym yn argymell eich bod yn defnyddio un o’r porwyr canlynol:",
         "bulletPoint1": "Y fersiwn diweddaraf o Google Chrome, Microsoft Edge, Mozilla Firefox, Samsung Internet neu Internet Explorer",
         "bulletPoint2": "Safari 12 neu ddiweddarach",
         "bulletPoint3": "Safari ar gyfer iOS 12.1 neu ddiweddarach",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1213,7 +1213,7 @@
       },
       "section2": {
         "header": "Cael mynydiad i’ch GOV.UK One Login",
-        "paragraph1": "Rydych yn gyfrifol am wneud yr holl drefniadau i chi gael mynediad i’ch GOV.UK One Login. Mae hyn yn cynnwys darparu eich dyfais eich hun, system weithredu, porwr a chysylltiad rhyngrwyd. Dylech ddefnyddio dyfais sy’n defnyddio system weithredu Windows, OS, iOS neu Android. Rydym yn argymell eich bod yn defnyddio un o’r porwyr canlynol:",
+        "paragraph1": "Rydych yn gyfrifol am wneud yr holl drefniadau i chi gael mynediad i’ch GOV.UK One Login. Mae hyn yn cynnwys darparu eich dyfais eich hun, system weithredu, porwr a chysylltiad rhyngrwyd. Dylech ddefnyddio dyfais sy’n defnyddio system weithredu Windows, macOS, iOS neu Android. Rydym yn argymell eich bod yn defnyddio un o’r porwyr canlynol:",
         "bulletPoint1": "Y fersiwn diweddaraf o Google Chrome, Microsoft Edge, Mozilla Firefox, Samsung Internet neu Internet Explorer",
         "bulletPoint2": "Safari 12 neu ddiweddarach",
         "bulletPoint3": "Safari ar gyfer iOS 12.1 neu ddiweddarach",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1211,7 +1211,7 @@
       },
       "section2": {
         "header": "Accessing GOV.UK One Login",
-        "paragraph1": "You are responsible for making all arrangements for you to access GOV.UK One Login. This includes providing your own device, operating system, browser and internet connection. You should use a device that uses a Windows, OS, iOS or Android operating system. We recommend you use one of the following browsers:",
+        "paragraph1": "You are responsible for making all arrangements for you to access GOV.UK One Login. This includes providing your own device, operating system, browser and internet connection. You should use a device that uses a Windows, macOS, iOS or Android operating system. We recommend you use one of the following browsers:",
         "bulletPoint1": "The latest version of Google Chrome, Microsoft Edge, Mozilla Firefox, Samsung Internet or Internet Explorer",
         "bulletPoint2": "Safari 12 or later",
         "bulletPoint3": "Safari for iOS 12.1 or later",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1213,7 +1213,7 @@
       },
       "section2": {
         "header": "Accessing GOV.UK One Login",
-        "paragraph1": "You are responsible for making all arrangements for you to access GOV.UK One Login. This includes providing your own device, operating system, browser and internet connection. You should use a device that uses a Windows, OS, iOS or Android operating system. We recommend you use one of the following browsers:",
+        "paragraph1": "You are responsible for making all arrangements for you to access GOV.UK One Login. This includes providing your own device, operating system, browser and internet connection. You should use a device that uses a Windows, macOS, iOS or Android operating system. We recommend you use one of the following browsers:",
         "bulletPoint1": "The latest version of Google Chrome, Microsoft Edge, Mozilla Firefox, Samsung Internet or Internet Explorer",
         "bulletPoint2": "Safari 12 or later",
         "bulletPoint3": "Safari for iOS 12.1 or later",


### PR DESCRIPTION
## What

'mac' was missing from the beginning of one of our Ts&Cs lines. Updated the English and Welsh translations to name the operating system correctly.

## How to review

1. Code Review