### PR TITLE
BAU: Remove link from translations

### DIFF
--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -55,7 +55,7 @@
         {% set detailsHTML %}
         <p class="govuk-body">
             {{'pages.resetPasswordCheckEmail.details.text1' | translate}}
-            <a href="{{'pages.resetPasswordCheckEmail.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.details.sendCodeLinkText'| translate}}</a>
+            <a href="/reset-password-resend-code" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.details.sendCodeLinkText'| translate}}</a>
             {{'pages.resetPasswordCheckEmail.details.text2' | translate}}.
         </p>
         {% endset %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -437,7 +437,6 @@
         "summaryText": "Problemau gyda’r cod?",
         "text1": "Gallwn ",
         "sendCodeLinkText": "anfon y cod eto",
-        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
         "text2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn"
       },
       "sendAnotherEmailLinkText": "Anfon e-bost arall",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -437,7 +437,6 @@
         "summaryText": "Problems with the code?",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
-        "sendCodeLinkHref": "/reset-password-resend-code",
         "text2": " if the code is not working or you did not receive it"
       },
       "sendAnotherEmailLinkText": "Send another email",


### PR DESCRIPTION
The link for resending the email code in the password reset journey can be hard-coded in the template (we shouldn't have hrefs in the template file - a more general problem than this to be fixed subsequently.

This also fixes a bug where the welsh translation took the user to a non allowed path, effectively breaking the ability to resend an email code on the reset password journey in welsh. (This illustrates why we shouldn't have hrefs in translation files)

## How to review 

Static review or go through a password reset journey and see that the links to resend code go to the same place in english as in welsh and work. 
