### PR TITLE
BAU: Increase PasskeyRolloutPercentage to 100%

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -629,7 +629,7 @@ Mappings:
       PasskeyPromptClientAllowList: ""
       PasskeyPromptClientDenyList: ""
       serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
-      PasskeyRolloutPercentage: 30
+      PasskeyRolloutPercentage: 100
 
   # /acceptance-tests/{env}}/CUCUMBER_FILTER_TAGS
   AcceptanceTestTags:


### PR DESCRIPTION
## What

Increase "should prompt to register passkey" prompt rollout to 100% in production.

## How to review

1. Code Review