### PR TITLE
Bau: remove redundant new code link code

### DIFF
--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -3,10 +3,6 @@
 
 {% set pageTitleName = 'pages.securityRequestsExceededExpired.title' | translate %}
 
-{% if isResendCodeRequest %}
-    {% set newCodeLink = newCodeLink + "?isResendCodeRequest=true" %}
-{% endif %}
-
 {% block content %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.securityRequestsExceededExpired.header' | translate }}</h1>
 

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -53,11 +53,6 @@ export function securityCodeTriesExceededGet(
   }
 
   return res.render("security-code-error/index-too-many-requests.njk", {
-    newCodeLink: getNewCodePath(
-      req.query.actionType as SecurityCodeErrorType,
-      req.session.user.isAccountCreationJourney
-    ),
-    isResendCodeRequest: req.query.isResendCodeRequest,
     isAccountCreationJourney: req.session.user?.isAccountCreationJourney,
   });
 }
@@ -66,9 +61,7 @@ export function securityCodeCannotRequestCodeGet(
   req: Request,
   res: Response
 ): void {
-  res.render("security-code-error/index-too-many-requests.njk", {
-    newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
-  });
+  res.render("security-code-error/index-too-many-requests.njk");
 }
 
 export function securityCodeEnteredExceededGet(

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -52,9 +52,7 @@ export function securityCodeTriesExceededGet(
     );
   }
 
