### PR TITLE
AUT-5611: Redirect accessibility statement to GOV.UK

### DIFF
--- a/src/components/common/footer/footer-pages-controller.ts
+++ b/src/components/common/footer/footer-pages-controller.ts
@@ -33,25 +33,19 @@ export function supportPost(req: Request, res: Response): void {
 }
 
 function redirectToExternalPrivacyNotice(req: Request, res: Response) {
-  if (req.i18n?.language === "cy") {
-    return res.redirect(
-      "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice.cy"
-    );
-  }
-  res.redirect(
-    "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice"
-  );
+  const privacyNoticeUrl =
+    req.i18n?.language === "cy"
+      ? "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice.cy"
+      : "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice";
+  res.redirect(privacyNoticeUrl);
 }
 
 function redirectToExternalAccessibilityStatement(req: Request, res: Response) {
-  if (req.i18n?.language === "cy") {
-    return res.redirect(
-      "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement.cy"
-    );
-  }
-  res.redirect(
-    "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement"
-  );
+  const accessibilityStatementUrl =
+    req.i18n?.language === "cy"
+      ? "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement.cy"
+      : "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement";
+  res.redirect(accessibilityStatementUrl);
 }
 
 function appendQueryParam(param: string, value: string, url: string) {

--- a/src/components/common/footer/footer-pages-controller.ts
+++ b/src/components/common/footer/footer-pages-controller.ts
@@ -11,7 +11,7 @@ export function termsConditionsGet(req: Request, res: Response): void {
 }
 
 export function accessibilityStatementGet(req: Request, res: Response): void {
-  res.render("common/footer/accessibility-statement.njk");
+  redirectToExternalAccessibilityStatement(req, res);
 }
 
 export function supportGet(req: Request, res: Response): void {
@@ -40,6 +40,17 @@ function redirectToExternalPrivacyNotice(req: Request, res: Response) {
   }
   res.redirect(
     "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice"
+  );
+}
+
+function redirectToExternalAccessibilityStatement(req: Request, res: Response) {
+  if (req.i18n?.language === "cy") {
+    return res.redirect(
+      "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement.cy"
+    );
+  }
+  res.redirect(
+    "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement"
   );
 }
 

--- a/src/components/common/footer/tests/footer-pages-integration.test.ts
+++ b/src/components/common/footer/tests/footer-pages-integration.test.ts
@@ -48,3 +48,42 @@ describe("Integration:: privacy notice link", () => {
     });
   });
 });
+
+describe("Integration:: accessibility statement link", () => {
+  it("should redirect to the accessibility statement", async () => {
+    const app = await createApp();
+    await request(app)
+      .get(PATH_NAMES.ACCESSIBILITY_STATEMENT)
+      .expect(302)
+      .then((res) => {
+        expect(res.headers["location"]).to.equal(
+          "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement"
+        );
+      });
+  });
+
+  it("should redirect to the welsh accessibility statement when the lng cookie is cy", async () => {
+    const app = await createApp();
+    await request(app)
+      .get(PATH_NAMES.ACCESSIBILITY_STATEMENT)
+      .set("Cookie", ["lng=cy"])
+      .expect(302)
+      .then((res) => {
+        expect(res.headers["location"]).to.equal(
+          "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement.cy"
+        );
+      });
+  });
+
+  it("should redirect to the welsh accessibility statement when the lng query param is cy", async () => {
+    const app = await createApp();
+    await request(app)
+      .get(PATH_NAMES.ACCESSIBILITY_STATEMENT + "?lng=cy")
+      .expect(302)
+      .then((res) => {
+        expect(res.headers["location"]).to.equal(
+          "https://www.gov.uk/guidance/govuk-one-login-accessibility-statement.cy"
+        );
+      });
+  });
+});

--- a/src/components/common/layout/tests/base-integration.test.ts
+++ b/src/components/common/layout/tests/base-integration.test.ts
@@ -97,6 +97,13 @@ describe("Integration:: base page ", () => {
       expect($(".govuk-footer").length).to.equal(1);
     });
 
+    it("should link to the accessibility statement in the footer", async () => {
+      const link = $(
+        `.govuk-footer a[href="${PATH_NAMES.ACCESSIBILITY_STATEMENT}"]`
+      );
+      expect(link.length).to.equal(1);
+    });
+
     describe("when in a non-production environment", () => {
       it("should render the test phase banner", async () => {
         expect($(".govuk-phase-banner").length).to.equal(1);


### PR DESCRIPTION
## What

Central UCD asked for the accessibility statement to move to www.gov.uk so that the team taking it on owns the content, rather than us hosting and updating it from this repo.

The redirect picks the Welsh URL from the request language, the same way the privacy notice redirect added in AUT-4284 does.

It also asserts that the footer carries the link. `base.njk` hardcodes that href rather than taking it from `PATH_NAMES`, and the acceptance test that clicked it is being removed, so nothing else would have caught a typo.

The template and its translations are now unreachable. They are removed in a follow-up so there is a rollback path while the redirect is confirmed in production.

## How to review

1. Code review. The behaviour change is one line in `accessibilityStatementGet`. The new helper sits next to `redirectToExternalPrivacyNotice` and is written the same way on purpose, so the pair reads as one thing. The second commit switches both to a ternary, per review.
1. Run the tests. `npm run test:unit` and `npm run test:integration`. Three redirect cases in `src/components/common/footer/tests/footer-pages-integration.test.ts`, and one footer assertion in `src/components/common/layout/tests/base-integration.test.ts`. The footer one was checked against a deliberately broken href to confirm it fails.
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml).
1. Click **Accessibility statement** in the page footer. Expect to land on `https://www.gov.uk/guidance/govuk-one-login-accessibility-statement`, titled "GOV.UK One Login: accessibility statement".
1. Press the browser back button. Expect to land back on the page you came from, not to be bounced forward to GOV.UK again. A 302 should not leave a history entry, and the privacy notice has behaved this way in production since mid 2025, but it is one click to confirm.
1. Switch the page to Welsh and click the same link. Expect the `.cy` URL, titled "GOV.UK One Login: Datganiad hygyrchedd".
1. Check the other footer links still work: Cookies, Terms and conditions, Privacy notice.

The template, its translations, the `pages.ts` entry and the snapshot images are untouched, so the snapshot tests and the `/templates/accessibility-statement` preview are unaffected.

Verified locally on this branch: 1213 unit tests pass, and 390 of 393 integration tests pass. The 3 failures are in `Integration:: authorize`, are pre-existing on `main` (confirmed by running them in a clean worktree at `origin/main`) and need the API stub that `./startup.sh` provides.

## Checklist

- [ ] Performance analyst has been notified of the change.

  N/A

- [x] A UCD review has been performed.

  Central UCD requested the move. The GOV.UK page is now live, so I will deploy this to a dev environment and show them the redirect landing on the real page, in both languages, before merging.

- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

  **A companion PR is needed, and it merges before this one:** [authentication-acceptance-tests#977](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/977).

- [x] Documentation has been updated to reflect these changes.

  Nothing in `README.md` or `docs/` describes the page, other than `docs/diagrams/usecase/auth-use-case-overview.puml`, which shows a "View Accessibility Statement" use case that stays accurate.
