### PR TITLE
BAU: Increase PasskeyRolloutPercentage to 1%

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -629,7 +629,7 @@ Mappings:
       PasskeyPromptClientAllowList: ""
       PasskeyPromptClientDenyList: ""
       serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
-      PasskeyRolloutPercentage: 0.25
+      PasskeyRolloutPercentage: 1
 
   # /acceptance-tests/{env}}/CUCUMBER_FILTER_TAGS
   AcceptanceTestTags:


### PR DESCRIPTION
## What

Increasing from 0.25%. Controls the number of people we prompt to register their first passkey during the sign-in flow.

## How to review

1. Code Review