-  return res.render("security-code-error/index-too-many-requests.njk", {
-    isAccountCreationJourney: req.session.user?.isAccountCreationJourney,
-  });
+  return res.render("security-code-error/index-too-many-requests.njk");
 }
 
 export function securityCodeCannotRequestCodeGet(

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -9,11 +9,9 @@ import {
   securityCodeInvalidGet,
   securityCodeTriesExceededGet,
   securityCodeEnteredExceededGet,
-  getNewCodePath,
 } from "../security-code-error-controller.js";
 import {
   pathWithQueryParam,
-  SECURITY_CODE_ERROR,
   SecurityCodeErrorType,
 } from "../../common/constants.js";
 import type { RequestOutput, ResponseOutput } from "mock-req-res";
@@ -74,8 +72,6 @@ describe("security code controller", () => {
         expect(res.render).to.have.calledWith(
           "security-code-error/index-too-many-requests.njk",
           {
-            newCodeLink: params.newCodeLink,
-            isResendCodeRequest: undefined,
             isAccountCreationJourney: params.isAccountCreationJourney,
           }
         );
@@ -92,9 +88,6 @@ describe("security code controller", () => {
 
         expect(res.render).to.have.calledWith(
           "security-code-error/index-too-many-requests.njk",
-          {
-            newCodeLink: params.expectedCodeLink,
-          }
         );
       });
     });
@@ -389,12 +382,6 @@ describe("security code controller", () => {
         expect(res.render).to.have.calledWith(
           "security-code-error/index-too-many-requests.njk",
           {
-            newCodeLink: pathWithQueryParam(
-              PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
-              SECURITY_CODE_ERROR,
-              SecurityCodeErrorType.MfaMaxRetries
-            ),
-            isResendCodeRequest: undefined,
             isAccountCreationJourney: undefined,
           }
         );
@@ -416,12 +403,6 @@ describe("security code controller", () => {
         expect(res.render).to.have.calledWith(
           "security-code-error/index-too-many-requests.njk",
           {
-            newCodeLink: pathWithQueryParam(
-              PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
-              SECURITY_CODE_ERROR,
-              SecurityCodeErrorType.MfaMaxRetries
-            ),
-            isResendCodeRequest: undefined,
             isAccountCreationJourney: undefined,
           }
         );
@@ -439,8 +420,6 @@ describe("security code controller", () => {
         expect(res.render).to.have.calledWith(
           "security-code-error/index-too-many-requests.njk",
           {
-            newCodeLink: getNewCodePath(SecurityCodeErrorType.OtpBlocked),
-            isResendCodeRequest: undefined,
             isAccountCreationJourney: undefined,
           }
         );
@@ -455,12 +434,6 @@ describe("security code controller", () => {
       expect(res.render).to.have.calledWith(
         "security-code-error/index-too-many-requests.njk",
         {
-          newCodeLink: pathWithQueryParam(
-            PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
-            SECURITY_CODE_ERROR,
-            SecurityCodeErrorType.MfaMaxRetries
-          ),
-          isResendCodeRequest: undefined,
           isAccountCreationJourney: true,
         }
       );

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -63,17 +63,12 @@ describe("security code controller", () => {
     SCENARIOS.SECURITY_CODE_TRIES_EXCEEDED_GET.forEach(function (params) {
       it(`should render index-too-many-requests.njk for ${params.actionType} when max number of codes have been sent`, () => {
         req.query.actionType = params.actionType;
-        req.session.user.isAccountCreationJourney =
-          params.isAccountCreationJourney;
         res.locals.strategicAppChannel = true;
 
         securityCodeTriesExceededGet(req as Request, res as Response);
 
         expect(res.render).to.have.calledWith(
-          "security-code-error/index-too-many-requests.njk",
-          {
-            isAccountCreationJourney: params.isAccountCreationJourney,
-          }
+          "security-code-error/index-too-many-requests.njk"
         );
       });
     });
@@ -87,7 +82,7 @@ describe("security code controller", () => {
         securityCodeCannotRequestCodeGet(req, res);
 
         expect(res.render).to.have.calledWith(
-          "security-code-error/index-too-many-requests.njk",
+          "security-code-error/index-too-many-requests.njk"
         );
       });
     });
@@ -380,10 +375,7 @@ describe("security code controller", () => {
         securityCodeTriesExceededGet(req as Request, res as Response);
 
         expect(res.render).to.have.calledWith(
-          "security-code-error/index-too-many-requests.njk",
-          {
-            isAccountCreationJourney: undefined,
-          }
+          "security-code-error/index-too-many-requests.njk"
         );
         expect(req.session.user.codeRequestLock).to.eq(
           "Mon, 01 Jan 2024 00:15:00 GMT"
@@ -401,10 +393,7 @@ describe("security code controller", () => {
         securityCodeTriesExceededGet(req as Request, res as Response);
 
         expect(res.render).to.have.calledWith(
-          "security-code-error/index-too-many-requests.njk",
-          {
-            isAccountCreationJourney: undefined,
-          }
+          "security-code-error/index-too-many-requests.njk"
         );
       }
     );
@@ -418,10 +407,7 @@ describe("security code controller", () => {
         securityCodeTriesExceededGet(req as Request, res as Response);
 
         expect(res.render).to.have.calledWith(
-          "security-code-error/index-too-many-requests.njk",
-          {
-            isAccountCreationJourney: undefined,
-          }
+          "security-code-error/index-too-many-requests.njk"
         );
       }
     );
@@ -432,10 +418,7 @@ describe("security code controller", () => {
       securityCodeTriesExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
-        "security-code-error/index-too-many-requests.njk",
-        {
-          isAccountCreationJourney: true,
-        }
+        "security-code-error/index-too-many-requests.njk"
       );
     });
 

--- a/src/components/templates/pages.ts
+++ b/src/components/templates/pages.ts
@@ -552,14 +552,11 @@ export const pages: Record<string, Page | PageVariant[]> = {
   [PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED]: {
     template: "security-code-error/index-too-many-requests.njk",
     options: {
-      newCodeLink: "#",
-      isResendCodeRequest: false,
       isAccountCreationJourney: false,
     },
   },
   [PATH_NAMES.SECURITY_CODE_WAIT]: {
     template: "security-code-error/index-too-many-requests.njk",
-    options: { newCodeLink: "#" },
   },
 
   // Account interventions

--- a/src/components/templates/pages.ts
+++ b/src/components/templates/pages.ts
@@ -551,9 +551,6 @@ export const pages: Record<string, Page | PageVariant[]> = {
   ],
   [PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED]: {
     template: "security-code-error/index-too-many-requests.njk",
-    options: {
-      isAccountCreationJourney: false,
-    },
   },
   [PATH_NAMES.SECURITY_CODE_WAIT]: {
     template: "security-code-error/index-too-many-requests.njk",


### PR DESCRIPTION
Removes redundant variables being passed in to the "index-too-many-requests" template.

### How to review 

Verify that the code changes are safe i.e. the removals make no functional difference.