### PR TITLE
BAU: Increase PasskeyRolloutPercentage to 10%

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -629,7 +629,7 @@ Mappings:
       PasskeyPromptClientAllowList: ""
       PasskeyPromptClientDenyList: ""
       serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
-      PasskeyRolloutPercentage: 1
+      PasskeyRolloutPercentage: 10
 
   # /acceptance-tests/{env}}/CUCUMBER_FILTER_TAGS
   AcceptanceTestTags:


### PR DESCRIPTION


## What

Increase 'PasskeyRolloutPercentage' to 10%

- 10% of users signing in will see the passkey prompt 
- Increasing as per the rollout plan: https://govukverify.atlassian.net/wiki/x/oAT9jwE

## How to review

1. Code Review

## Checklist

- [x] Performance analyst has been notified of the change.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3597
